### PR TITLE
WASM lib module export

### DIFF
--- a/wasmaudioworklet/app.html
+++ b/wasmaudioworklet/app.html
@@ -8,7 +8,7 @@
     <button id="startaudiobutton" onclick="startaudio()" disabled title="start synth">&#x25B6;</button>
     <button id="stopaudiobutton" onclick="stopaudio()" title="stop synth" style="display: none">&#9724;</button>
     <button id="savesongbutton" disabled  title="save song (clears recorded data)">&#x1f4be;</button>
-    <button onclick="insertRecording()" title="insert recording at cursor">&#128203;</button>
+    <button onclick="insertRecording()" title="insert recording at cursor" style="height: 31px">&#128203;</button>
     
     <label>
       <select id="midichannelmappingselection" title="select instrument" onchange="currentMidiChannelMapping=this.value">
@@ -38,8 +38,6 @@
     
     <div style="flex-grow: 1"></div>
     <button id="exportbutton" onclick="compileSong(true)" title="Export">&#x21E9;</button>
-    
-    <div class="spinner"></div>
   </div>
   <br />
   <div id="subtoolbar1" class="subtoolbar">
@@ -82,7 +80,8 @@
   <div id="main-progress-bar" class="progress-border">
     <div class="progress-text">50%</div>
     <div class="progress-fill" style="width:20%"></div>
-  </div>
+  </div> 
+  <div class="spinner"></div>
   <div class="footer">
     webassembly music experiment - (c) 2019-2020 peter salomonsen
   </div>

--- a/wasmaudioworklet/audioworkletprocessor.js
+++ b/wasmaudioworklet/audioworkletprocessor.js
@@ -15,7 +15,7 @@ class PatternSeqAudioWorkletProcessor extends AudioWorkletProcessor {
           this.wasmInstance = (await WebAssembly.instantiate(msg.data.wasm, {
             environment: { SAMPLERATE: msg.data.samplerate },
             env: {
-              abort: () => console.log(abort)
+              abort: () => console.log('webassembly synth abort, should not happen')
             }
           })).instance.exports;
           

--- a/wasmaudioworklet/common/ui/modal.html.js
+++ b/wasmaudioworklet/common/ui/modal.html.js
@@ -1,0 +1,42 @@
+export const modalTemplate = (modalcontent) => `<style>
+    .modaldiv {
+        position: fixed;
+        top:0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 80%;
+        height: 180px;
+        margin: auto;
+        text-align: center;
+        padding: 20px;
+        background-color: rgba(0, 0, 0, 0.8);
+        border: #4a4 solid 5px;
+        color: #4a4;
+        font-family: monospace;
+        font-size: 20px;
+        border-radius: 50px;
+    }
+    button, textarea {
+        font-family: monospace;
+        background-color: #cfc;
+        border-color: #4a4;
+        border-width: 1px;
+        color:#050;
+        padding: 10px;
+        font-size: 20px;
+        
+        border-radius: 4px;
+        white-space: nowrap;
+        
+        margin: 2px;
+        user-select: none;
+    }
+    textarea {
+        width: 80%;
+        height: 80px;
+    }
+</style>
+<div class="modaldiv">
+    ${modalcontent}
+</div>`;

--- a/wasmaudioworklet/common/ui/modal.js
+++ b/wasmaudioworklet/common/ui/modal.js
@@ -1,0 +1,20 @@
+import { modalTemplate } from './modal.html.js';
+
+customElements.define('common-modal',
+    class extends HTMLElement {
+        constructor() {
+            super();
+            
+            this.attachShadow({mode: 'open'});
+            this.resultPromise = new Promise(resolve => this.shadowRoot.result = resolve);
+        }
+    });
+
+export async function modal(modalContent) {
+    const modalElement = document.createElement('common-modal');
+    modalElement.shadowRoot.innerHTML = modalTemplate(modalContent);
+    document.documentElement.appendChild(modalElement);
+    const result = await modalElement.resultPromise;
+    document.documentElement.removeChild(modalElement);
+    return result;
+}

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wasm-music",
     "description": "Javascript/WebAssembly live coding environment for music and synthesis",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "repository": {
         "url": "https://github.com/petersalomonsen/javascriptmusic"
     },

--- a/wasmaudioworklet/pattern_tools.js
+++ b/wasmaudioworklet/pattern_tools.js
@@ -1,344 +1,349 @@
-global.hld = 1;
-global.bpm = 100;
-global.beats_per_pattern_shift = 2;
-global.pattern_size_shift = 4;
-global.looptimes = 1;
+export function createPatternToolsGlobal() {
+	const global = {};
 
-global.instrumentNames = [];
-global.instrumentDefs = {};
-const instrumentPatternListArr = [];
-const patternsMap = {};
-global.instrumentGroupMap = {};
-const instrumentsArr = [];
-const instrumentIndexMap = {};
-const soloMap = {};
-const muteMap = {};
+	global.hld = 1;
+	global.bpm = 100;
+	global.beats_per_pattern_shift = 2;
+	global.pattern_size_shift = 4;
+	global.looptimes = 1;
 
-let onlyPlayPatternsEnabled = false;
-let playPatternsList = [];
+	global.instrumentNames = [];
+	global.instrumentDefs = {};
+	const instrumentPatternListArr = [];
+	const patternsMap = {};
+	global.instrumentGroupMap = {};
+	const instrumentsArr = [];
+	const instrumentIndexMap = {};
+	const soloMap = {};
+	const muteMap = {};
 
-let currentPatternPosition = 0;
+	let onlyPlayPatternsEnabled = false;
+	let playPatternsList = [];
 
-global.ticksperbeat = () => ( 1 << pattern_size_shift >> beats_per_pattern_shift );
+	let currentPatternPosition = 0;
 
-let globalparamdefs;
-let globalcmddefs;
+	global.ticksperbeat = () => ( 1 << global.pattern_size_shift >> global.beats_per_pattern_shift );
 
-let patternAutoNameCount = 0;
+	let globalparamdefs;
+	let globalcmddefs;
 
-global.calculatePatternSize = () => {
-	global.patternsize = 1 << global.pattern_size_shift;
-};
+	let patternAutoNameCount = 0;
 
-global.calculatePatternSize();
-global.soloInstrument = (name) => {
-	soloMap[name] = true;
-};
+	global.calculatePatternSize = () => {
+		global.patternsize = 1 << global.pattern_size_shift;
+	};
 
-global.muteInstrument = (name) => {
-	muteMap[name] = true;
-};
-global.addInstrument = (name, instrument) => {
-    instrumentIndexMap[name] = instrumentsArr.length;
-    
-    // for 4klang instrument defs
-    if(typeof instrument === 'string') {
-        instrumentsArr.push(instrument.split('\n')
-            .map(l => l.trim())
-            .filter(l => l.length > 0)
-            .join('\n'));	
-    } else {
-        instrumentsArr.push(instrument);
-    }
+	global.calculatePatternSize();
+	global.soloInstrument = (name) => {
+		soloMap[name] = true;
+	};
 
-    instrumentPatternListArr.push([]);
-    global.instrumentNames.push(name);
-    global.instrumentDefs[name] = instrument;
-};
+	global.muteInstrument = (name) => {
+		muteMap[name] = true;
+	};
+	global.addInstrument = (name, instrument) => {
+		instrumentIndexMap[name] = instrumentsArr.length;
+		
+		// for 4klang instrument defs
+		if(typeof instrument === 'string') {
+			instrumentsArr.push(instrument.split('\n')
+				.map(l => l.trim())
+				.filter(l => l.length > 0)
+				.join('\n'));	
+		} else {
+			instrumentsArr.push(instrument);
+		}
 
-/**
- * prepare pattern and register it to list of patterns
- */
-global.pp = (stepsperbeat, patterndata, channels = 1) => {
-	const channelpatterns = pattern(stepsperbeat, patterndata, channels);
-	if(channels === 1) {	
-		return addPattern(null, channelpatterns);
-	} else {
+		instrumentPatternListArr.push([]);
+		global.instrumentNames.push(name);
+		global.instrumentDefs[name] = instrument;
+	};
+
+	/**
+	 * prepare pattern and register it to list of patterns
+	 */
+	global.pp = (stepsperbeat, patterndata, channels = 1) => {
+		const channelpatterns = global.pattern(stepsperbeat, patterndata, channels);
+		if(channels === 1) {	
+			return global.addPattern(null, channelpatterns);
+		} else {
+			for(let n=0;n<channels;n++) {
+				channelpatterns[n] = global.addPattern(null, channelpatterns[n]);
+			}
+			return channelpatterns;
+		}
+	};
+
+	global.getPatternByName = (patternName) => {
+		return patternsMap[patternName];
+	};
+
+	/**
+	 * Register pattern in pattern list
+	 */
+	global.addPattern = (name, pattern) => {	
+		if(!name) {
+			patternAutoNameCount++;
+			name = `.PATTERN${patternAutoNameCount}`
+		}
+		if(pattern.length > global.patternsize) {
+			for(let n=0;n<pattern.length; n += global.patternsize) {
+				global.addPattern(name + '_' + Math.floor(n / global.patternsize), pattern.slice(n, n + global.patternsize));			
+			}
+		} else {
+			for(let n=0;n < global.patternsize; n++) {
+				if(pattern[n] === undefined) {
+					pattern[n] = 0;
+				} else if(typeof pattern[n] === 'function') {
+					pattern[n] = pattern[n]();
+				}
+			}
+			patternsMap[name] = pattern;
+		}
+		return name;
+	};
+
+	/**
+	 * Add array of prepared patterns
+	 */
+	global.addPatterns = (patterns) => {
+		for(let n=0;n<patterns.length;n++) {
+			patterns[n] = addPattern(null, patterns[n]);
+		}
+		return patterns;
+	};
+
+	global.addInstrumentGroup = (groupName, instrumentNames) => global.instrumentGroupMap[groupName] = instrumentNames;
+
+	const playPatternsFunc = (patterns, incrementPosition = 1) => {		
+		Object.keys(patterns).forEach(groupName => {
+			if(global.instrumentGroupMap[groupName]) {
+				const groupInstruments = global.instrumentGroupMap[groupName];
+				const groupPatterns = patterns[groupName];
+				for(let n=0;n<patterns[groupName].length;n++) {
+					patterns[groupInstruments[n]] = groupPatterns[n];
+				}
+				delete patterns[groupName];
+			}
+		});
+		Object.keys(patterns).forEach(instrumentName => {
+			const instrumentIndex = instrumentIndexMap[instrumentName];
+			if(instrumentIndex === undefined) {
+				console.error('Unknown instrument '+instrumentName);
+				return;
+			}
+			const instrPatternList = instrumentPatternListArr[instrumentIndex];
+			let patternName = patterns[instrumentName];
+
+			if(muteMap[instrumentName] || Object.keys(soloMap).length > 0 && !soloMap[instrumentName]) {
+				console.log('muted', instrumentName);
+				patternName = undefined;
+			}
+		
+			if(patternsMap[patternName]===undefined && patternsMap[patternName + '_0']) {			
+				for(let patternIndex = 0; patternsMap[patternName + '_' + patternIndex] !== undefined; patternIndex++) {
+					instrPatternList[currentPatternPosition + patternIndex] = patternName + '_' + patternIndex;
+				}			
+			} else if(patternsMap[patternName]!==undefined) {
+				instrPatternList[currentPatternPosition] = patterns[instrumentName];
+			} else if(patternName) {
+				console.error('Unknown pattern '+patternName);
+			}
+		});
+
+		// Increment pattern position
+		for(let inc = 0; inc < incrementPosition; inc++) {
+			for(let n=0;n<instrumentPatternListArr.length;n++) {
+				if(instrumentPatternListArr[n][currentPatternPosition]===undefined) {
+					// Insert '0' to tracks without pattern data
+					instrumentPatternListArr[n][currentPatternPosition] = '0';
+				}
+			}
+			currentPatternPosition ++;
+		}
+	};
+
+	global.logCurrentSongTime = () => {
+		const elapsedTicks = (currentPatternPosition * global.patternsize);
+		const elapsedBeats = elapsedTicks / ticksperbeat();
+		const minutes = elapsedBeats / bpm;
+		console.error(currentPatternPosition, Math.floor(minutes) + ':' + Math.floor((minutes * 60) % 60));
+	};
+
+	global.playPatterns = (patterns, incrementPosition = 1, logPosition = false) => { 
+		if(onlyPlayPatternsEnabled) {
+			return;
+		}
+		playPatternsList.push(() => {
+			if(logPosition) {
+				logCurrentSongTime();
+			}
+			playPatternsFunc(patterns, incrementPosition);
+		});
+	};
+	global.onlyplayPatterns = (patterns, incrementPosition = 1) => { 
+		if(!onlyPlayPatternsEnabled) {
+			playPatternsList = [];
+		}
+		onlyPlayPatternsEnabled = true;
+		playPatternsList.push(() => playPatternsFunc(patterns, incrementPosition));
+	};
+	global.playFromHere = () => { 
+		playPatternsList = [];	
+	};
+	global.loopHere = () => {
+		onlyPlayPatternsEnabled = true;
+	};
+
+	global.repeatSection = (times, func, initial=0) => {
+		for(let n=initial;n<times;n++) {
+			func(n);
+		}
+	}
+	global.noteValues = new Array(128).fill(null).map((v, ndx) => 
+		(['c','cs','d','ds','e','f','fs','g','gs','a','as','b'])[ndx%12]+''+Math.floor(ndx/12)
+	);
+	global.noteValues.forEach((note, ndx) => global[note] = (duration, velocity) => {
+		if(duration) {
+			// round duration to the closest tick
+			let roundedDuration = Math.round(duration  * global.ticksperbeat());
+			if (roundedDuration === 0) {
+				roundedDuration = 1;
+			}
+			return () => new Array(roundedDuration).fill(null).map((v, n) => n===0 ? ndx : global.hld);
+		} else {
+			return ndx;
+		}
+	});
+
+	Array.prototype.repeat = function(times = 1) {
+		const arrToRepat = this.slice(0);
+		let arr = this;
+		for(let n = 0 ; n < times ; n++ ) {
+			arr = arr.concat(arrToRepat);
+		}
+		return arr;    
+	}
+
+	class PatternArray extends Array {
+		transposeNotes(transposeAmount) {		
+			return this.map(v => v > 1 ? (v + transposeAmount) : v);
+		}
+
+		
+	}
+
+	/**
+	 * convert array of note functions and entries with multiple channels
+	 * to flat numeric value (pattern) arrays.
+	 */
+	global.pattern = (stepsperbeat, notearray, channels = 1) => {
+		const inc = global.ticksperbeat() / stepsperbeat;
+
+		const channelPatterns = [];
+		
 		for(let n=0;n<channels;n++) {
-			channelpatterns[n] = addPattern(null, channelpatterns[n]);
+			channelPatterns.push(new PatternArray());
 		}
-		return channelpatterns;
-	}
-};
+		
+		let pattern = channelPatterns[0];
+		
+		for(let n = 0;n < notearray.length; n++) {
+			const notefunc = notearray[n];
+			
+			const quantizedpos = Math.round(n*inc);
 
-global.getPatternByName = (patternName) => {
-	return patternsMap[patternName];
-};
+			const processNote = (note) => {
+				if(note && note.constructor && note.constructor.name === 'Function') {			
+					const notearr = note();
+					if(Array.isArray(notearr)) {
+						for(let en = 0; en < notearr.length ; en++) {
+							pattern[quantizedpos + en] = notearr[en];
+						}
+					} else {
+						pattern[quantizedpos] = note;
+					}
+				} else if(note !== undefined) {
+					pattern[quantizedpos] = note;
+				}
+			};
 
-/**
- * Register pattern in pattern list
- */
-global.addPattern = (name, pattern) => {	
-	if(!name) {
-		patternAutoNameCount++;
-		name = `.PATTERN${patternAutoNameCount}`
-	}
-	if(pattern.length > patternsize) {
-		for(let n=0;n<pattern.length; n+=patternsize) {
-			addPattern(name + '_' + Math.floor(n / patternsize), pattern.slice(n, n + patternsize));			
-		}
-	} else {
-		for(let n=0;n<patternsize; n++) {
+			if(Array.isArray(notefunc) && channels > 1) {
+				for(let c = 0;c<notefunc.length;c++) {
+					pattern = channelPatterns[c];
+					processNote(notefunc[c]);
+				}			
+				pattern = channelPatterns[0];
+			} else {
+				processNote(notefunc);
+			}	
+			
 			if(pattern[n] === undefined) {
 				pattern[n] = 0;
 			} else if(typeof pattern[n] === 'function') {
 				pattern[n] = pattern[n]();
 			}
 		}
-		patternsMap[name] = pattern;
-	}
-	return name;
-};
-
-/**
- * Add array of prepared patterns
- */
-global.addPatterns = (patterns) => {
-	for(let n=0;n<patterns.length;n++) {
-		patterns[n] = addPattern(null, patterns[n]);
-	}
-	return patterns;
-};
-
-global.addInstrumentGroup = (groupName, instrumentNames) => instrumentGroupMap[groupName] = instrumentNames;
-
-const playPatternsFunc = (patterns, incrementPosition = 1) => {		
-	Object.keys(patterns).forEach(groupName => {
-		if(instrumentGroupMap[groupName]) {
-			const groupInstruments = instrumentGroupMap[groupName];
-			const groupPatterns = patterns[groupName];
-			for(let n=0;n<patterns[groupName].length;n++) {
-				patterns[groupInstruments[n]] = groupPatterns[n];
-			}
-			delete patterns[groupName];
-		}
-	});
-	Object.keys(patterns).forEach(instrumentName => {
-		const instrumentIndex = instrumentIndexMap[instrumentName];
-		if(instrumentIndex === undefined) {
-			console.error('Unknown instrument '+instrumentName);
-			return;
-		}
-		const instrPatternList = instrumentPatternListArr[instrumentIndex];
-		let patternName = patterns[instrumentName];
-
-		if(muteMap[instrumentName] || Object.keys(soloMap).length > 0 && !soloMap[instrumentName]) {
-			console.log('muted', instrumentName);
-			patternName = undefined;
-		}
-	
-		if(patternsMap[patternName]===undefined && patternsMap[patternName + '_0']) {			
-			for(let patternIndex = 0; patternsMap[patternName + '_' + patternIndex] !== undefined; patternIndex++) {
-				instrPatternList[currentPatternPosition + patternIndex] = patternName + '_' + patternIndex;
-			}			
-		} else if(patternsMap[patternName]!==undefined) {
-			instrPatternList[currentPatternPosition] = patterns[instrumentName];
-		} else if(patternName) {
-			console.error('Unknown pattern '+patternName);
-		}
-	});
-
-	// Increment pattern position
-	for(let inc = 0; inc < incrementPosition; inc++) {
-		for(let n=0;n<instrumentPatternListArr.length;n++) {
-			if(instrumentPatternListArr[n][currentPatternPosition]===undefined) {
-				// Insert '0' to tracks without pattern data
-				instrumentPatternListArr[n][currentPatternPosition] = '0';
-			}
-		}
-		currentPatternPosition ++;
-	}
-};
-
-global.logCurrentSongTime = () => {
-	const elapsedTicks = (currentPatternPosition * patternsize);
-	const elapsedBeats = elapsedTicks / ticksperbeat();
-	const minutes = elapsedBeats / bpm;
-	console.error(currentPatternPosition, Math.floor(minutes) + ':' + Math.floor((minutes * 60) % 60));
-};
-
-global.playPatterns = (patterns, incrementPosition = 1, logPosition = false) => { 
-	if(onlyPlayPatternsEnabled) {
-		return;
-	}
-	playPatternsList.push(() => {
-		if(logPosition) {
-			logCurrentSongTime();
-		}
-		playPatternsFunc(patterns, incrementPosition);
-	});
-};
-global.onlyplayPatterns = (patterns, incrementPosition = 1) => { 
-	if(!onlyPlayPatternsEnabled) {
-		playPatternsList = [];
-	}
-	onlyPlayPatternsEnabled = true;
-	playPatternsList.push(() => playPatternsFunc(patterns, incrementPosition));
-};
-global.playFromHere = () => { 
-	playPatternsList = [];	
-};
-global.loopHere = () => {
-	onlyPlayPatternsEnabled = true;
-};
-
-global.repeatSection = (times, func, initial=0) => {
-	for(let n=initial;n<times;n++) {
-		func(n);
-	}
-}
-global.noteValues = new Array(128).fill(null).map((v, ndx) => 
-    (['c','cs','d','ds','e','f','fs','g','gs','a','as','b'])[ndx%12]+''+Math.floor(ndx/12)
-);
-global.noteValues.forEach((note, ndx) => global[note] = (duration, velocity) => {
-	if(duration) {
-		// round duration to the closest tick
-		let roundedDuration = Math.round(duration  * ticksperbeat());
-		if (roundedDuration === 0) {
-			roundedDuration = 1;
-		}
-		return () => new Array(roundedDuration).fill(null).map((v, n) => n===0 ? ndx : hld);
-	} else {
-		return ndx;
-	}
-});
-
-Array.prototype.repeat = function(times = 1) {
-    const arrToRepat = this.slice(0);
-    let arr = this;
-    for(let n = 0 ; n < times ; n++ ) {
-        arr = arr.concat(arrToRepat);
-    }
-    return arr;    
-}
-
-class PatternArray extends Array {
-	transposeNotes(transposeAmount) {		
-		return this.map(v => v > 1 ? (v + transposeAmount) : v);
-	}
-
-	
-}
-
-/**
- * convert array of note functions and entries with multiple channels
- * to flat numeric value (pattern) arrays.
- */
-global.pattern = (stepsperbeat, notearray, channels = 1) => {
-	const inc = ticksperbeat() / stepsperbeat;
-
-	const channelPatterns = [];
-	
-	for(let n=0;n<channels;n++) {
-		channelPatterns.push(new PatternArray());
-	}
-	
-	let pattern = channelPatterns[0];
-	
-	for(let n = 0;n < notearray.length; n++) {
-		const notefunc = notearray[n];
-		
-		const quantizedpos = Math.round(n*inc);
-
-		const processNote = (note) => {
-			if(note && note.constructor && note.constructor.name === 'Function') {			
-				const notearr = note();
-				if(Array.isArray(notearr)) {
-					for(let en = 0; en < notearr.length ; en++) {
-						pattern[quantizedpos + en] = notearr[en];
-					}
-				} else {
-					pattern[quantizedpos] = note;
-				}
-			} else if(note !== undefined) {
-				pattern[quantizedpos] = note;
-			}
-		};
-
-		if(Array.isArray(notefunc) && channels > 1) {
-			for(let c = 0;c<notefunc.length;c++) {
-				pattern = channelPatterns[c];
-				processNote(notefunc[c]);
-			}			
-			pattern = channelPatterns[0];
+		if(channels === 1) {
+			return pattern;
 		} else {
-			processNote(notefunc);
+			return channelPatterns;
 		}	
-		
-		if(pattern[n] === undefined) {
-			pattern[n] = 0;
-		} else if(typeof pattern[n] === 'function') {
-			pattern[n] = pattern[n]();
-		}
-	}
-	if(channels === 1) {
-		return pattern;
-	} else {
-		return channelPatterns;
-	}	
-};
+	};
 
-const patternNameToIndexMap = { '0': 0 };
-global.max_patterns = 0;
+	const patternNameToIndexMap = { '0': 0 };
+	global.max_patterns = 0;
 
 
-global.generatePatterns = () => {
-		playPatternsList.forEach((playFunc) => playFunc());
+	global.generatePatterns = () => {
+			playPatternsList.forEach((playFunc) => playFunc());
 
-		const patternStringMap = {};
-		patternStringMap[new Array(patternsize).fill(0).join(', ')] = 0;
-		
-		let patterns = [];
-		let patternNo = 1;
-		Object.keys(patternsMap).forEach((patternName) => {
-			const patternString = patternsMap[patternName].join(', ');
-			if(patternStringMap[patternString] !== undefined) {
-				patternNameToIndexMap[patternName] = patternStringMap[patternString];
-				// console.log('Reusing pattern', patternName, patternString);
-			} else {
-				patternStringMap[patternString] = patternNo;
-				patternNameToIndexMap[patternName] = patternNo;
-				patterns.push(patternsMap[patternName]);				
-
-				patternNo++;
-			}
-		});
-		return patterns;
-    };
-    
-global.generateInstrumentPatternLists = () => {
-		let instrumentPatternLists = [];
-            
-		instrumentPatternListArr.forEach((instrumentPatternList, ndx) => {
-            if(instrumentPatternList.length > max_patterns) {
-				max_patterns = instrumentPatternList.length;
-			}			
-		});
-                
-		for(let n = 0;n < instrumentsArr.length; n++) {
-			let instrumentPatternList = instrumentPatternListArr[n];
+			const patternStringMap = {};
+			patternStringMap[new Array(global.patternsize).fill(0).join(', ')] = 0;
 			
-			if(instrumentPatternList === undefined) {
-				instrumentPatternList = [];
-            }
+			let patterns = [];
+			let patternNo = 1;
+			Object.keys(patternsMap).forEach((patternName) => {
+				const patternString = patternsMap[patternName].join(', ');
+				if(patternStringMap[patternString] !== undefined) {
+					patternNameToIndexMap[patternName] = patternStringMap[patternString];
+					// console.log('Reusing pattern', patternName, patternString);
+				} else {
+					patternStringMap[patternString] = patternNo;
+					patternNameToIndexMap[patternName] = patternNo;
+					patterns.push(patternsMap[patternName]);				
 
-			if(instrumentPatternList.length < max_patterns) {
-				for(let ndx = instrumentPatternList.length; ndx < max_patterns; ndx++) {
-					instrumentPatternList.push(0);
+					patternNo++;
 				}
+			});
+			return patterns;
+		};
+		
+	global.generateInstrumentPatternLists = () => {
+			let instrumentPatternLists = [];
+				
+			instrumentPatternListArr.forEach((instrumentPatternList, ndx) => {
+				if(instrumentPatternList.length > global.max_patterns) {
+					global.max_patterns = instrumentPatternList.length;
+				}			
+			});
+					
+			for(let n = 0;n < instrumentsArr.length; n++) {
+				let instrumentPatternList = instrumentPatternListArr[n];
+				
+				if(instrumentPatternList === undefined) {
+					instrumentPatternList = [];
+				}
+
+				if(instrumentPatternList.length < global.max_patterns) {
+					for(let ndx = instrumentPatternList.length; ndx < global.max_patterns; ndx++) {
+						instrumentPatternList.push(0);
+					}
+				}
+				
+				instrumentPatternLists.push(instrumentPatternList.map(patternName => patternNameToIndexMap[patternName]));
 			}
-			
-			instrumentPatternLists.push(instrumentPatternList.map(patternName => patternNameToIndexMap[patternName]));
-        }
-		return instrumentPatternLists;
-    };
+			return instrumentPatternLists;
+		};
+	return global;
+}

--- a/wasmaudioworklet/player/wamusicplayer.html
+++ b/wasmaudioworklet/player/wamusicplayer.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <input type="file" onchange="playWASMFile(event)"/>
+        <script>
+            function playWASMFile(event) {
+                const fileurl = URL.createObjectURL(event.target.files[0]);
+                const worker = new Worker(URL.createObjectURL(new Blob(['('+(async function(url) {                    
+                    const bin = await fetch(url).then(r => r.arrayBuffer());
+                    const mod = await WebAssembly.instantiate(bin, {
+                            wasi_unstable: {
+                                fd_write: function(p, iovec) {
+                                    const mem32u = new Uint32Array(mod.instance.exports.memory.buffer);
+                                    const audiobufptr = mem32u[iovec >> 2];
+                                    const audiobuf = new Float32Array(mod.instance.exports.memory.buffer,
+                                                    audiobufptr, 128 * 2);
+                                    
+                                    postMessage(audiobuf);
+                                }
+                            }
+                    });
+                    console.log(mod.instance);
+                    mod.instance.exports._start();
+                }).toString() + `)('${fileurl}')`])));   
+
+                const context = new AudioContext();
+
+                let chunkIndex = 0;
+                worker.onmessage = msg => {
+                    
+                    const bufferSource = context.createBufferSource();
+                    bufferSource.buffer = msg;
+                    bufferSource.connect(destination);
+                    bufferSource.start((chunkIndex++) * (128 / context.sampleRate));
+                };
+            }
+        </script>
+    </body>
+</html>

--- a/wasmaudioworklet/style.css
+++ b/wasmaudioworklet/style.css
@@ -105,12 +105,20 @@ input::placeholder {
 
 .spinner {
     display: none;
-    border: 12px solid #f3f3f3;
+    position: fixed;
+    margin: auto;
+    top:0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+    background-color: rgba(0,0,0, 0.5);
+    border: 20px solid #f3f3f3;
     border-radius: 50%;
-    border-top: 12px solid #3498db;
+    border-top: 20px solid #3498db;
+    z-index: 1000;
     
-    width: 15px;
-    height: 15px;
+    width: 100px;
+    height: 100px;
     -webkit-animation: spin 1s linear infinite; /* Safari */
     animation: spin 1s linear infinite;
   }

--- a/wasmaudioworklet/webaudiomodules/wammanager.js
+++ b/wasmaudioworklet/webaudiomodules/wammanager.js
@@ -11,7 +11,6 @@ export let wamsynth;
 let wamPaused;
 let lastPostedSong = [];
 let samplerate;
-let audioContext;
 let visualizeEventIndex = 0;
 
 export async function loadWAM() {
@@ -39,7 +38,6 @@ export async function startWAM(actx) {
         wamsynth.connect(actx.destination);
         samplerate = actx.sampleRate;
         toggleSpinner(false);
-        audioContext = actx;
         console.log('WAM synth started');
     }
 }

--- a/wasmaudioworklet/webaudiomodules/wammanager.spec.js
+++ b/wasmaudioworklet/webaudiomodules/wammanager.spec.js
@@ -5,12 +5,15 @@ import { compileSong } from '../midisequencer/songcompiler.js';
 describe('wammanager', async function() {
     this.timeout(10000);
     let recordedData;
+    let sampleRate;
 
     this.beforeAll(async () => {
         document.documentElement.appendChild(document.createElement('app-javascriptmusic'));
         await waitForAppReady();
 
         const audioContext = new AudioContext();
+        sampleRate = audioContext.sampleRate;
+
         await startWAM(audioContext);
         wamsynth._waitForMessage = wamsynth.waitForMessage;
         wamsynth.waitForMessage = async function() {            
@@ -26,22 +29,37 @@ describe('wammanager', async function() {
         window.audioworkletnode = undefined;
         document.documentElement.removeChild(document.querySelector('app-javascriptmusic'));
     });
+    function transformRecordedDataToSampleRate(recordedData) {
+        const recordingDataSampeRate = 44100;
+        if (sampleRate !== recordingDataSampeRate) {
+            // transform to actual samplerate
+            const transformed = {};
+            Object.keys(recordedData.recorded).forEach(k => {
+                transformed[k * sampleRate / recordingDataSampeRate] = recordedData.recorded[k];
+            });
+            recordedData.recorded = transformed;
+        }
+    }
     it('should get recorded data as an array of events', async () => {
         recordedData = {recorded: {"16384":[[144,62,100]],"22784":[[144,62,0]],"32256":[[144,65,100]],"37120":[[144,65,0]],"49920":[[144,69,100]],"53248":[[144,69,0]]}};
+        transformRecordedDataToSampleRate(recordedData);
         const eventlist = await getRecordedData();
         assert.equal(eventlist.length, 6);
         const expected = [
-                [ 0.37151927437641724, 144, 62, 100 ],
-                [ 0.5166439909297053, 144, 62, 0 ],
-                [ 0.7314285714285714, 144, 65, 100 ],
-                [ 0.8417233560090703, 144, 65, 0 ],
-                [ 1.1319727891156464, 144, 69, 100 ],
-                [ 1.207437641723356, 144, 69, 0 ]
+                [ 0.37, 144, 62, 100 ],
+                [ 0.52, 144, 62, 0 ],
+                [ 0.73, 144, 65, 100 ],
+                [ 0.84, 144, 65, 0 ],
+                [ 1.13, 144, 69, 100 ],
+                [ 1.21, 144, 69, 0 ]
             ];
-        eventlist.forEach((event, ndx) => assert.equal(JSON.stringify(event), JSON.stringify(expected[ndx])))
+        eventlist.forEach((event, ndx) => assert.equal(
+            JSON.stringify(event.map((val, ndx) => ndx > 0 ? val : Math.round(val * 100) / 100)),
+            JSON.stringify(expected[ndx])))
     });
     it('should get recorded as an ordered array of events', async () => {
         recordedData = {recorded: {"33024":[[146,60,100]],"33280":[[146,64,100]],"35328":[[146,67,100]],"46336":[[146,60,0]],"46848":[[146,64,0]],"47616":[[146,67,0]],"55040":[[146,62,100]],"56576":[[146,69,100]],"61184":[[146,66,100]],"89344":[[146,66,0]],"89600":[[146,69,0]],"90368":[[146,62,0]],"131072":[[146,60,100]],"138752":[[146,64,100]],"140288":[[146,60,0]],"146944":[[146,67,100]],"148480":[[146,64,0]],"151040":[[146,67,0]],"166144":[[146,72,100]],"169472":[[146,72,0]],"169728":[[146,71,100]],"172800":[[146,71,0]],"193792":[[146,67,100]],"200448":[[146,67,0]],"213504":[[146,64,100]],"218880":[[146,64,0]]}};
+        transformRecordedDataToSampleRate(recordedData);
         const eventlist = await getRecordedData();
         for (let n = 1; n < eventlist.length ; n++) {
             assert(eventlist[n -1][0] <= eventlist[n][0], `${eventlist[n -1][0]} > ${eventlist[n][0]}`);


### PR DESCRIPTION
Add another WASM export mode: library module for use from other WASM modules or from C ( by converting from WASM to C as shown in the gist here: https://gist.github.com/petersalomonsen/58c3d977d35c60bfee58c4f5d19aa9f5 )

For the new export mode, a modal is needed to be able to choose executable WASM or library WASM. Added a generic modal web component using template strings for customizing the modal content, which is part of a showcase (to be written more about in the future) of how to use built-in Web Components technologies instead of a framework like React or Angular.

The javascript song compiler use of `eval` is replaced with a function created from a string, as `eval` does not work with rollup (which is to  be introduced in the future).
