### PR TITLE
editable midiparts

### DIFF
--- a/wasmaudioworklet/synth1/assembly/__tests__/midi/midisequencerpart.spec.ts
+++ b/wasmaudioworklet/synth1/assembly/__tests__/midi/midisequencerpart.spec.ts
@@ -1,0 +1,101 @@
+import { MidiSequencerPart } from "../../midi/sequencer/midisequencerpart";
+
+describe("midiparts", () => {
+    it("should update midiparts in the sequencer", () => {
+        const eventlist: u8[] = [
+            0x00, 0x90, 0x40, 0x64,
+            0x80, 0x01, 0x80, 0x40, 0x00, // time = 0x80
+            0x40, 0x90, 0x40, 0x64, // time = 0xc0
+            0x80, 0x01, 0x80, 0x40, 0x00 // time = 0x140
+        ];
+        const midiSequencerPart = new MidiSequencerPart(eventlist);
+
+        midiSequencerPart.playEvents(0x40);
+
+        expect(midiSequencerPart.currentEventTime).toBe(0);
+        expect(midiSequencerPart.currentEventIndex).toBe(4);
+
+        midiSequencerPart.playEvents(0x80);
+        expect(midiSequencerPart.currentEventTime).toBe(0x80);
+        expect(midiSequencerPart.currentEventIndex).toBe(9);
+
+        midiSequencerPart.playEvents(0xa0);
+        expect(midiSequencerPart.currentEventTime).toBe(0x80);
+        expect(midiSequencerPart.currentEventIndex).toBe(9);
+
+        midiSequencerPart.playEvents(0xc0);
+        expect(midiSequencerPart.currentEventTime).toBe(0xc0);
+        expect(midiSequencerPart.currentEventIndex).toBe(13);
+
+        midiSequencerPart.playEvents(0x141);
+        expect(midiSequencerPart.currentEventTime).toBe(0x140);
+        expect(midiSequencerPart.currentEventIndex).toBe(18);
+
+        const eventlist2: u8[] = [
+            0x00, 0x90, 0x40, 0x64,
+            0x01, 0x80, 0x40, 0x00, // time = 0x01
+            0x03, 0x90, 0x40, 0x64, // time = 0x04
+            0x05, 0x80, 0x40, 0x00 // time = 0x09
+        ];
+
+        for (let n = 0; n < eventlist2.length; n++) {
+            midiSequencerPart.setEventListValueAt(n, eventlist2[n]);
+        }
+        midiSequencerPart.changeEventListLength(eventlist2.length);
+
+        midiSequencerPart.playEvents(0x02);
+
+        expect(midiSequencerPart.currentEventTime).toBe(1);
+        expect(midiSequencerPart.currentEventIndex).toBe(8);
+
+        midiSequencerPart.playEvents(0x09);
+        expect(midiSequencerPart.currentEventTime).toBe(0x09);
+        expect(midiSequencerPart.currentEventIndex).toBe(16);
+
+        const eventlist3: u8[] = [
+            0x00, 0x90, 0x40, 0x64,
+            0x01, 0x80, 0x40, 0x00, // time = 0x01
+            0x03, 0x90, 0x40, 0x64, // time = 0x04
+            0x05, 0x80, 0x40, 0x00, // time = 0x09
+            0x07, 0x90, 0x40, 0x64, // time = 0x10
+            0x80, 0x01, 0x80, 0x40, 0x00, // time = 0x90
+            0x40, 0x90, 0x40, 0x64, // time = 0xd0
+            0x80, 0x01, 0x80, 0x40, 0x00 // time = 0x150
+        ];
+
+        for (let n = 0; n < eventlist3.length; n++) {
+            midiSequencerPart.setEventListValueAt(n, eventlist3[n]);
+        }
+        midiSequencerPart.changeEventListLength(eventlist3.length);
+
+        midiSequencerPart.playEvents(0x02);
+
+        expect(midiSequencerPart.currentEventTime).toBe(1);
+        expect(midiSequencerPart.currentEventIndex).toBe(8);
+
+        midiSequencerPart.playEvents(0x09);
+        expect(midiSequencerPart.currentEventTime).toBe(0x09);
+        expect(midiSequencerPart.currentEventIndex).toBe(16);
+
+        midiSequencerPart.playEvents(0x40 + 0x10);
+
+        expect(midiSequencerPart.currentEventTime).toBe(0 + 0x10);
+        expect(midiSequencerPart.currentEventIndex).toBe(4 + 16);
+
+        midiSequencerPart.playEvents(0x80 + 0x10);
+        expect(midiSequencerPart.currentEventTime).toBe(0x80 + 0x10);
+        expect(midiSequencerPart.currentEventIndex).toBe(9 + 16);
+
+        midiSequencerPart.playEvents(0xa0 + 0x10);
+        expect(midiSequencerPart.currentEventTime).toBe(0x80 + 0x10);
+        expect(midiSequencerPart.currentEventIndex).toBe(9 + 16);
+
+        midiSequencerPart.playEvents(0xc0 + 0x10);
+        expect(midiSequencerPart.currentEventTime).toBe(0xc0 + 0x10);
+        expect(midiSequencerPart.currentEventIndex).toBe(13 + 16);
+
+        midiSequencerPart.playEvents(0x141 + 0x10);
+        expect(midiSequencerPart.currentEventTime).toBe(0x140 + 0x10);
+        expect(midiSequencerPart.currentEventIndex).toBe(18 + 16);
+    })
+});

--- a/wasmaudioworklet/synth1/assembly/__tests__/midi/midisequencerpart.spec.ts
+++ b/wasmaudioworklet/synth1/assembly/__tests__/midi/midisequencerpart.spec.ts
@@ -1,3 +1,4 @@
+import { addMidiPart, changeMidiPartEventListLength, getDuration, setMidiPartEventListValueAt, setMidiPartSchedule } from "../../midi/sequencer/midisequencer";
 import { MidiSequencerPart } from "../../midi/sequencer/midisequencerpart";
 
 describe("midiparts", () => {
@@ -42,6 +43,7 @@ describe("midiparts", () => {
             midiSequencerPart.setEventListValueAt(n, eventlist2[n]);
         }
         midiSequencerPart.changeEventListLength(eventlist2.length);
+        expect(midiSequencerPart.eventlist.length).toBe(eventlist2.length);
 
         midiSequencerPart.playEvents(0x02);
 
@@ -62,11 +64,12 @@ describe("midiparts", () => {
             0x40, 0x90, 0x40, 0x64, // time = 0xd0
             0x80, 0x01, 0x80, 0x40, 0x00 // time = 0x150
         ];
-
+        
         for (let n = 0; n < eventlist3.length; n++) {
             midiSequencerPart.setEventListValueAt(n, eventlist3[n]);
         }
-        midiSequencerPart.changeEventListLength(eventlist3.length);
+        expect(midiSequencerPart.eventlist.length).toBe(eventlist3.length);
+        midiSequencerPart.findLastEventTime();
 
         midiSequencerPart.playEvents(0x02);
 
@@ -97,5 +100,24 @@ describe("midiparts", () => {
         midiSequencerPart.playEvents(0x141 + 0x10);
         expect(midiSequencerPart.currentEventTime).toBe(0x140 + 0x10);
         expect(midiSequencerPart.currentEventIndex).toBe(18 + 16);
-    })
+
+        expect(midiSequencerPart.lastEventTime).toBe(0x140 + 0x10);
+    });
+    it("should add midiparts", () => {
+        const midipartindex = addMidiPart(8);
+        setMidiPartSchedule(0, midipartindex, 0);
+        expect(getDuration()).toBe(0);
+        const eventlist2: u8[] = [
+            0x00, 0x90, 0x40, 0x64,
+            0x01, 0x80, 0x40, 0x00, // time = 0x01
+            0x03, 0x90, 0x40, 0x64, // time = 0x04
+            0x05, 0x80, 0x40, 0x00 // time = 0x09
+        ];
+        for (let n = 0; n < eventlist2.length; n++) {
+            setMidiPartEventListValueAt(midipartindex, n, eventlist2[n]);
+        }
+        changeMidiPartEventListLength(midipartindex, eventlist2.length);
+        setMidiPartSchedule(0, midipartindex, 0);
+        expect(getDuration()).toBe(0x09);
+    });
 });

--- a/wasmaudioworklet/synth1/assembly/midi/sequencer/midisequencer.ts
+++ b/wasmaudioworklet/synth1/assembly/midi/sequencer/midisequencer.ts
@@ -1,6 +1,7 @@
 import { SAMPLERATE } from "../../environment";
 import { midiparts, midipartschedule } from "./midiparts";
 import { fillSampleBuffer, sampleBufferFrames } from "../midisynth";
+import { MidiSequencerPart, MidiSequencerPartSchedule } from "./midisequencerpart";
 
 const PLAY_EVENT_INTERVAL = ((sampleBufferFrames * 1000) as f64 / SAMPLERATE);
 
@@ -44,5 +45,31 @@ export function playEventsAndFillSampleBuffer(): void {
 }
 
 export function setMidiPartSchedule(ndx: i32, midipartindex: i32, startTime: i32): void {
-    midipartschedule[ndx].updateEndTime(midipartindex, startTime);
+    if (ndx>=midipartschedule.length) {
+        midipartschedule[ndx] = new MidiSequencerPartSchedule(midipartindex, startTime);
+    } else {
+        midipartschedule[ndx].updateEndTime(midipartindex, startTime);
+    }
+}
+
+export function setMidiPartEventListValueAt(midipartindex: i32, eventlistindex: i32, value: u8): void {
+    midiparts[midipartindex].setEventListValueAt(eventlistindex, value);
+}
+
+export function changeMidiPartEventListLength(midipartindex: i32, length: i32): void {
+    midiparts[midipartindex].changeEventListLength(length);
+}
+
+export function addMidiPart(eventlistlength: i32): i32 {
+    return midiparts.push(new MidiSequencerPart(new Array<u8>(eventlistlength))) - 1;
+}
+
+export function getDuration(): i32 {
+    let duration: i32 = 0;
+    for (let n = 0;n<midipartschedule.length; n++) {
+        if (midipartschedule[n].endTime > duration) {
+            duration = midipartschedule[n].endTime;
+        }
+    }
+    return duration;
 }

--- a/wasmaudioworklet/synth1/assembly/midi/sequencer/midisequencerpart.ts
+++ b/wasmaudioworklet/synth1/assembly/midi/sequencer/midisequencerpart.ts
@@ -7,7 +7,19 @@ export class MidiSequencerPart {
     previousTargetTime: i32 = 0;
     lastEventTime: i32 = 0;
 
-    constructor(public eventlist: u8[]) {
+    constructor(public eventlist: Array<u8>) {
+        this.findLastEventTime();
+    }
+
+    public changeEventListLength(newLength: i32): void {
+        this.eventlist.length = newLength;
+    }
+
+    public setEventListValueAt(ndx: i32, val: u8): void {
+        this.eventlist[ndx] = val;
+    }
+
+    public findLastEventTime(): void {
         let lastEventTime = 0;
         for (let ndx = 0; ndx < this.eventlist.length;ndx += 3) {
             let deltaTime: i32 = 0;

--- a/wasmaudioworklet/synth1/assembly/midi/sequencer/midisequencerpart.ts
+++ b/wasmaudioworklet/synth1/assembly/midi/sequencer/midisequencerpart.ts
@@ -13,6 +13,7 @@ export class MidiSequencerPart {
 
     public changeEventListLength(newLength: i32): void {
         this.eventlist.length = newLength;
+        this.findLastEventTime();
     }
 
     public setEventListValueAt(ndx: i32, val: u8): void {


### PR DESCRIPTION
a wasm midisynth file already contains midi data, but currently no way to edit the content of the midiparts. this makes the parts editable and so there's no need for JS code in the audioworklet for the midisequence