### PR TITLE
faust effects + bridge polish: typed effect params, host-side file adoption, IDE resolution, OPFS dump

### DIFF
--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -20,9 +20,9 @@
 // events that match are our own work and skipped.
 
 import { WebSocketServer } from 'ws';
-import { writeFile, readFile, mkdir, symlink, lstat } from 'node:fs/promises';
+import { writeFile, readFile, mkdir, symlink, lstat, readdir, rm } from 'node:fs/promises';
 import { watch } from 'node:fs';
-import { dirname, resolve, join, sep } from 'node:path';
+import { dirname, resolve, join, sep, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -166,6 +166,13 @@ wss.on('connection', (ws) => {
 
 async function handleTreeDump(msg) {
     if (!Array.isArray(msg.files)) return;
+    // Clear any OPFS-managed leftover before laying down the fresh snapshot,
+    // so work/ always matches what the browser actually has in OPFS — no
+    // stale files from previous sessions / other songs.
+    const cleared = await clearOpfsContents();
+    if (cleared > 0) {
+        process.stderr.write(`[claude-bridge] tree_dump: cleared ${cleared} stale entry/entries\n`);
+    }
     let written = 0;
     for (const f of msg.files) {
         if (!isSafeRelPath(f.path)) continue;
@@ -177,6 +184,40 @@ async function handleTreeDump(msg) {
         }
     }
     process.stderr.write(`[claude-bridge] tree_dump: wrote ${written}/${msg.files.length} file(s)\n`);
+}
+
+// Paths in work/ that the bridge considers OPFS-managed (i.e. round-trip
+// to the browser). Bridge-private files like _state.json, tsconfig.json
+// — plus anything under synth1/assembly/ if a stray host-side write
+// somehow lands there — stay out.
+function isOpfsManagedPath(relPath) {
+    if (relPath === '_state.json' || relPath === 'tsconfig.json') return false;
+    if (relPath.startsWith('synth1/assembly/') || relPath === 'synth1/assembly') return false;
+    return true;
+}
+
+// Remove every OPFS-managed file/dir under work/ so a fresh tree_dump
+// produces a 1:1 mirror. Bridge-private files (tsconfig.json,
+// _state.json) and the (currently empty) `synth1/assembly/` path stay.
+async function clearOpfsContents() {
+    let removed = 0;
+    let entries;
+    try { entries = await readdir(WORK_DIR, { withFileTypes: true }); } catch (_e) { return 0; }
+    for (const entry of entries) {
+        const relPath = entry.name;
+        if (!isOpfsManagedPath(relPath)) continue;
+        const full = join(WORK_DIR, entry.name);
+        try {
+            await rm(full, { recursive: true, force: true });
+            removed++;
+        } catch (e) {
+            process.stderr.write(`[claude-bridge] could not remove ${relPath}: ${e.message}\n`);
+        }
+    }
+    // Tracking state is invalidated by the wipe.
+    mirroredFiles.clear();
+    lastWritten.clear();
+    return removed;
 }
 
 function handleEditorState(msg) {
@@ -225,18 +266,24 @@ async function writeState() {
 }
 
 // Recursive watch of WORK_DIR. macOS supports recursive natively; on Linux,
-// fs.watch with recursive is best-effort. Only paths in `mirroredFiles`
-// round-trip — anything else under work/ (notably the symlinked AS runtime)
-// is host-only and we leave it alone.
+// fs.watch with recursive is best-effort. Files already tracked in
+// `mirroredFiles` round-trip back to the browser; new files dropped into
+// the OPFS namespace by the host (e.g. a new `.dsp` in `work/faust/...`)
+// are adopted and broadcast too. Anything outside the OPFS namespace
+// (private bridge files, synth1/assembly/* if anything slips in) is
+// ignored.
 watch(WORK_DIR, { recursive: true }, async (_eventType, filename) => {
     if (!filename) return;
     const relPath = filename.split(sep).join('/');
-    if (relPath === '_state.json' || relPath === 'tsconfig.json') return;
     if (!isSafeRelPath(relPath)) return;
+    if (!isOpfsManagedPath(relPath)) return;
 
     const filePath = join(WORK_DIR, relPath);
-    const opfsPath = mirroredFiles.get(filePath);
-    if (!opfsPath) return; // not a bridge-owned file (e.g. symlinked AS source)
+    let opfsPath = mirroredFiles.get(filePath);
+    if (!opfsPath) {
+        // New host-side file — adopt it under its mirror path.
+        opfsPath = relPath;
+    }
 
     let buf;
     try {
@@ -249,6 +296,7 @@ watch(WORK_DIR, { recursive: true }, async (_eventType, filename) => {
     const encoded = binary ? buf.toString('base64') : buf.toString('utf8');
     if (lastWritten.get(filePath) === encoded) return; // our own write
     lastWritten.set(filePath, encoded);
+    mirroredFiles.set(filePath, opfsPath);
     broadcastApplyFile(opfsPath, encoded, binary);
 });
 

--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -110,6 +110,12 @@ async function writeTsconfig() {
             // we want IntelliSense, not a strict TS lint of AS source.
             strict: false,
             skipLibCheck: true,
+            // Preserve symlinks so a file reached through
+            // `tools/claude-bridge/faust/...` (sibling symlink) keeps that
+            // path for its OWN relative imports — otherwise TS resolves
+            // it back to `work/faust/...` and `../../../mixes/...` no
+            // longer points at the on-disk AS runtime.
+            preserveSymlinks: true,
         },
         include: ['**/*.ts', '**/*.d.ts'],
         // Pull in AS's own type declarations for f32 / StaticArray / Mathf

--- a/tools/faust2as/faust2asc.js
+++ b/tools/faust2as/faust2asc.js
@@ -23,7 +23,7 @@ import {
 import {
     toClassName,
     transpileDsp as transpileDspPure,
-    transpileMastering as transpileMasteringPure,
+    transpileEffect as transpileEffectPure,
     assembleSingleFile,
     assembleBundle,
 } from '../../wasmaudioworklet/faust/transpile-core.js';
@@ -42,13 +42,13 @@ if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     console.log(`  --name      Class name for the generated MidiVoice (default: derived from filename)`);
     console.log(`  --out       Output .ts file path`);
     console.log(`  --bundle    Transpile multiple DSPs into a single bundle with initializeMidiSynth()`);
-    console.log(`  --mastering Generate a global stereo effect wired into postprocess() on outputline`);
+    console.log(`  --effect    Generate a standalone Effect class (stereo in/out) with a default singleton wired into postprocess() on outputline`);
     process.exit(0);
 }
 
 const bundleMode = args.includes('--bundle');
 const forEditor = args.includes('--for-editor');
-const masteringMode = args.includes('--mastering');
+const effectMode = args.includes('--effect');
 let outputPath = null;
 let className = null;
 const dspFiles = [];
@@ -56,7 +56,7 @@ const dspFiles = [];
 for (let i = 0; i < args.length; i++) {
     if (args[i] === '--bundle') continue;
     if (args[i] === '--for-editor') continue;
-    if (args[i] === '--mastering') continue;
+    if (args[i] === '--effect') continue;
     if (args[i] === '--name' && args[i + 1]) { className = args[++i]; continue; }
     if (args[i] === '--out' && args[i + 1]) { outputPath = args[++i]; continue; }
     dspFiles.push(args[i]);
@@ -67,7 +67,7 @@ if (dspFiles.length === 0) {
     process.exit(1);
 }
 
-if (masteringMode) {
+if (effectMode) {
     if (!className) {
         className = toClassName(path.basename(dspFiles[0], '.dsp'));
     }
@@ -196,10 +196,10 @@ function transpileDsp(inputDsp, clsName, options = {}) {
     return result;
 }
 
-function transpileMastering(inputDsp, clsName) {
-    console.log(`Compiling ${path.basename(inputDsp)} -> ${clsName} (asc, mastering)`);
+function transpileEffect(inputDsp, clsName) {
+    console.log(`Compiling ${path.basename(inputDsp)} -> ${clsName} (asc, effect)`);
     const asSource = compileFaustToAS(inputDsp, `-lang asc -cn ${clsName}`);
-    return transpileMasteringPure({
+    return transpileEffectPure({
         asSource,
         clsName,
         sourceFile: path.basename(inputDsp),
@@ -211,8 +211,8 @@ function transpileMastering(inputDsp, clsName) {
 // ---------------------------------------------------------------------------
 
 let output;
-if (masteringMode) {
-    output = transpileMastering(dspFiles[0], className);
+if (effectMode) {
+    output = transpileEffect(dspFiles[0], className);
 } else if (bundleMode) {
     const results = dspFiles.map(dsp => {
         const base = path.basename(dsp, '.dsp');

--- a/wasmaudioworklet/faust/browser-transpile.js
+++ b/wasmaudioworklet/faust/browser-transpile.js
@@ -1,12 +1,12 @@
 // browser-transpile.js — Faust .dsp → AssemblyScript transpiler for the
 // in-browser editor. Lazy-loads @psalomo/faustwasm from jsDelivr, mounts
 // any sibling .lib/.dsp files into the libfaust virtual FS, runs faust
-// (twice if there's an effect= declaration, or once for stereo
-// mastering), then calls the pure transpile-core to assemble the .ts.
+// (twice if there's an effect= declaration, or once for a standalone
+// stereo effect), then calls the pure transpile-core to assemble the .ts.
 
 import {
     transpileDsp,
-    transpileMastering,
+    transpileEffect,
     assembleSingleFile,
     toClassName,
 } from './transpile-core.js';
@@ -117,7 +117,7 @@ export async function transpileDspSource(dspSource, dspBaseName, libsByPath = {}
         const asSource = normalizeASSource(faustFS.readFile(outVirt, { encoding: 'utf8' }));
 
         if (isStereoEffect(asSource)) {
-            const lines = transpileMastering({
+            const lines = transpileEffect({
                 asSource,
                 clsName,
                 sourceFile: dspBaseName,

--- a/wasmaudioworklet/faust/transpile-core.js
+++ b/wasmaudioworklet/faust/transpile-core.js
@@ -14,7 +14,7 @@
 //   reshapeInstanceClear(...)
 //   reshapeSIGInit(...)
 //   transpileDsp({ asSource, effectAsSource, clsName, sourceFile, options })
-//   transpileMastering({ asSource, clsName, sourceFile })
+//   transpileEffect({ asSource, clsName, sourceFile })
 //   generateNRPNSetParam(lines, ccParams, globalFields)
 //   generateNRPNDefaults(lines, ccParams, channelIndex)
 //   assembleSingleFile(result, { forEditor })
@@ -1341,22 +1341,39 @@ export function assembleBundle(results, { forEditor = false } = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Mastering mode: standalone stereo effect on outputline
+// Standalone Effect class: stereo-in/stereo-out, public named params, and a
+// generic `process(left, right): void` that writes to `this.signal`. A
+// default singleton + `postprocess()` hook is also generated so the effect
+// auto-mastering the outputline still works without any caller changes.
 // ---------------------------------------------------------------------------
 
-// transpileMastering({ asSource, clsName, sourceFile })
+// transpileEffect({ asSource, clsName, sourceFile })
 //   asSource   — AS output for a stereo effect (2 in, 2 out)
 //   clsName    — class name for the generated mastering class
 //   sourceFile — basename of the .dsp source (e.g. "master_me.dsp"); used
 //                only for the // Source: header comment
 //
 // Returns the array of output lines (caller joins with '\n').
-export function transpileMastering({ asSource, clsName, sourceFile, importDepth = 1 }) {
+export function transpileEffect({ asSource, clsName, sourceFile, importDepth = 1 }) {
     const parsed = parseASSource(asSource, clsName);
-    const { numInputs, numOutputs } = extractUIFromJSON(asSource);
+    const { uiParams, numInputs, numOutputs } = extractUIFromJSON(asSource);
 
     if (numInputs !== 2 || numOutputs !== 2) {
         throw new Error(`Mastering mode requires stereo I/O (2 in, 2 out). Got ${numInputs} in, ${numOutputs} out.`);
+    }
+
+    // Derive a public, AS-friendly name for each UI param (same scheme as
+    // the MIDI-instrument path) and build a `this.<niceName>` substitution
+    // map so the generated process() body references the renamed fields.
+    const takenNames = new Set();
+    const uiByField = new Map();
+    for (const p of uiParams) {
+        p.niceName = deriveNiceName(p, takenNames);
+        uiByField.set(p.field, p);
+    }
+    const paramRefs = new Map();
+    for (const p of uiParams) {
+        paramRefs.set(p.field, `this.${p.niceName}`);
     }
 
     const tablePrefix = '_' + clsName + '_';
@@ -1370,13 +1387,13 @@ export function transpileMastering({ asSource, clsName, sourceFile, importDepth 
 
     const out = [];
     out.push(`// Mastering effect: ${clsName}`);
-    out.push(`// Auto-transpiled from Faust DSP by faust2asc.js (--mastering)`);
+    out.push(`// Auto-transpiled from Faust DSP by faust2asc.js (--effect)`);
     out.push(`// Source: ${sourceFile}`);
     out.push('');
     // importDepth = number of '..' segments above the assembly/ root
     // (default 1 matches faust/<name>.ts; 3 for faust/sub/dir/<name>.ts).
     const up = '../'.repeat(importDepth);
-    out.push(`import { outputline, midichannels } from '${up}mixes/globalimports';`);
+    out.push(`import { outputline, midichannels, StereoSignal } from '${up}mixes/globalimports';`);
     out.push(`import { SAMPLERATE } from '${up}environment';`);
     out.push('');
 
@@ -1392,15 +1409,25 @@ export function transpileMastering({ asSource, clsName, sourceFile, importDepth 
     }
 
     out.push(`export class ${clsName} {`);
+    // Public output bus — process(left, right) writes here.
+    out.push(`    signal: StereoSignal = new StereoSignal();`);
 
     for (const field of parsed.fields) {
         if (field.name === 'fSampleRate') continue;
+        const ui = uiByField.get(field.name);
         if (field.isArray) {
             const sizeMatch = field.initializer ? field.initializer.match(/new\s+(?:Static)?Array<\w+>\((\d+)\)/) : null;
             const size = sizeMatch ? sizeMatch[1] : '0';
             out.push(`    private ${field.name}: StaticArray<${field.type}> = new StaticArray<${field.type}>(${size});`);
         } else if (field.name === 'IOTA0' || field.name.startsWith('IOTA')) {
             out.push(`    private ${field.name}: i32 = 0;`);
+        } else if (ui) {
+            // Public, renamed, documented UI param.
+            const def = parsed.defaults[field.name] != null
+                ? parsed.defaults[field.name]
+                : `<f32>(${ui.init})`;
+            out.push(paramDocComment(ui));
+            out.push(`    ${ui.niceName}: f32 = ${def};`);
         } else if (parsed.defaults[field.name] !== undefined) {
             out.push(`    private ${field.name}: f32 = ${parsed.defaults[field.name]};`);
         } else if (field.initializer) {
@@ -1432,34 +1459,32 @@ export function transpileMastering({ asSource, clsName, sourceFile, importDepth 
     out.push('    }');
     out.push('');
 
-    out.push('    process(): void {');
-    out.push('        const _inL: f32 = outputline.left;');
-    out.push('        const _inR: f32 = outputline.right;');
+    out.push('    process(inL: f32, inR: f32): void {');
     out.push('');
 
     const compute = parseComputeBody(parsed.computeBody);
 
     for (const decl of compute.preLoopDecls) {
-        let line = reshapeASLine(decl, clsName, null, staticFieldMap);
+        let line = reshapeASLine(decl, clsName, paramRefs, staticFieldMap);
         line = line.replace(/^let\s+(fSlow|iSlow)/, 'const $1');
         out.push('        ' + line);
     }
     if (compute.preLoopDecls.length > 0) out.push('');
 
     for (const bodyLine of compute.loopBodyLines) {
-        let line = reshapeASLine(bodyLine, clsName, null, staticFieldMap);
+        let line = reshapeASLine(bodyLine, clsName, paramRefs, staticFieldMap);
 
-        line = line.replace(/input0\[\w+\]/g, '_inL');
-        line = line.replace(/input1\[\w+\]/g, '_inR');
+        line = line.replace(/input0\[\w+\]/g, 'inL');
+        line = line.replace(/input1\[\w+\]/g, 'inR');
 
         const out0Match = line.match(/^output0\[\w+\]\s*=\s*(.*);$/);
         if (out0Match) {
-            out.push(`        outputline.left = ${out0Match[1]};`);
+            out.push(`        this.signal.left = ${out0Match[1]};`);
             continue;
         }
         const out1Match = line.match(/^output1\[\w+\]\s*=\s*(.*);$/);
         if (out1Match) {
-            out.push(`        outputline.right = ${out1Match[1]};`);
+            out.push(`        this.signal.right = ${out1Match[1]};`);
             continue;
         }
 
@@ -1469,7 +1494,7 @@ export function transpileMastering({ asSource, clsName, sourceFile, importDepth 
     out.push('');
 
     for (const shiftLine of compute.delayShiftLines) {
-        const line = reshapeASLine(shiftLine, clsName, null, staticFieldMap);
+        const line = reshapeASLine(shiftLine, clsName, paramRefs, staticFieldMap);
         out.push('        ' + line);
     }
 
@@ -1477,6 +1502,11 @@ export function transpileMastering({ asSource, clsName, sourceFile, importDepth 
     out.push('}');
     out.push('');
 
+    // Backwards-compat: keep the synth engine's `initializeMidiSynth` /
+    // `postprocess` hooks pointing at a singleton that mastering-processes
+    // the outputline, so existing songs keep working. Custom signal-routing
+    // callers should instantiate the class themselves and call
+    // `master.process(left, right)` with their own inputs.
     const instanceVar = clsName.charAt(0).toLowerCase() + clsName.slice(1);
     out.push(`const ${instanceVar}: ${clsName} = new ${clsName}();`);
     out.push('');
@@ -1484,7 +1514,9 @@ export function transpileMastering({ asSource, clsName, sourceFile, importDepth 
     out.push('}');
     out.push('');
     out.push('export function postprocess(): void {');
-    out.push(`    ${instanceVar}.process();`);
+    out.push(`    ${instanceVar}.process(outputline.left, outputline.right);`);
+    out.push(`    outputline.left = ${instanceVar}.signal.left;`);
+    out.push(`    outputline.right = ${instanceVar}.signal.right;`);
     out.push('}');
     out.push('');
 

--- a/wasmaudioworklet/opfs-export.html
+++ b/wasmaudioworklet/opfs-export.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>OPFS export</title>
+  <style>
+    html, body { margin: 0; padding: 16px; font-family: ui-monospace, monospace; background: #111; color: #eee; }
+    button { font: inherit; padding: 8px 16px; background: #2a2a2a; color: #eee; border: 1px solid #444; border-radius: 4px; cursor: pointer; }
+    button:hover { background: #333; }
+    #status { margin-top: 16px; white-space: pre-wrap; line-height: 1.4; }
+    #tree { margin-top: 12px; font-size: 12px; color: #999; max-height: 50vh; overflow: auto; border: 1px solid #2a2a2a; padding: 8px; border-radius: 4px; display: none; }
+    .err { color: #ff7373; }
+    .ok { color: #6cff6c; }
+  </style>
+</head>
+<body>
+  <h2>OPFS export</h2>
+  <p>Walks the Origin Private File System on this origin and downloads everything as a zip. Useful for inspecting the wasm-git repo state (the <code>.git</code> directory with all packs) outside the browser.</p>
+  <button id="export">Export OPFS → zip</button>
+  <button id="inspect">List contents only</button>
+  <div id="status"></div>
+  <pre id="tree"></pre>
+
+  <script type="module">
+    import JSZip from 'https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm';
+
+    const status = document.getElementById('status');
+    const tree = document.getElementById('tree');
+    const setStatus = (s, cls = '') => { status.className = cls; status.textContent = s; };
+
+    async function walk(dir, prefix, onFile, onDir) {
+        for await (const [name, handle] of dir.entries()) {
+            const path = prefix + name;
+            if (handle.kind === 'directory') {
+                onDir?.(path);
+                await walk(handle, path + '/', onFile, onDir);
+            } else {
+                const file = await handle.getFile();
+                await onFile(path, file);
+            }
+        }
+    }
+
+    async function getRoot() {
+        if (!navigator.storage || !navigator.storage.getDirectory) {
+            throw new Error('navigator.storage.getDirectory not supported in this browser.');
+        }
+        return await navigator.storage.getDirectory();
+    }
+
+    document.getElementById('inspect').addEventListener('click', async () => {
+        tree.style.display = 'block';
+        tree.textContent = '';
+        try {
+            setStatus('Walking OPFS…');
+            const root = await getRoot();
+            let fileCount = 0;
+            let totalBytes = 0;
+            await walk(root, '', (path, file) => {
+                tree.textContent += `${path}\t${file.size}\n`;
+                fileCount++;
+                totalBytes += file.size;
+            }, (path) => {
+                tree.textContent += `${path}/\n`;
+            });
+            setStatus(`Done. ${fileCount} file(s), ${(totalBytes / 1024).toFixed(1)} KiB total.`, 'ok');
+        } catch (e) {
+            setStatus('Failed: ' + e.message, 'err');
+            console.error(e);
+        }
+    });
+
+    document.getElementById('export').addEventListener('click', async () => {
+        tree.style.display = 'block';
+        tree.textContent = '';
+        try {
+            setStatus('Walking OPFS and zipping…');
+            const root = await getRoot();
+            const zip = new JSZip();
+            let fileCount = 0;
+            let totalBytes = 0;
+            await walk(root, '', async (path, file) => {
+                const buf = await file.arrayBuffer();
+                zip.file(path, buf);
+                tree.textContent += `+ ${path}\t${file.size}\n`;
+                fileCount++;
+                totalBytes += file.size;
+            });
+            setStatus(`Generating zip… (${fileCount} files, ${(totalBytes / 1024).toFixed(1)} KiB)`);
+            const blob = await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = `opfs-${location.hostname}-${Date.now()}.zip`;
+            a.click();
+            URL.revokeObjectURL(a.href);
+
+            setStatus(`Downloaded ${a.download} — ${fileCount} files, ${(totalBytes / 1024).toFixed(1)} KiB uncompressed.`, 'ok');
+        } catch (e) {
+            setStatus('Failed: ' + e.message, 'err');
+            console.error(e);
+        }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Originally just the faust effect-path refactor; while wiring it through and using it in a real song the bridge needed a handful of follow-on fixes too. Four loosely related changes — kept together since they all serve the same goal: getting a Faust effect (or any AS-music source) from the in-browser editor into a host-side IDE with full IntelliSense, and back to OPFS without friction.

## 1. Faust transpileEffect: typed public params + `process(left, right)` API

What was `transpileMastering` becomes `transpileEffect`. The generated class shape:

```ts
export class MasterMe {
    signal: StereoSignal = new StereoSignal();
    /** Target [init: -18, min: -50, max: -2, step: 1, unit: dB] */
    target: f32 = <f32>(-18.0);
    /** global bypass [init: 0, min: 0, max: 1, step: 0.01] */
    global_bypass: f32 = <f32>(0.0);
    // …
    process(inL: f32, inR: f32): void { /* writes to this.signal */ }
}
```

(Names come from Faust's `[symbol:foo]` if present — keeps snake_case for master_me — otherwise a slugified label gives camelCase. Doc comments carry init/min/max/step/unit.)

The auto-generated singleton + `postprocess()` hook still mounts the effect on `outputline` so existing songs Just Work; custom callers can instantiate the class and feed it any stereo source.

Renames:
- `transpileMastering` → `transpileEffect` in `transpile-core.js` (browser-transpile.js + faust2asc.js follow).
- `--mastering` CLI flag → `--effect`.

**Breaking**: songs that called `master.process()` directly on the auto-singleton need to use either the auto `postprocess()` (recommended) or call `process(inL, inR)` explicitly.

## 2. Bridge: host-side file adoption + clean tree_dump

The bridge used to only round-trip files the browser had previously pushed; anything dropped into `work/` from the host (a new `.dsp` for a reverb, say) was silently ignored. Now:

- **`fs.watch` adopts new files** under the OPFS namespace, broadcasting them as `apply_file` to the browser → browser `writefileandstage`s them into the wasm-git repo.
- **`tree_dump` clears stale OPFS-managed entries** in `work/` before laying down the new snapshot — no more leftover files from previous sessions / other songs.

So dropping `zitaRev.dsp` into `work/faust/zitaRev/dsp/` now has the same effect as creating it in the in-browser file dialog.

## 3. Bridge: `preserveSymlinks` in generated tsconfig

The work/ files import the AS runtime via `../mixes/…`, `../faust/…`, etc., which resolve through sibling symlinks at the bridge package level. With the default `preserveSymlinks: false`, TS resolves those symlinks to real paths and the chained `../../../mixes/…` imports inside transpiled `.ts` files then point at non-existent locations — IntelliSense falls back to a stale class shape. Setting `preserveSymlinks: true` keeps the symlinked address, the chain resolves correctly, and editor autocomplete sees the new `signal` field and `process(inL, inR)` shape.

## 4. `wasmaudioworklet/opfs-export.html` — OPFS debug tool

A standalone HTML page that walks the Origin Private File System on this origin and downloads it as a zip — including the wasm-git repo's `.git` directory and all packs. Useful when OPFS contents need to be inspected outside the browser (`git fsck`, `git verify-pack`, …). Loaded JSZip from jsDelivr, no build step. Two buttons: list-only or full zip.

## Files

- `wasmaudioworklet/faust/transpile-core.js` — rename + Effect class shape.
- `wasmaudioworklet/faust/browser-transpile.js` — rename of imported binding.
- `tools/faust2as/faust2asc.js` — CLI rename (`--mastering` → `--effect`).
- `tools/claude-bridge/relay.js` — host-side watcher adoption, tree_dump clear, `preserveSymlinks: true`.
- `wasmaudioworklet/opfs-export.html` — debug dump page.

## Test plan

- [x] `node tools/faust2as/generate-test-sources.js` regenerates cleanly (test sources are voice DSPs; unchanged path).
- [x] Re-transpile `master_me.dsp` in browser → new shape (public `target`, `global_bypass`, …; `signal: StereoSignal`; `process(inL, inR)`).
- [x] Re-transpile `zitaRev.dsp` (new file via Faust upstream) → `ZitaRev` class with `level`, `wetDryMix`, `midRt60`, etc.
- [x] Drop a `.dsp` into `work/faust/<…>/` from the host → relay broadcasts `apply_file` → file appears in OPFS (`git status` shows it staged).
- [x] After `npm start`, `tsc -p work/` resolves all `../mixes/…` and `../faust/…` imports; the boolean→number warnings remain (AS-vs-TS semantic difference, expected).
- [ ] `opfs-export.html` "List contents only" prints the wasm-git tree; "Export OPFS → zip" downloads a working zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)