### PR TITLE
claude-editor-bridge: mirror wasm-git OPFS tree to a host folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ out
 dist
 mediacontent
 resources
+.claude/
+.wrangler/
+test-results/

--- a/tools/claude-bridge/.gitignore
+++ b/tools/claude-bridge/.gitignore
@@ -1,0 +1,2 @@
+work/
+node_modules/

--- a/tools/claude-bridge/README.md
+++ b/tools/claude-bridge/README.md
@@ -1,0 +1,51 @@
+# claude-editor-bridge
+
+Local relay that bridges the [wasmaudioworklet](../../wasmaudioworklet/) web app
+editors to Claude Code:
+
+- Web app ↔ relay over **WebSocket** (default `ws://localhost:17890`)
+- Claude Code ↔ relay over **MCP** on **stdio**
+
+The web app proactively pushes editor state (active editor, content, cursor,
+selection) on focus and edit events. The relay caches the latest snapshot and
+serves MCP tool calls from cache, so Claude tool calls don't round-trip.
+
+## v1 scope
+
+- Protocol carries `editor_type` (`faust` / `song` / `synth` / `shader`) so
+  Claude can apply syntax-appropriate edits even though only one editor is
+  wired (Faust) in v1.
+- One MCP tool: `get_active_buffer`.
+
+## Setup
+
+```sh
+cd tools/claude-bridge
+npm install
+```
+
+Register the relay with Claude Code (e.g. in `~/.claude/settings.json` or
+`.claude.json`):
+
+```jsonc
+{
+  "mcpServers": {
+    "editor-bridge": {
+      "command": "node",
+      "args": ["/absolute/path/to/javascriptmusic/tools/claude-bridge/relay.js"]
+    }
+  }
+}
+```
+
+Then start Claude Code as usual — it spawns the relay on stdio. The relay
+opens the WebSocket port for the web app to connect to.
+
+## Configuration
+
+- `CLAUDE_BRIDGE_PORT` — WebSocket port (default `17890`).
+
+## Status
+
+WIP — `get_active_buffer` only. Next: `replace_range`, `insert_at_cursor`,
+editor lock, runtime context (audio errors, playhead).

--- a/tools/claude-bridge/README.md
+++ b/tools/claude-bridge/README.md
@@ -1,51 +1,50 @@
 # claude-editor-bridge
 
-Local relay that bridges the [wasmaudioworklet](../../wasmaudioworklet/) web app
-editors to Claude Code:
+Local relay that mirrors the [wasmaudioworklet](../../wasmaudioworklet/) web app
+editor buffers to a working folder so Claude Code can edit them as ordinary
+files.
 
-- Web app ↔ relay over **WebSocket** (default `ws://localhost:17890`)
-- Claude Code ↔ relay over **MCP** on **stdio**
+```
+browser editors  <— WebSocket —>  relay  <— filesystem —>  tools/claude-bridge/work/
+                                                            ^ Claude Code edits here
+```
 
-The web app proactively pushes editor state (active editor, content, cursor,
-selection) on focus and edit events. The relay caches the latest snapshot and
-serves MCP tool calls from cache, so Claude tool calls don't round-trip.
+No MCP server, no custom edit ops — Claude Code just uses `Read` / `Edit` /
+`Glob` / `Grep` on the mirror files like any other source tree.
 
-## v1 scope
+## Mirror layout
 
-- Protocol carries `editor_type` (`faust` / `song` / `synth` / `shader`) so
-  Claude can apply syntax-appropriate edits even though only one editor is
-  wired (Faust) in v1.
-- One MCP tool: `get_active_buffer`.
+`work/` (gitignored) is populated as you focus editors in the web app:
 
-## Setup
+| File              | Backed by                     |
+| ----------------- | ----------------------------- |
+| `song.js`         | song editor                   |
+| `synth.ts`        | synth editor (AssemblyScript) |
+| `shader.glsl`     | fragment shader editor        |
+| `faust.dsp`       | currently-open Faust .dsp     |
+| `_state.json`     | active editor + cursor + selection metadata, per editor |
+
+## Usage
 
 ```sh
 cd tools/claude-bridge
 npm install
+npm start            # listens on ws://localhost:17890
 ```
 
-Register the relay with Claude Code (e.g. in `~/.claude/settings.json` or
-`.claude.json`):
-
-```jsonc
-{
-  "mcpServers": {
-    "editor-bridge": {
-      "command": "node",
-      "args": ["/absolute/path/to/javascriptmusic/tools/claude-bridge/relay.js"]
-    }
-  }
-}
-```
-
-Then start Claude Code as usual — it spawns the relay on stdio. The relay
-opens the WebSocket port for the web app to connect to.
+Open the web app — it auto-connects to the relay (see
+`wasmaudioworklet/claude-bridge-client.js`). Focus an editor; the mirror file
+appears in `work/`. Edit it with Claude Code; the web app's editor updates in
+place.
 
 ## Configuration
 
 - `CLAUDE_BRIDGE_PORT` — WebSocket port (default `17890`).
 
-## Status
+## v1 caveats
 
-WIP — `get_active_buffer` only. Next: `replace_range`, `insert_at_cursor`,
-editor lock, runtime context (audio errors, playhead).
+- **Last writer wins.** If you type in the browser at the same instant Claude
+  is writing, one side overwrites the other. The lock-during-edit-session model
+  (see the project memory) is the planned fix.
+- **One Faust file at a time.** `faust.dsp` reflects whichever .dsp is open in
+  the editor. Switching files in the browser replaces the mirror content.

--- a/tools/claude-bridge/README.md
+++ b/tools/claude-bridge/README.md
@@ -1,30 +1,34 @@
 # claude-editor-bridge
 
-Local relay that mirrors the [wasmaudioworklet](../../wasmaudioworklet/) web app
-editor buffers to a working folder so Claude Code can edit them as ordinary
-files.
+Local relay that mirrors the [wasmaudioworklet](../../wasmaudioworklet/) web
+app's OPFS-backed wasm-git working tree to a host filesystem folder so Claude
+Code (and any other host-side editor) can edit it as ordinary files.
 
 ```
-browser editors  <— WebSocket —>  relay  <— filesystem —>  tools/claude-bridge/work/
-                                                            ^ Claude Code edits here
+browser editors / wasm-git OPFS  <— WebSocket —>  relay  <— filesystem —>  tools/claude-bridge/work/
+                                                                          ^ Claude Code, VSCode, vim, etc. edit here
 ```
 
-No MCP server, no custom edit ops — Claude Code just uses `Read` / `Edit` /
-`Glob` / `Grep` on the mirror files like any other source tree.
+No MCP server, no custom edit ops — Claude Code uses `Read` / `Edit` / `Glob`
+/ `Grep` on the mirror tree like any other source folder.
 
-## Mirror layout
+## What gets mirrored
 
-`work/` (gitignored) is populated as you focus editors in the web app:
+`work/` (gitignored) holds the full OPFS git tree at the paths it has in the
+repo: e.g. `work/song.js`, `work/synth.ts`, `work/shader.glsl`,
+`work/faust/master_me/dsp/master_me.dsp`. Plus `_state.json` with the active
+editor + cursor + selection per editor (song/synth/shader/faust).
 
-| File              | Backed by                     |
-| ----------------- | ----------------------------- |
-| `song.js`         | song editor                   |
-| `synth.ts`        | synth editor (AssemblyScript) |
-| `shader.glsl`     | fragment shader editor        |
-| `faust.dsp`       | currently-open Faust .dsp     |
-| `_state.json`     | active editor + cursor + selection metadata, per editor |
+The mirror only populates when the web app is opened with a `?gitrepo=...`
+URL — the OPFS-backed wasm-git client is the source of truth for the tree
+sync.
 
-## Usage
+For now: text files only, `.git/` excluded, no deletes. Binary files
+(samples, PNGs, .wasm) are skipped — they'd need base64 framing and a way
+to pull raw OPFS bytes that wasm-git's text-only `readfile` doesn't yet
+expose.
+
+## Setup
 
 ```sh
 cd tools/claude-bridge
@@ -32,19 +36,29 @@ npm install
 npm start            # listens on ws://localhost:17890
 ```
 
-Open the web app — it auto-connects to the relay (see
-`wasmaudioworklet/claude-bridge-client.js`). Focus an editor; the mirror file
-appears in `work/`. Edit it with Claude Code; the web app's editor updates in
-place.
+Open the web app with a git repo (e.g. `?gitrepo=…`). The relay logs
+`tree_dump: wrote N file(s)` once the wasm-git client is ready. From then on:
+
+- **Browser edit → host**: each editor change pushes a `file_changed` →
+  relay writes the mirror.
+- **Host edit → browser**: any change to a mirror file fires `fs.watch` →
+  relay broadcasts `apply_file` → client writes back to OPFS via wasm-git's
+  `writefileandstage`, and if an editor is currently showing that path,
+  refreshes the buffer in place.
 
 ## Configuration
 
 - `CLAUDE_BRIDGE_PORT` — WebSocket port (default `17890`).
 
-## v1 caveats
+## Caveats
 
-- **Last writer wins.** If you type in the browser at the same instant Claude
-  is writing, one side overwrites the other. The lock-during-edit-session model
-  (see the project memory) is the planned fix.
-- **One Faust file at a time.** `faust.dsp` reflects whichever .dsp is open in
-  the editor. Switching files in the browser replaces the mirror content.
+- **Last writer wins.** Simultaneous edits on the same file from both sides
+  race. The lock-during-edit-session model (see project memory) is the
+  planned fix.
+- **No `.git`** in the mirror, so host-side `git status` / `git diff`
+  don't reflect the wasm-git repo's actual state. Including the `.git`
+  directory is the next obvious extension — needs careful handling because
+  git operations generate event storms on `fs.watch`.
+- **No binary files**: until wasm-git exposes raw byte reads of OPFS
+  entries.
+- **No deletes** propagate from host → OPFS yet — only creates/updates.

--- a/tools/claude-bridge/package-lock.json
+++ b/tools/claude-bridge/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "claude-editor-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-editor-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "claude-editor-bridge": "relay.js"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/tools/claude-bridge/package.json
+++ b/tools/claude-bridge/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-editor-bridge",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Local relay that bridges the wasmaudioworklet web app editors to Claude Code via WebSocket + MCP.",
+  "bin": {
+    "claude-editor-bridge": "./relay.js"
+  },
+  "scripts": {
+    "start": "node relay.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/tools/claude-bridge/package.json
+++ b/tools/claude-bridge/package.json
@@ -1,9 +1,9 @@
 {
   "name": "claude-editor-bridge",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Local relay that bridges the wasmaudioworklet web app editors to Claude Code via WebSocket + MCP.",
+  "description": "Local relay that mirrors wasmaudioworklet editor buffers to a working folder. Claude Code edits the files; the relay syncs both directions via WebSocket.",
   "bin": {
     "claude-editor-bridge": "./relay.js"
   },
@@ -11,7 +11,6 @@
     "start": "node relay.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
     "ws": "^8.18.0"
   }
 }

--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -1,37 +1,67 @@
 #!/usr/bin/env node
-// Local relay bridging the web app editors (over WebSocket) to Claude Code
-// (over MCP/stdio). v1 surface: a single `get_active_buffer` tool.
+// Local relay that mirrors web-app editor buffers to a working folder.
+// Claude Code edits the files in that folder with its usual Read/Edit tools;
+// the relay propagates those changes back into the browser via WebSocket.
 //
-// Architecture: the web app proactively pushes editor state on focus, content,
-// and cursor changes. The relay caches the latest snapshot and serves it
-// synchronously to MCP tool calls, avoiding a round-trip per call.
+//   Browser → relay  : `state` WS message → write `<id>.<ext>` in work/
+//   Relay   → browser: fs.watch fires → `replace_buffer` WS message
+//
+// Echo prevention: every file write records the content in `lastWritten`;
+// when fs.watch fires with matching content, the change is ours and skipped.
 
 import { WebSocketServer } from 'ws';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-    CallToolRequestSchema,
-    ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import { writeFile, readFile, mkdir } from 'node:fs/promises';
+import { watch } from 'node:fs';
+import { dirname, resolve, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORK_DIR = resolve(__dirname, 'work');
+const STATE_FILE = join(WORK_DIR, '_state.json');
 const WS_PORT = Number(process.env.CLAUDE_BRIDGE_PORT) || 17890;
 
-// Latest snapshot from whichever editor most recently reported focus + state.
-// Shape: { id, editor_type, language, name, content, cursor, selection, updatedAt }
-let activeEditor = null;
-let connectedClients = 0;
+// One mirror file per editor id, named `<id>.<ext>`. `faust.dsp` always
+// reflects whichever .dsp file is currently open in the Faust editor — the
+// "real" path lives in _state.json.
+const EXTENSIONS = {
+    song: 'js',
+    synth: 'ts',
+    shader: 'glsl',
+    faust: 'dsp',
+};
 
+function pathForId(id) {
+    const ext = EXTENSIONS[id] || 'txt';
+    return join(WORK_DIR, `${id}.${ext}`);
+}
+
+function idForFilename(filename) {
+    for (const [id, ext] of Object.entries(EXTENSIONS)) {
+        if (filename === `${id}.${ext}`) return id;
+    }
+    return null;
+}
+
+// In-memory state.
+const editorMeta = {}; // id -> { file (real path), cursor, selection, name, editor_type, language }
+let activeEditor = null;
+const lastWritten = new Map(); // absolute path -> content
+
+await mkdir(WORK_DIR, { recursive: true });
+
+const clients = new Set();
 const wss = new WebSocketServer({ port: WS_PORT });
 
 wss.on('listening', () => {
-    process.stderr.write(`[claude-bridge] WS listening on ws://localhost:${WS_PORT}\n`);
+    process.stderr.write(`[claude-bridge] WS on ws://localhost:${WS_PORT}\n`);
+    process.stderr.write(`[claude-bridge] mirror dir: ${WORK_DIR}\n`);
 });
 
 wss.on('connection', (ws) => {
-    connectedClients++;
-    process.stderr.write(`[claude-bridge] client connected (${connectedClients} total)\n`);
+    clients.add(ws);
+    process.stderr.write(`[claude-bridge] client connected (${clients.size} total)\n`);
 
-    ws.on('message', (data) => {
+    ws.on('message', async (data) => {
         let msg;
         try {
             msg = JSON.parse(data.toString());
@@ -40,80 +70,72 @@ wss.on('connection', (ws) => {
             return;
         }
         if (msg.type === 'state') {
-            activeEditor = {
-                id: msg.editor?.id,
-                editor_type: msg.editor?.editor_type,
-                language: msg.editor?.language,
-                name: msg.editor?.name,
-                content: msg.content,
-                cursor: msg.cursor,
-                selection: msg.selection,
-                updatedAt: Date.now(),
-            };
-        } else if (msg.type === 'blur') {
-            if (activeEditor && activeEditor.id === msg.id) {
-                activeEditor = null;
-            }
+            await handleStatePush(msg);
         }
     });
 
     ws.on('close', () => {
-        connectedClients--;
-        if (connectedClients === 0) {
-            activeEditor = null;
-        }
+        clients.delete(ws);
     });
 });
 
-const server = new Server(
-    { name: 'claude-editor-bridge', version: '0.0.1' },
-    { capabilities: { tools: {} } }
-);
-
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [
-        {
-            name: 'get_active_buffer',
-            description:
-                'Return the currently focused editor in the web app: its type ' +
-                '(faust/song/synth/shader), language, file name, full content, ' +
-                'cursor position, and selection (if any). Returns an error if ' +
-                'no web app client is connected or no editor is focused.',
-            inputSchema: {
-                type: 'object',
-                properties: {},
-                additionalProperties: false,
-            },
-        },
-    ],
-}));
-
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    if (req.params.name === 'get_active_buffer') {
-        if (!activeEditor) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text:
-                            connectedClients === 0
-                                ? 'No web app client is connected to the bridge.'
-                                : 'No editor is currently focused in the web app.',
-                    },
-                ],
-                isError: true,
-            };
-        }
-        return {
-            content: [{ type: 'text', text: JSON.stringify(activeEditor, null, 2) }],
-        };
-    }
-    return {
-        content: [{ type: 'text', text: `Unknown tool: ${req.params.name}` }],
-        isError: true,
+async function handleStatePush(msg) {
+    const id = msg.editor?.id;
+    if (!id || !(id in EXTENSIONS)) return;
+    const filePath = pathForId(id);
+    editorMeta[id] = {
+        mirror: basename(filePath),
+        file: msg.editor.name,
+        editor_type: msg.editor.editor_type,
+        language: msg.editor.language,
+        cursor: msg.cursor,
+        selection: msg.selection,
     };
+    activeEditor = id;
+    lastWritten.set(filePath, msg.content);
+    try {
+        await writeFile(filePath, msg.content);
+    } catch (e) {
+        process.stderr.write(`[claude-bridge] write failed ${filePath}: ${e.message}\n`);
+    }
+    await writeState();
+}
+
+async function writeState() {
+    const state = { activeEditor, editors: editorMeta };
+    try {
+        await writeFile(STATE_FILE, JSON.stringify(state, null, 2));
+    } catch (e) {
+        process.stderr.write(`[claude-bridge] state write failed: ${e.message}\n`);
+    }
+}
+
+// Watch the mirror dir for Claude's edits. fs.watch may fire multiple events
+// per change on some platforms; we dedupe via content comparison against
+// `lastWritten`.
+watch(WORK_DIR, async (_eventType, filename) => {
+    if (!filename || filename === '_state.json') return;
+    const id = idForFilename(filename);
+    if (!id) return;
+    const filePath = join(WORK_DIR, filename);
+    let content;
+    try {
+        content = await readFile(filePath, 'utf8');
+    } catch (_e) {
+        return; // file may have been deleted/replaced mid-event
+    }
+    if (lastWritten.get(filePath) === content) return; // our own write
+    lastWritten.set(filePath, content);
+    broadcastReplaceBuffer(id, content);
 });
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
-process.stderr.write('[claude-bridge] MCP server ready on stdio\n');
+function broadcastReplaceBuffer(id, content) {
+    const payload = JSON.stringify({ type: 'replace_buffer', id, content });
+    let delivered = 0;
+    for (const c of clients) {
+        if (c.readyState !== c.OPEN) continue;
+        c.send(payload);
+        delivered++;
+    }
+    process.stderr.write(`[claude-bridge] replace_buffer ${id} → ${delivered} client(s)\n`);
+}

--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -1,18 +1,28 @@
 #!/usr/bin/env node
-// Local relay that mirrors web-app editor buffers to a working folder.
-// Claude Code edits the files in that folder with its usual Read/Edit tools;
-// the relay propagates those changes back into the browser via WebSocket.
+// Local relay that mirrors the web app's OPFS-backed wasm-git working tree to
+// `tools/claude-bridge/work/`. Claude Code (or any host-side editor) edits the
+// files there with its normal tools; the relay syncs both directions over
+// WebSocket.
 //
-//   Browser → relay  : `state` WS message → write `<id>.<ext>` in work/
-//   Relay   → browser: fs.watch fires → `replace_buffer` WS message
+// Protocol (browser <-> relay, JSON over WS):
+//   browser -> relay
+//     { type: 'tree_dump', files: [{ path, content, binary }] }
+//         Full snapshot — sent on connect once the wasm-git client is ready.
+//     { type: 'file_changed', path, content, binary }
+//         A single file write originating in the browser.
+//     { type: 'editor_state', editor, path, cursor, selection, language }
+//         Editor cursor/selection metadata. Persisted to `_state.json`.
+//   relay -> browser
+//     { type: 'apply_file', path, content, binary }
+//         A single mirror-file changed in `work/` (e.g. by Claude Code).
 //
-// Echo prevention: every file write records the content in `lastWritten`;
-// when fs.watch fires with matching content, the change is ours and skipped.
+// Echo prevention: every write records the bytes in `lastWritten`; fs.watch
+// events that match are our own work and skipped.
 
 import { WebSocketServer } from 'ws';
 import { writeFile, readFile, mkdir } from 'node:fs/promises';
 import { watch } from 'node:fs';
-import { dirname, resolve, join, basename } from 'node:path';
+import { dirname, resolve, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -20,32 +30,11 @@ const WORK_DIR = resolve(__dirname, 'work');
 const STATE_FILE = join(WORK_DIR, '_state.json');
 const WS_PORT = Number(process.env.CLAUDE_BRIDGE_PORT) || 17890;
 
-// One mirror file per editor id, named `<id>.<ext>`. `faust.dsp` always
-// reflects whichever .dsp file is currently open in the Faust editor — the
-// "real" path lives in _state.json.
-const EXTENSIONS = {
-    song: 'js',
-    synth: 'ts',
-    shader: 'glsl',
-    faust: 'dsp',
-};
-
-function pathForId(id) {
-    const ext = EXTENSIONS[id] || 'txt';
-    return join(WORK_DIR, `${id}.${ext}`);
-}
-
-function idForFilename(filename) {
-    for (const [id, ext] of Object.entries(EXTENSIONS)) {
-        if (filename === `${id}.${ext}`) return id;
-    }
-    return null;
-}
-
-// In-memory state.
-const editorMeta = {}; // id -> { file (real path), cursor, selection, name, editor_type, language }
+// Editor cursor/selection per editor id, persisted to _state.json.
 let activeEditor = null;
-const lastWritten = new Map(); // absolute path -> content
+const editorMeta = {}; // id -> { path, cursor, selection, language, language }
+// Echo guard: text content (or base64 for binary) we last wrote per absolute path.
+const lastWritten = new Map();
 
 await mkdir(WORK_DIR, { recursive: true });
 
@@ -69,8 +58,17 @@ wss.on('connection', (ws) => {
             process.stderr.write(`[claude-bridge] bad message: ${e.message}\n`);
             return;
         }
-        if (msg.type === 'state') {
-            await handleStatePush(msg);
+        try {
+            if (msg.type === 'tree_dump') {
+                await handleTreeDump(msg);
+            } else if (msg.type === 'file_changed') {
+                await writeMirrorFile(msg.path, msg.content, !!msg.binary);
+            } else if (msg.type === 'editor_state') {
+                handleEditorState(msg);
+                await writeState();
+            }
+        } catch (e) {
+            process.stderr.write(`[claude-bridge] handler failed (${msg.type}): ${e.message}\n`);
         }
     });
 
@@ -79,26 +77,52 @@ wss.on('connection', (ws) => {
     });
 });
 
-async function handleStatePush(msg) {
-    const id = msg.editor?.id;
-    if (!id || !(id in EXTENSIONS)) return;
-    const filePath = pathForId(id);
-    editorMeta[id] = {
-        mirror: basename(filePath),
-        file: msg.editor.name,
-        editor_type: msg.editor.editor_type,
-        language: msg.editor.language,
-        cursor: msg.cursor,
-        selection: msg.selection,
-    };
-    activeEditor = id;
-    lastWritten.set(filePath, msg.content);
-    try {
-        await writeFile(filePath, msg.content);
-    } catch (e) {
-        process.stderr.write(`[claude-bridge] write failed ${filePath}: ${e.message}\n`);
+async function handleTreeDump(msg) {
+    if (!Array.isArray(msg.files)) return;
+    let written = 0;
+    for (const f of msg.files) {
+        if (!isSafeRelPath(f.path)) continue;
+        try {
+            await writeMirrorFile(f.path, f.content, !!f.binary);
+            written++;
+        } catch (e) {
+            process.stderr.write(`[claude-bridge] tree_dump: skipped ${f.path}: ${e.message}\n`);
+        }
     }
-    await writeState();
+    process.stderr.write(`[claude-bridge] tree_dump: wrote ${written}/${msg.files.length} file(s)\n`);
+}
+
+function handleEditorState(msg) {
+    if (!msg.editor) return;
+    editorMeta[msg.editor] = {
+        path: msg.path ?? null,
+        cursor: msg.cursor ?? null,
+        selection: msg.selection ?? null,
+        language: msg.language ?? null,
+    };
+    activeEditor = msg.editor;
+}
+
+// Reject paths that escape WORK_DIR or use Windows separators / abs paths.
+function isSafeRelPath(p) {
+    if (typeof p !== 'string' || p.length === 0) return false;
+    if (p.startsWith('/') || p.includes('\\')) return false;
+    if (p.split('/').some((part) => part === '..' || part === '')) return false;
+    return true;
+}
+
+async function writeMirrorFile(relPath, content, binary) {
+    if (!isSafeRelPath(relPath)) throw new Error(`unsafe path: ${relPath}`);
+    const filePath = join(WORK_DIR, relPath);
+    await mkdir(dirname(filePath), { recursive: true });
+    if (binary) {
+        const buf = Buffer.from(content, 'base64');
+        lastWritten.set(filePath, content); // store base64 form for compare
+        await writeFile(filePath, buf);
+    } else {
+        lastWritten.set(filePath, content);
+        await writeFile(filePath, content);
+    }
 }
 
 async function writeState() {
@@ -110,32 +134,48 @@ async function writeState() {
     }
 }
 
-// Watch the mirror dir for Claude's edits. fs.watch may fire multiple events
-// per change on some platforms; we dedupe via content comparison against
-// `lastWritten`.
-watch(WORK_DIR, async (_eventType, filename) => {
-    if (!filename || filename === '_state.json') return;
-    const id = idForFilename(filename);
-    if (!id) return;
-    const filePath = join(WORK_DIR, filename);
-    let content;
+// Recursive watch of WORK_DIR. macOS supports recursive natively; on Linux,
+// fs.watch with recursive is best-effort. The relPath delivered by Node's
+// watcher uses platform separators — normalize to forward slashes.
+watch(WORK_DIR, { recursive: true }, async (_eventType, filename) => {
+    if (!filename) return;
+    const relPath = filename.split(sep).join('/');
+    if (relPath === '_state.json' || relPath.startsWith('_state.json')) return;
+    if (!isSafeRelPath(relPath)) return;
+
+    const filePath = join(WORK_DIR, relPath);
+    let buf;
     try {
-        content = await readFile(filePath, 'utf8');
+        buf = await readFile(filePath);
     } catch (_e) {
         return; // file may have been deleted/replaced mid-event
     }
-    if (lastWritten.get(filePath) === content) return; // our own write
-    lastWritten.set(filePath, content);
-    broadcastReplaceBuffer(id, content);
+
+    const binary = isLikelyBinary(relPath);
+    const encoded = binary ? buf.toString('base64') : buf.toString('utf8');
+    if (lastWritten.get(filePath) === encoded) return; // our own write
+    lastWritten.set(filePath, encoded);
+    broadcastApplyFile(relPath, encoded, binary);
 });
 
-function broadcastReplaceBuffer(id, content) {
-    const payload = JSON.stringify({ type: 'replace_buffer', id, content });
+const BINARY_EXTS = new Set([
+    'png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp',
+    'mp3', 'wav', 'ogg', 'flac', 'mid', 'midi',
+    'wasm', 'bin', 'zip', 'gz', 'tar',
+    'woff', 'woff2', 'ttf', 'otf',
+]);
+function isLikelyBinary(p) {
+    const ext = p.toLowerCase().split('.').pop();
+    return BINARY_EXTS.has(ext);
+}
+
+function broadcastApplyFile(path, content, binary) {
+    const payload = JSON.stringify({ type: 'apply_file', path, content, binary });
     let delivered = 0;
     for (const c of clients) {
         if (c.readyState !== c.OPEN) continue;
         c.send(payload);
         delivered++;
     }
-    process.stderr.write(`[claude-bridge] replace_buffer ${id} → ${delivered} client(s)\n`);
+    process.stderr.write(`[claude-bridge] apply_file ${path} → ${delivered} client(s)\n`);
 }

--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Local relay bridging the web app editors (over WebSocket) to Claude Code
+// (over MCP/stdio). v1 surface: a single `get_active_buffer` tool.
+//
+// Architecture: the web app proactively pushes editor state on focus, content,
+// and cursor changes. The relay caches the latest snapshot and serves it
+// synchronously to MCP tool calls, avoiding a round-trip per call.
+
+import { WebSocketServer } from 'ws';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+    CallToolRequestSchema,
+    ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const WS_PORT = Number(process.env.CLAUDE_BRIDGE_PORT) || 17890;
+
+// Latest snapshot from whichever editor most recently reported focus + state.
+// Shape: { id, editor_type, language, name, content, cursor, selection, updatedAt }
+let activeEditor = null;
+let connectedClients = 0;
+
+const wss = new WebSocketServer({ port: WS_PORT });
+
+wss.on('listening', () => {
+    process.stderr.write(`[claude-bridge] WS listening on ws://localhost:${WS_PORT}\n`);
+});
+
+wss.on('connection', (ws) => {
+    connectedClients++;
+    process.stderr.write(`[claude-bridge] client connected (${connectedClients} total)\n`);
+
+    ws.on('message', (data) => {
+        let msg;
+        try {
+            msg = JSON.parse(data.toString());
+        } catch (e) {
+            process.stderr.write(`[claude-bridge] bad message: ${e.message}\n`);
+            return;
+        }
+        if (msg.type === 'state') {
+            activeEditor = {
+                id: msg.editor?.id,
+                editor_type: msg.editor?.editor_type,
+                language: msg.editor?.language,
+                name: msg.editor?.name,
+                content: msg.content,
+                cursor: msg.cursor,
+                selection: msg.selection,
+                updatedAt: Date.now(),
+            };
+        } else if (msg.type === 'blur') {
+            if (activeEditor && activeEditor.id === msg.id) {
+                activeEditor = null;
+            }
+        }
+    });
+
+    ws.on('close', () => {
+        connectedClients--;
+        if (connectedClients === 0) {
+            activeEditor = null;
+        }
+    });
+});
+
+const server = new Server(
+    { name: 'claude-editor-bridge', version: '0.0.1' },
+    { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+        {
+            name: 'get_active_buffer',
+            description:
+                'Return the currently focused editor in the web app: its type ' +
+                '(faust/song/synth/shader), language, file name, full content, ' +
+                'cursor position, and selection (if any). Returns an error if ' +
+                'no web app client is connected or no editor is focused.',
+            inputSchema: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+            },
+        },
+    ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    if (req.params.name === 'get_active_buffer') {
+        if (!activeEditor) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text:
+                            connectedClients === 0
+                                ? 'No web app client is connected to the bridge.'
+                                : 'No editor is currently focused in the web app.',
+                    },
+                ],
+                isError: true,
+            };
+        }
+        return {
+            content: [{ type: 'text', text: JSON.stringify(activeEditor, null, 2) }],
+        };
+    }
+    return {
+        content: [{ type: 'text', text: `Unknown tool: ${req.params.name}` }],
+        isError: true,
+    };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+process.stderr.write('[claude-bridge] MCP server ready on stdio\n');

--- a/wasmaudioworklet/claude-bridge-client.js
+++ b/wasmaudioworklet/claude-bridge-client.js
@@ -1,24 +1,78 @@
-// WebSocket client that pushes the focused editor's state to the local
-// claude-editor-bridge relay. The relay caches the snapshot and serves it to
-// Claude Code via MCP. See tools/claude-bridge/.
+// WebSocket client that mirrors the OPFS-backed wasm-git working tree to the
+// local claude-editor-bridge relay (see tools/claude-bridge/).
+//
+//   browser -> relay  : tree_dump (on connect / git sync), file_changed (per
+//                       editor save), editor_state (cursor/selection)
+//   relay   -> browser: apply_file (Claude or external edits in work/)
+//
+// `attachGitRepo({ listfiles, readfile, writefileandstage })` must be called
+// once the wasm-git client is ready. Before that, only editor_state messages
+// flow; file content sync is dormant.
 
 const DEFAULT_PORT = 17890;
 const RECONNECT_MS = 3000;
-const STATE_DEBOUNCE_MS = 200;
+const EDITOR_DEBOUNCE_MS = 250;
+
+const BINARY_EXTS = new Set([
+    'png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp',
+    'mp3', 'wav', 'ogg', 'flac', 'mid', 'midi',
+    'wasm', 'bin', 'zip', 'gz', 'tar',
+    'woff', 'woff2', 'ttf', 'otf',
+]);
+function isLikelyBinary(p) {
+    const ext = (p || '').toLowerCase().split('.').pop();
+    return BINARY_EXTS.has(ext);
+}
 
 class ClaudeBridgeClient {
     constructor() {
         this.ws = null;
-        this.editors = new Map();
+        this.editors = new Map(); // id -> { cm, language, getPath }
         this.activeEditorId = null;
         this.reconnectTimer = null;
         this.warned = false;
         this.url = `ws://localhost:${DEFAULT_PORT}`;
+        this.git = null; // { listfiles, readfile, writefileandstage }
+        this.treeSynced = false;
     }
 
     start() {
         if (this.ws) return;
         this._connect();
+    }
+
+    attachGitRepo({ listfiles, readfile, writefileandstage }) {
+        this.git = { listfiles, readfile, writefileandstage };
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+            this._sendTreeDump().catch((e) => console.warn('[claude-bridge] tree_dump failed', e));
+        }
+    }
+
+    // Call after a remote sync (pull/commit) to refresh Claude's view.
+    async resyncTree() {
+        if (!this.git) return;
+        this.treeSynced = false;
+        await this._sendTreeDump();
+    }
+
+    // Register a CodeMirror 5 editor with the bridge. `getPath` returns the
+    // OPFS-relative path currently shown in this editor (may be null).
+    registerEditor(cm, { id, language, getPath }) {
+        if (!cm) return;
+        this.editors.set(id, { cm, language, getPath });
+
+        cm.on('focus', () => {
+            this.activeEditorId = id;
+            this._scheduleEditorSync(id);
+        });
+
+        let timer = null;
+        const debounced = (kind) => {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => this._editorSync(id, kind), EDITOR_DEBOUNCE_MS);
+        };
+        cm.on('changes', () => debounced('changes'));
+        cm.on('cursorActivity', () => debounced('cursor'));
     }
 
     _connect() {
@@ -30,10 +84,15 @@ class ClaudeBridgeClient {
         }
         this.ws.addEventListener('open', () => {
             this.warned = false;
-            if (this.activeEditorId) this._sendState();
+            this.treeSynced = false;
+            if (this.git) {
+                this._sendTreeDump().catch((e) => console.warn('[claude-bridge] tree_dump failed', e));
+            }
+            if (this.activeEditorId) this._editorSync(this.activeEditorId, 'reconnect');
         });
         this.ws.addEventListener('close', () => {
             this.ws = null;
+            this.treeSynced = false;
             this._scheduleReconnect();
         });
         this.ws.addEventListener('error', () => {
@@ -47,21 +106,8 @@ class ClaudeBridgeClient {
         this.ws.addEventListener('message', (ev) => {
             let msg;
             try { msg = JSON.parse(ev.data); } catch (_e) { return; }
-            if (msg.type === 'replace_buffer') this._replaceBuffer(msg);
+            if (msg.type === 'apply_file') this._applyFile(msg).catch((e) => console.warn('[claude-bridge] apply_file failed', e));
         });
-    }
-
-    // Replace a specific editor's buffer with `content` (from a Claude edit on
-    // the mirror file). Cursor is preserved when possible.
-    _replaceBuffer(msg) {
-        const entry = this.editors.get(msg.id);
-        if (!entry) return;
-        const cm = entry.cm;
-        const next = msg.content ?? '';
-        if (cm.doc.getValue() === next) return;
-        const sels = cm.doc.listSelections();
-        cm.doc.setValue(next);
-        try { cm.doc.setSelections(sels); } catch (_e) { /* positions may no longer be valid */ }
     }
 
     _scheduleReconnect() {
@@ -72,35 +118,51 @@ class ClaudeBridgeClient {
         }, RECONNECT_MS);
     }
 
-    // Register a CodeMirror 5 instance with the bridge. `getName` may be a
-    // function (called each time) or a static string.
-    registerEditor(cm, { id, editor_type, language, getName }) {
-        if (!cm) return;
-        const entry = { cm, id, editor_type, language, getName };
-        this.editors.set(id, entry);
-
-        cm.on('focus', () => {
-            this.activeEditorId = id;
-            this._sendState();
-        });
-
-        let timer = null;
-        const debounced = () => {
-            if (timer) clearTimeout(timer);
-            timer = setTimeout(() => {
-                if (this.activeEditorId === id) this._sendState();
-            }, STATE_DEBOUNCE_MS);
-        };
-        cm.on('changes', debounced);
-        cm.on('cursorActivity', debounced);
+    async _sendTreeDump() {
+        if (!this.git || !this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        const allPaths = await this.git.listfiles('');
+        // Skip .git for now — change-storm risk and most users don't want it in scope.
+        const paths = allPaths.filter((p) => !p.startsWith('.git/') && p !== '.git');
+        const files = [];
+        for (const path of paths) {
+            try {
+                const binary = isLikelyBinary(path);
+                if (binary) {
+                    // wasm-git readfile returns strings; skip binaries until we
+                    // have a clean way to pull raw bytes from OPFS.
+                    continue;
+                }
+                const content = await this.git.readfile(path);
+                if (typeof content !== 'string') continue;
+                files.push({ path, content, binary: false });
+            } catch (e) {
+                console.warn('[claude-bridge] tree_dump skip', path, e?.message || e);
+            }
+        }
+        try {
+            this.ws.send(JSON.stringify({ type: 'tree_dump', files }));
+            this.treeSynced = true;
+            console.info(`[claude-bridge] tree_dump sent — ${files.length} file(s)`);
+        } catch (e) {
+            console.warn('[claude-bridge] tree_dump send failed', e);
+        }
     }
 
-    _sendState() {
+    // Send editor_state (always) and file_changed (if content for this editor's
+    // path has actually changed since the last send).
+    _scheduleEditorSync(id) {
+        // Immediate sync on focus — pairs with the cursor-activity debounce.
+        this._editorSync(id, 'focus');
+    }
+
+    _lastSentForEditor = new Map(); // id -> { path, content }
+
+    _editorSync(id, _kind) {
         if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-        if (!this.activeEditorId) return;
-        const entry = this.editors.get(this.activeEditorId);
+        const entry = this.editors.get(id);
         if (!entry) return;
         const cm = entry.cm;
+        const path = typeof entry.getPath === 'function' ? entry.getPath() : entry.getPath;
         const cursor = cm.doc.getCursor();
         const selection = cm.doc.somethingSelected()
             ? {
@@ -109,24 +171,56 @@ class ClaudeBridgeClient {
                   to: cm.doc.getCursor('to'),
               }
             : null;
-        const name = typeof entry.getName === 'function' ? entry.getName() : entry.getName;
         try {
-            this.ws.send(
-                JSON.stringify({
-                    type: 'state',
-                    editor: {
-                        id: entry.id,
-                        editor_type: entry.editor_type,
-                        language: entry.language,
-                        name,
-                    },
-                    content: cm.doc.getValue(),
-                    cursor: { line: cursor.line, ch: cursor.ch },
-                    selection,
-                })
-            );
-        } catch (_e) {
-            // Ignore — close handler will trigger reconnect.
+            this.ws.send(JSON.stringify({
+                type: 'editor_state',
+                editor: id,
+                path,
+                cursor: { line: cursor.line, ch: cursor.ch },
+                selection,
+                language: entry.language,
+            }));
+        } catch (_e) { /* close handler will reconnect */ }
+
+        if (!path || !this.treeSynced) return;
+        const content = cm.doc.getValue();
+        const prev = this._lastSentForEditor.get(id);
+        if (prev && prev.path === path && prev.content === content) return;
+        this._lastSentForEditor.set(id, { path, content });
+        try {
+            this.ws.send(JSON.stringify({
+                type: 'file_changed',
+                path,
+                content,
+                binary: false,
+            }));
+        } catch (_e) { /* ditto */ }
+    }
+
+    // A mirror file changed in work/ — write it back into OPFS and, if any
+    // open editor is showing that path, refresh its buffer.
+    async _applyFile(msg) {
+        const path = msg.path;
+        if (!path) return;
+        // Update OPFS via wasm-git (text only for now).
+        if (this.git && !msg.binary) {
+            try {
+                await this.git.writefileandstage(path, msg.content);
+            } catch (e) {
+                console.warn('[claude-bridge] writefileandstage failed', path, e?.message || e);
+            }
+        }
+        // Refresh any editor currently showing this path.
+        for (const [id, entry] of this.editors) {
+            const editorPath = typeof entry.getPath === 'function' ? entry.getPath() : entry.getPath;
+            if (editorPath !== path) continue;
+            const cm = entry.cm;
+            if (cm.doc.getValue() === msg.content) continue;
+            const sels = cm.doc.listSelections();
+            cm.doc.setValue(msg.content);
+            try { cm.doc.setSelections(sels); } catch (_e) { /* positions may no longer be valid */ }
+            // Avoid immediate echo back as file_changed.
+            this._lastSentForEditor.set(id, { path, content: msg.content });
         }
     }
 }

--- a/wasmaudioworklet/claude-bridge-client.js
+++ b/wasmaudioworklet/claude-bridge-client.js
@@ -44,6 +44,24 @@ class ClaudeBridgeClient {
                 this.warned = true;
             }
         });
+        this.ws.addEventListener('message', (ev) => {
+            let msg;
+            try { msg = JSON.parse(ev.data); } catch (_e) { return; }
+            if (msg.type === 'replace_buffer') this._replaceBuffer(msg);
+        });
+    }
+
+    // Replace a specific editor's buffer with `content` (from a Claude edit on
+    // the mirror file). Cursor is preserved when possible.
+    _replaceBuffer(msg) {
+        const entry = this.editors.get(msg.id);
+        if (!entry) return;
+        const cm = entry.cm;
+        const next = msg.content ?? '';
+        if (cm.doc.getValue() === next) return;
+        const sels = cm.doc.listSelections();
+        cm.doc.setValue(next);
+        try { cm.doc.setSelections(sels); } catch (_e) { /* positions may no longer be valid */ }
     }
 
     _scheduleReconnect() {

--- a/wasmaudioworklet/claude-bridge-client.js
+++ b/wasmaudioworklet/claude-bridge-client.js
@@ -1,0 +1,116 @@
+// WebSocket client that pushes the focused editor's state to the local
+// claude-editor-bridge relay. The relay caches the snapshot and serves it to
+// Claude Code via MCP. See tools/claude-bridge/.
+
+const DEFAULT_PORT = 17890;
+const RECONNECT_MS = 3000;
+const STATE_DEBOUNCE_MS = 200;
+
+class ClaudeBridgeClient {
+    constructor() {
+        this.ws = null;
+        this.editors = new Map();
+        this.activeEditorId = null;
+        this.reconnectTimer = null;
+        this.warned = false;
+        this.url = `ws://localhost:${DEFAULT_PORT}`;
+    }
+
+    start() {
+        if (this.ws) return;
+        this._connect();
+    }
+
+    _connect() {
+        try {
+            this.ws = new WebSocket(this.url);
+        } catch (_e) {
+            this._scheduleReconnect();
+            return;
+        }
+        this.ws.addEventListener('open', () => {
+            this.warned = false;
+            if (this.activeEditorId) this._sendState();
+        });
+        this.ws.addEventListener('close', () => {
+            this.ws = null;
+            this._scheduleReconnect();
+        });
+        this.ws.addEventListener('error', () => {
+            if (!this.warned) {
+                console.info(
+                    `[claude-bridge] not connected (${this.url}) — start the relay if you want Claude Code integration`
+                );
+                this.warned = true;
+            }
+        });
+    }
+
+    _scheduleReconnect() {
+        if (this.reconnectTimer) return;
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = null;
+            this._connect();
+        }, RECONNECT_MS);
+    }
+
+    // Register a CodeMirror 5 instance with the bridge. `getName` may be a
+    // function (called each time) or a static string.
+    registerEditor(cm, { id, editor_type, language, getName }) {
+        if (!cm) return;
+        const entry = { cm, id, editor_type, language, getName };
+        this.editors.set(id, entry);
+
+        cm.on('focus', () => {
+            this.activeEditorId = id;
+            this._sendState();
+        });
+
+        let timer = null;
+        const debounced = () => {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => {
+                if (this.activeEditorId === id) this._sendState();
+            }, STATE_DEBOUNCE_MS);
+        };
+        cm.on('changes', debounced);
+        cm.on('cursorActivity', debounced);
+    }
+
+    _sendState() {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        if (!this.activeEditorId) return;
+        const entry = this.editors.get(this.activeEditorId);
+        if (!entry) return;
+        const cm = entry.cm;
+        const cursor = cm.doc.getCursor();
+        const selection = cm.doc.somethingSelected()
+            ? {
+                  text: cm.doc.getSelection(),
+                  from: cm.doc.getCursor('from'),
+                  to: cm.doc.getCursor('to'),
+              }
+            : null;
+        const name = typeof entry.getName === 'function' ? entry.getName() : entry.getName;
+        try {
+            this.ws.send(
+                JSON.stringify({
+                    type: 'state',
+                    editor: {
+                        id: entry.id,
+                        editor_type: entry.editor_type,
+                        language: entry.language,
+                        name,
+                    },
+                    content: cm.doc.getValue(),
+                    cursor: { line: cursor.line, ch: cursor.ch },
+                    selection,
+                })
+            );
+        } catch (_e) {
+            // Ignore — close handler will trigger reconnect.
+        }
+    }
+}
+
+export const claudeBridge = new ClaudeBridgeClient();

--- a/wasmaudioworklet/e2e/claude-bridge.spec.js
+++ b/wasmaudioworklet/e2e/claude-bridge.spec.js
@@ -1,0 +1,169 @@
+// End-to-end test for the claude-editor-bridge: confirms that file edits
+// propagate both directions between the host filesystem (`tools/claude-bridge/
+// work/`) and the in-browser editor backed by wasm-git's OPFS.
+//
+// Requires:
+//   - NEAR sandbox running on :3030 (`npm run near-sandbox`) — same as the
+//     existing near-git tests.
+//   - Port 17890 free. The test kills any process bound there before booting
+//     its own relay.
+
+import { test, expect } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import { readFile, writeFile, rm, stat } from 'node:fs/promises';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    NEAR_REPO_CONTRACT,
+    setupServiceWorker,
+    clearOPFS,
+    waitForAppReady,
+    pushBaseline,
+} from './near-git-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_DIR = resolve(__dirname, '../../tools/claude-bridge');
+const RELAY_PATH = join(BRIDGE_DIR, 'relay.js');
+const WORK_DIR = join(BRIDGE_DIR, 'work');
+
+let relay = null;
+
+async function killExistingRelay() {
+    await new Promise((resolveP) => {
+        const p = spawn('sh', ['-c', 'lsof -ti :17890 | xargs kill 2>/dev/null; true']);
+        p.on('exit', () => resolveP());
+    });
+    // Give the OS a moment to release the port.
+    await new Promise((r) => setTimeout(r, 200));
+}
+
+async function startRelay() {
+    relay = spawn('node', [RELAY_PATH], { stdio: ['ignore', 'pipe', 'pipe'], cwd: BRIDGE_DIR });
+    let ready = false;
+    return await new Promise((resolveP, rejectP) => {
+        const timeout = setTimeout(() => {
+            if (!ready) rejectP(new Error('relay did not become ready in 5s'));
+        }, 5000);
+        relay.stderr.on('data', (chunk) => {
+            const s = chunk.toString();
+            process.stdout.write('[relay] ' + s);
+            if (!ready && s.includes('WS on ws://')) {
+                ready = true;
+                clearTimeout(timeout);
+                resolveP();
+            }
+        });
+        relay.on('exit', (code) => {
+            if (!ready) rejectP(new Error(`relay exited early with code ${code}`));
+        });
+    });
+}
+
+async function stopRelay() {
+    if (!relay) return;
+    relay.kill('SIGTERM');
+    await new Promise((r) => relay.on('exit', r));
+    relay = null;
+}
+
+async function waitForFileContent(path, expected, timeout = 10000) {
+    const deadline = Date.now() + timeout;
+    let lastSeen = '<no file>';
+    while (Date.now() < deadline) {
+        try {
+            const content = await readFile(path, 'utf8');
+            lastSeen = content;
+            if (content === expected) return;
+        } catch (_e) { /* not present yet */ }
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+        `waitForFileContent timeout for ${path}\n` +
+        `expected: ${JSON.stringify(expected).slice(0, 120)}\n` +
+        `last seen: ${JSON.stringify(lastSeen).slice(0, 120)}`,
+    );
+}
+
+function getEditorContent(page) {
+    return page.evaluate(() => {
+        return document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror.getValue();
+    });
+}
+
+function setEditorContent(page, content) {
+    return page.evaluate((text) => {
+        const cm = document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror;
+        cm.setValue(text);
+    }, content);
+}
+
+test.describe('claude-editor-bridge OPFS tree sync', () => {
+    const repoName = NEAR_REPO_CONTRACT + '.git';
+    const songPath = join(WORK_DIR, 'song.js');
+
+    test.beforeAll(async () => {
+        await killExistingRelay();
+        await rm(WORK_DIR, { recursive: true, force: true });
+        await startRelay();
+    });
+
+    test.afterAll(async () => {
+        await stopRelay();
+        await rm(WORK_DIR, { recursive: true, force: true });
+    });
+
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, repoName);
+    });
+
+    test('host edit on work/song.js propagates to the browser editor', async ({ page }) => {
+        const baseline = '// bridge test baseline\nlet x = 1;\n';
+
+        await page.goto('http://localhost:8080');
+        await setupServiceWorker(page);
+        await pushBaseline(page, repoName, baseline);
+
+        await clearOPFS(page, repoName);
+        await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+        await waitForAppReady(page);
+
+        // Editor loads the baseline …
+        await expect.poll(() => getEditorContent(page), { timeout: 15000 })
+            .toBe(baseline);
+
+        // … and the bridge mirrors it to work/song.js (= tree_dump finished).
+        await waitForFileContent(songPath, baseline, 15000);
+
+        // Host writes new content directly to the mirror.
+        const fromHost = '// written by the test from the host fs\nlet y = 42;\n';
+        await writeFile(songPath, fromHost);
+
+        // Bridge should deliver apply_file → browser editor.
+        await expect.poll(() => getEditorContent(page), { timeout: 10000 })
+            .toBe(fromHost);
+    });
+
+    test('browser edit in #editor propagates to work/song.js', async ({ page }) => {
+        const baseline = '// bridge test baseline\nlet x = 1;\n';
+
+        await page.goto('http://localhost:8080');
+        await setupServiceWorker(page);
+        await pushBaseline(page, repoName, baseline);
+
+        await clearOPFS(page, repoName);
+        await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+        await waitForAppReady(page);
+
+        await expect.poll(() => getEditorContent(page), { timeout: 15000 })
+            .toBe(baseline);
+        await waitForFileContent(songPath, baseline, 15000);
+
+        // Edit in the browser → file_changed → mirror file updates.
+        const fromBrowser = '// written from the browser editor\nlet z = 99;\n';
+        await setEditorContent(page, fromBrowser);
+
+        await waitForFileContent(songPath, fromBrowser, 10000);
+    });
+});

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -91,27 +91,23 @@ export async function initEditor(componentRoot) {
     claudeBridge.start();
     claudeBridge.registerEditor(songsourceeditor, {
         id: 'song',
-        editor_type: 'song',
         language: 'javascript',
-        getName: () => gitrepoconfig?.songfilename || '(unsaved song buffer)',
+        getPath: () => gitrepoconfig?.songfilename || null,
     });
     claudeBridge.registerEditor(synthsourceeditor, {
         id: 'synth',
-        editor_type: 'synth',
         language: 'assemblyscript',
-        getName: () => gitrepoconfig?.synthfilename || '(unsaved synth buffer)',
+        getPath: () => gitrepoconfig?.synthfilename || null,
     });
     claudeBridge.registerEditor(shadersourceeditor, {
         id: 'shader',
-        editor_type: 'shader',
         language: 'glsl',
-        getName: () => gitrepoconfig?.fragmentshader || '(unsaved shader buffer)',
+        getPath: () => gitrepoconfig?.fragmentshader || null,
     });
     claudeBridge.registerEditor(faustsourceeditor, {
         id: 'faust',
-        editor_type: 'faust',
         language: 'faust',
-        getName: () => currentFaustFilename || '(unsaved faust buffer)',
+        getPath: () => currentFaustFilename || null,
     });
 
     window.toggleEditors = (editorid, checked) => {
@@ -767,8 +763,12 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
     } else if (gitrepoparam) {
         gitrepoconfig = await initWASMGitClient(gitrepoparam.split('=')[1]);
         appendToSubtoolbar1(document.createElement('wasmgit-ui'));
+        // wasm-git is ready — let the bridge pull the full tree into work/.
+        claudeBridge.attachGitRepo({ listfiles, readfile, writefileandstage });
 
         addRemoteSyncListener(async () => {
+            // After a pull/commit, re-sync the bridge's mirror.
+            claudeBridge.resyncTree().catch((e) => console.warn('bridge resync failed', e));
             try {
                 const newconfig = await getConfig();
                 if (newconfig && newconfig.songfilename) {

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -18,6 +18,7 @@ import { exportVideo, setupWebGL } from './visualizer/fragmentshader.js';
 import { triggerDownload } from './common/filedownload.js';
 import { decodeBufferFromPNG, encodeBufferAsPNG } from './common/png.js';
 import { isSointuSong, getSointuWasm, getSointuYaml } from './sointu/playsointu.js';
+import { claudeBridge } from './claude-bridge-client.js';
 export let songsourceeditor;
 export let synthsourceeditor;
 export let shadersourceeditor;
@@ -85,6 +86,16 @@ export async function initEditor(componentRoot) {
         mode: "text/plain",
         theme: "monokai",
         lineNumbers: true,
+    });
+
+    // v1: only the Faust editor reports to the Claude Code bridge. The
+    // protocol carries editor_type so adding the others later is a one-liner.
+    claudeBridge.start();
+    claudeBridge.registerEditor(faustsourceeditor, {
+        id: 'faust',
+        editor_type: 'faust',
+        language: 'faust',
+        getName: () => currentFaustFilename || '(unsaved faust buffer)',
     });
 
     window.toggleEditors = (editorid, checked) => {

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -88,9 +88,25 @@ export async function initEditor(componentRoot) {
         lineNumbers: true,
     });
 
-    // v1: only the Faust editor reports to the Claude Code bridge. The
-    // protocol carries editor_type so adding the others later is a one-liner.
     claudeBridge.start();
+    claudeBridge.registerEditor(songsourceeditor, {
+        id: 'song',
+        editor_type: 'song',
+        language: 'javascript',
+        getName: () => gitrepoconfig?.songfilename || '(unsaved song buffer)',
+    });
+    claudeBridge.registerEditor(synthsourceeditor, {
+        id: 'synth',
+        editor_type: 'synth',
+        language: 'assemblyscript',
+        getName: () => gitrepoconfig?.synthfilename || '(unsaved synth buffer)',
+    });
+    claudeBridge.registerEditor(shadersourceeditor, {
+        id: 'shader',
+        editor_type: 'shader',
+        language: 'glsl',
+        getName: () => gitrepoconfig?.fragmentshader || '(unsaved shader buffer)',
+    });
     claudeBridge.registerEditor(faustsourceeditor, {
         id: 'faust',
         editor_type: 'faust',

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -88,7 +88,11 @@ export async function initEditor(componentRoot) {
         lineNumbers: true,
     });
 
-    claudeBridge.start();
+    // Register editors with the bridge so it can route apply_file messages.
+    // The WS connection itself is only opened once a git repo is loaded
+    // (see the gitrepoparam branch below) — otherwise there's nothing to
+    // sync and the constant reconnect attempts add noise (and time, in
+    // Firefox enough to blow the WTR timeout).
     claudeBridge.registerEditor(songsourceeditor, {
         id: 'song',
         language: 'javascript',
@@ -763,7 +767,8 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
     } else if (gitrepoparam) {
         gitrepoconfig = await initWASMGitClient(gitrepoparam.split('=')[1]);
         appendToSubtoolbar1(document.createElement('wasmgit-ui'));
-        // wasm-git is ready — let the bridge pull the full tree into work/.
+        // wasm-git is ready — connect the bridge and pull the full tree.
+        claudeBridge.start();
         claudeBridge.attachGitRepo({ listfiles, readfile, writefileandstage });
 
         addRemoteSyncListener(async () => {

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -29,6 +29,7 @@
         "serve": "node devserver.js",
         "test-e2e": "npx playwright test",
         "test-near-git": "npx playwright test e2e/near-git.spec.js",
+        "test-claude-bridge": "npx playwright test e2e/claude-bridge.spec.js",
         "near-sandbox": "docker run --rm -p 3030:8080 ghcr.io/petersalomonsen/near-git-storage/sandbox:main",
         "test-faust": "node ../tools/faust2as/generate-test-sources.js && npx playwright test e2e/faust2as-compilation.spec.js"
     },


### PR DESCRIPTION
## Summary

Adds a local relay (`tools/claude-bridge/`) that mirrors the web app's
OPFS-backed wasm-git working tree to a host filesystem folder. Claude
Code — or any host-side editor (VSCode, vim, sed, …) — edits files in
`tools/claude-bridge/work/` and changes flow back to the browser's
editors; saves in the browser flow the other way.

No MCP server, no bespoke edit ops — Claude Code uses its normal
`Read` / `Edit` / `Glob` / `Grep` tools on the mirror tree.

## Architecture

```
browser editors / wasm-git OPFS  <— WebSocket —>  relay  <— filesystem —>  tools/claude-bridge/work/
                                                                          ^ Claude Code, VSCode, vim, etc.
```

- **Browser → relay**: full `tree_dump` on connect (and after git
  pull/commit), `file_changed` per editor save, `editor_state` for
  cursor/selection persisted to `_state.json`.
- **Relay → browser**: recursive `fs.watch` on `work/` → `apply_file`
  with the OPFS path → client `writefileandstage`s into OPFS via the
  wasm-git worker and refreshes any editor currently showing that path.
- Echo prevention via a last-written content map.
- Bridge only opens the WebSocket once a git repo is loaded
  (`?gitrepo=…`) — otherwise non-repo pages would burn time on
  reconnect retries.

## Why this shape (not the MCP version this PR started as)

Iterated through three designs in this branch:

1. MCP server + bespoke `insert_at_cursor` / `replace_range` ops —
   worked end-to-end but felt slow and fragile (transport churn,
   hard-reloads, custom ops reinventing what `Edit` already does).
2. File-mirror with four named editor buffers — simpler, but lost
   project-wide visibility.
3. **Current**: file-mirror of the whole OPFS tree at real paths.
   Claude can `Glob`/`Grep` across the project; host-side IDEs can
   open any file; the architecture matches Claude Code's strengths.

## Files

- `tools/claude-bridge/{package.json, relay.js, README.md, .gitignore}` — the relay package.
- `wasmaudioworklet/claude-bridge-client.js` — WS client, tree push, `apply_file` handler.
- `wasmaudioworklet/editorcontroller.js` — registers all four editors with the bridge and attaches the wasm-git API once a repo is loaded.
- `wasmaudioworklet/e2e/claude-bridge.spec.js` — Playwright test exercising both sync directions.
- `.gitignore` — adds local tooling caches (`.claude/`, `.wrangler/`, `test-results/`).

## v1 caveats

- **Text files only.** Binaries (samples, PNG-encoded WASM) are skipped until wasm-git exposes raw byte reads of OPFS entries.
- **`.git/` excluded** from the mirror, so host-side `git status` / `git diff` don't reflect wasm-git's state yet. Next obvious extension; needs careful handling because git operations produce `fs.watch` event storms.
- **No deletes** propagate host → OPFS.
- **Last writer wins** on simultaneous edits; the lock-during-edit-session model is the planned follow-up.

## Test plan

- [x] `cd tools/claude-bridge && npm install`
- [x] `npm start` — relay listens on `ws://localhost:17890`
- [x] Open the web app with `?gitrepo=…` — relay logs `tree_dump: wrote N file(s)` once wasm-git is ready
- [x] Edit a file in `work/` from VSCode / Claude / vim — editor in the browser refreshes in place
- [x] Edit in the browser editor — `work/` file updates
- [x] `npm run test-claude-bridge` (Playwright; requires `npm run near-sandbox`) — covers both directions end-to-end
- [x] CI green: WTR + Playwright E2E + AS synth + bundles + Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)