### PR TITLE
wasm-git: proceed without near (in offline-mode)

### DIFF
--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wasm-music",
     "description": "Javascript/WebAssembly live coding environment for music and synthesis",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "repository": {
         "url": "https://github.com/petersalomonsen/javascriptmusic"
     },

--- a/wasmaudioworklet/wasmgit/nearacl.js
+++ b/wasmaudioworklet/wasmgit/nearacl.js
@@ -30,8 +30,7 @@ async function logout() {
 
 async function loadAccountData() {
     let currentUser = {
-        accountId: walletConnection.getAccountId(),
-        balance: (await walletConnection.account().state()).amount
+        accountId: walletConnection.getAccountId()
     }
     
     const tokenMessage = btoa(JSON.stringify({accountId: currentUser.accountId, iat: new Date().getTime()}));

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -18,7 +18,11 @@ export async function initWASMGitClient(gitrepo) {
 
     gitrepourl = `https://githttpserverdemo.petersalomonsen.usw1.kubesail.io/${gitrepo}`;
         
-    await initNear();
+    try {
+        await initNear();
+    } catch (e) {
+        console.error('Failed to initialize near', e);
+    }
     if (nearAuthData) {
         worker.postMessage(nearAuthData);
         const result = await new Promise((resolve) =>


### PR DESCRIPTION
don't stop initializing wasm-git because of failing connection with near which will be the case when working in offline mode