### PR TITLE
MIT License (in case Yoshimi is not referenced)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           npm test
   firefoxxvfb:
     name: Firefox xvfb
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Firefox xvfb

--- a/4klang/LICENSE_4klang
+++ b/4klang/LICENSE_4klang
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Dominik Ries
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-WITHOUT-YOSHIMI
+++ b/LICENSE-WITHOUT-YOSHIMI
@@ -1,0 +1,27 @@
+NOTE:
+You may use this license only if you remove all references to 
+Yoshimi which requires the GPL license.
+
+==============================================================
+
+MIT License
+
+Copyright (c) 2018-2021 Peter Johan Salomonsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wasmaudioworklet/webaudiomodules/yoshimi.spec.js
+++ b/wasmaudioworklet/webaudiomodules/yoshimi.spec.js
@@ -13,7 +13,7 @@ const synthsource = `<?xml version="1.0" encoding="UTF-8"?>`;
 const noteNumberToFreq = (notenumber) => 220 * Math.pow(2, (notenumber - 69)/12);
 
 describe("yoshimi", function() {
-    this.timeout(10000);
+    this.timeout(20000);
 
     let appElement;
     let analyser;


### PR DESCRIPTION
Add MIT license as an option if not referencing Yoshimi
also add missing license for copies of 4klang sources

fixes #60