### PR TITLE
broadcastSend / broadcastWait: cross-window song sync via BroadcastChannel

### DIFF
--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -1,5 +1,5 @@
 import { startWAM, postSong as wamPostSong, pauseWAMSong, onMidi as wamOnMidi, wamsynth, resumeWAMSong } from './webaudiomodules/wammanager.js';
-import { createAudioWorklet as createMidiSynthAudioWorklet, onmidi as midiSynthOnMidi } from './synth1/audioworklet/midisynthaudioworklet.js';
+import { createAudioWorklet as createMidiSynthAudioWorklet, onmidi as midiSynthOnMidi, setBroadcastUiHandlers } from './synth1/audioworklet/midisynthaudioworklet.js';
 import { visualizeNoteOn, clearVisualization, setUseDefaultVisualizer } from './visualizer/defaultvisualizer.js';
 import { setPaused } from './visualizer/midieventlistvisualizer.js';
 import { attachSeek, detachSeek } from './app.js';
@@ -14,6 +14,21 @@ export function initAudioWorkletNode(componentRoot) {
     let audioworkletnode;
     let onmidi = () => { };
     let playing = false;
+
+    // Mirror auto-pause / auto-resume from the worklet (on broadcastWait
+    // / matching signal arrival) into the play checkbox + visualizer
+    // state. Don't post toggleSongPlay back — the worklet has already
+    // flipped its own playMidiSequence, so an echo would loop.
+    setBroadcastUiHandlers(
+        () => {
+            componentRoot.getElementById('toggleSongPlayCheckbox').checked = false;
+            setPaused(true);
+        },
+        () => {
+            componentRoot.getElementById('toggleSongPlayCheckbox').checked = true;
+            setPaused(false);
+        }
+    );
 
     const sessionSampleRate = sessionStorage.getItem('samplerate');
     const context = sessionSampleRate ?

--- a/wasmaudioworklet/e2e/broadcast-signal.spec.js
+++ b/wasmaudioworklet/e2e/broadcast-signal.spec.js
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+
+// Two-tab end-to-end coverage for broadcastSend / broadcastWait.
+// Both tabs run the app on the same origin, so they share a
+// BroadcastChannel('concert-sync') space. One tab parks on a wait, the
+// other emits the matching signal from its song, and we observe the
+// receiver's play checkbox flip back on as the resume side-effect.
+
+const synthSource = `
+import { midichannels, MidiChannel, MidiVoice, SineOscillator, Envelope, notefreq } from './globalimports';
+
+class SimpleSine extends MidiVoice {
+    osc: SineOscillator = new SineOscillator();
+    env: Envelope = new Envelope(0.0, 0.0, 1.0, 0.1);
+    noteon(note: u8, velocity: u8): void {
+        super.noteon(note, velocity);
+        this.osc.frequency = notefreq(note);
+        this.env.attack();
+    }
+    noteoff(): void { this.env.release(); }
+    isDone(): boolean { return this.env.isDone(); }
+    nextframe(): void {
+        const signal = this.osc.next() * this.env.next() * this.velocity / 256;
+        this.channel.signal.add(signal, signal);
+    }
+}
+export function initializeMidiSynth(): void {
+    midichannels[0] = new MidiChannel(1, (ch) => new SimpleSine(ch));
+}
+export function postprocess(): void {}
+`;
+
+// Sender song plays through, then emits 'go' at the end — the realistic
+// concert flow where one song finishes and hands off to the next.
+const senderSong = `
+setBPM(120);
+await createTrack(0).steps(4, [
+    c5, , , ,
+]);
+broadcastSend('go');
+`;
+
+// Receiver song parks on 'go' as its first event.
+const receiverSong = `
+setBPM(120);
+broadcastWait('go');
+await createTrack(0).steps(4, [
+    c5, , , ,
+]);
+`;
+
+async function waitForReady(page) {
+    await page.waitForFunction(() => {
+        const app = document.querySelector('app-javascriptmusic');
+        if (!app || !app.shadowRoot) return false;
+        return !!app.shadowRoot.querySelector('#editor .CodeMirror')
+            && !!app.shadowRoot.querySelector('#assemblyscripteditor .CodeMirror')
+            && !!app.shadowRoot.getElementById('startaudiobutton');
+    }, { timeout: 30000 });
+}
+
+async function setSongAndSynth(page, song, synth) {
+    await page.evaluate(({ song, synth }) => {
+        const root = document.querySelector('app-javascriptmusic').shadowRoot;
+        root.querySelector('#editor .CodeMirror').CodeMirror.setValue(song);
+        root.querySelector('#assemblyscripteditor .CodeMirror').CodeMirror.setValue(synth);
+    }, { song, synth });
+}
+
+async function isPlayChecked(page) {
+    return page.evaluate(() =>
+        document.querySelector('app-javascriptmusic').shadowRoot
+            .getElementById('toggleSongPlayCheckbox').checked
+    );
+}
+
+async function clickInsideApp(page, selector) {
+    await page.evaluate((sel) => {
+        document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector(sel).click();
+    }, selector);
+}
+
+test.describe('broadcast send/wait across windows', () => {
+    test('receiver parks on broadcastWait, sender emits matching signal, receiver resumes', async ({ context, baseURL }) => {
+        const receiver = await context.newPage();
+        const sender = await context.newPage();
+
+        // Surface page logs (and stamp them so the two streams don't blur).
+        receiver.on('console', (m) => console.log('[recv]', m.type(), m.text()));
+        receiver.on('pageerror', (e) => console.log('[recv-error]', e.message));
+        sender.on('console', (m) => console.log('[send]', m.type(), m.text()));
+        sender.on('pageerror', (e) => console.log('[send-error]', e.message));
+
+        await receiver.goto(baseURL);
+        await sender.goto(baseURL);
+        await waitForReady(receiver);
+        await waitForReady(sender);
+
+        await setSongAndSynth(receiver, receiverSong, synthSource);
+        await setSongAndSynth(sender, senderSong, synthSource);
+
+        // Start receiver first. It'll compile the synth (slow on first
+        // run), then the sequencer's very first event is the wait — so
+        // the play checkbox should auto-uncheck as the worklet hits it.
+        await clickInsideApp(receiver, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
+
+        // Sanity: receiver stays parked until *something* sends 'go'.
+        // Give it a beat to make sure no spurious resume happens.
+        await receiver.waitForTimeout(500);
+        expect(await isPlayChecked(receiver)).toBe(false);
+
+        // Start sender. Its song plays through its 4 steps (~500ms at
+        // 120 BPM) and the final event is broadcastSend('go'), which
+        // travels: worklet → main thread → BroadcastChannel → receiver's
+        // main thread → receiver's worklet. Receiver's wait clears,
+        // playMidiSequence flips back true, broadcastResumed is posted,
+        // the UI handler re-checks the box.
+        await clickInsideApp(sender, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(true);
+    });
+});

--- a/wasmaudioworklet/midisequencer/SEQUENCE_API.md
+++ b/wasmaudioworklet/midisequencer/SEQUENCE_API.md
@@ -208,6 +208,55 @@ Stops recording MIDI input.
 
 ---
 
+## Cross-Window Sync Functions
+
+Coordinate playback across multiple browser windows of the app via a shared
+`BroadcastChannel('concert-sync')`. Useful for splitting a live set across
+tabs (each tab has its own AudioContext / audio thread, so wasm compiles
+on save don't glitch the other tab's audio).
+
+Only available on the midi-synth path. Manually clicking the play
+checkbox or seeking the playhead clears any pending wait — a matching
+broadcast is the only thing that auto-resumes.
+
+### `broadcastSend(name)`
+Emits a named signal at the current song position. Other windows
+listening on the same channel can respond. Same-window listeners do not
+receive their own sends.
+
+**Parameters:**
+- `name` (string): Identifier for the signal
+
+**Example:**
+```javascript
+// Played in window A — the very last thing the song does is hand off
+// to whatever song is waiting on 'next-up'.
+await createTrack(0).steps(4, [c4,,,, e4,,,, g4,,,, c5,,,,]);
+broadcastSend('next-up');
+```
+
+### `broadcastWait(name)`
+Parks the sequencer at this point until a matching `broadcastSend(name)`
+arrives. While parked, the play checkbox is unchecked and the song
+clock is frozen. Signals that arrived *before* the wait engaged are
+ignored — only fresh post-wait signals resume playback.
+
+**Parameters:**
+- `name` (string): Identifier of the signal to wait for
+
+**Example:**
+```javascript
+// In window B — won't play anything until window A (or any other
+// listener) emits 'next-up'.
+setBPM(120);
+broadcastWait('next-up');
+await createTrack(0).steps(4, [
+    c5, , , ,
+]);
+```
+
+---
+
 ## Song Structure Functions
 
 ### `definePartStart(partName)`

--- a/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.js
+++ b/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.js
@@ -2,11 +2,22 @@ export function AudioWorkletProcessorSequencerModule() {
   const SEQ_MSG_LOOP = -1;
   const SEQ_MSG_START_RECORDING = -2;
   const SEQ_MSG_STOP_RECORDING = -3;
+  const SEQ_MSG_BROADCAST_SEND = -4;
+  const SEQ_MSG_BROADCAST_WAIT = -5;
 
   class MidiSequencer {
     constructor() {
       this.sequence = [];
       this.recorded = {};
+      // Name the wait is parked on. Set when onprocess encounters a
+      // SEQ_MSG_BROADCAST_WAIT event; while non-null, onprocess no-ops so
+      // currentFrame freezes. Cleared when a matching broadcast arrives
+      // (the processor's port handler clears it).
+      this.waitingForSignal = null;
+      // Called by onprocess when a SEQ_MSG_BROADCAST_SEND event fires.
+      // The processor wires this to a port.postMessage so the main thread
+      // can emit on a BroadcastChannel.
+      this.broadcastSender = null;
     }
 
     clearRecording() {
@@ -14,6 +25,9 @@ export function AudioWorkletProcessorSequencerModule() {
     }
 
     setSequenceData(sequencedata) {
+      // A new sequence's wait events haven't been encountered yet, so any
+      // pending wait from the old sequence is stale.
+      this.waitingForSignal = null;
       if (sequencedata.length > 0) {
         // clear recorded data
         this.clearRecording();
@@ -70,6 +84,9 @@ export function AudioWorkletProcessorSequencerModule() {
     }
 
     setCurrentTime(time) {
+      // Explicit seek clears any pending broadcast wait — the user moved
+      // the playhead deliberately, so playback should resume from there.
+      this.waitingForSignal = null;
       this.currentFrame = sampleRate * time / 1000;
       let sequenceIndex = 0;
       while (sequenceIndex < this.sequence.length &&
@@ -81,6 +98,11 @@ export function AudioWorkletProcessorSequencerModule() {
     }
 
     onprocess() {
+      // Parked on a broadcast wait — freeze the clock and skip event
+      // processing entirely. Cleared externally when the matching signal
+      // arrives.
+      if (this.waitingForSignal) return;
+
       let currentTime = this.getCurrentTime();
 
       while (this.sequenceIndex < this.sequence.length &&
@@ -103,6 +125,19 @@ export function AudioWorkletProcessorSequencerModule() {
               this.recordingActive = false;
               this.sequenceIndex++;
               break;
+            case SEQ_MSG_BROADCAST_SEND:
+              if (this.broadcastSender) {
+                this.broadcastSender(this.sequence[this.sequenceIndex].name);
+              }
+              this.sequenceIndex++;
+              break;
+            case SEQ_MSG_BROADCAST_WAIT:
+              // Advance past the wait so resume doesn't re-trigger it,
+              // then return immediately. currentFrame stays put — the
+              // song clock holds until the signal arrives.
+              this.waitingForSignal = this.sequence[this.sequenceIndex].name;
+              this.sequenceIndex++;
+              return;
           }
           if (loop) {
             break;

--- a/wasmaudioworklet/midisequencer/sequenceconstants.js
+++ b/wasmaudioworklet/midisequencer/sequenceconstants.js
@@ -1,3 +1,5 @@
 export const SEQ_MSG_LOOP = -1;
 export const SEQ_MSG_START_RECORDING = -2;
 export const SEQ_MSG_STOP_RECORDING = -3;
+export const SEQ_MSG_BROADCAST_SEND = -4;
+export const SEQ_MSG_BROADCAST_WAIT = -5;

--- a/wasmaudioworklet/midisequencer/songcompiler.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.js
@@ -1,6 +1,6 @@
 import { resetTick, setBPM, nextTick, currentTime, waitForBeat } from './pattern.js';
 import { TrackerPattern, pitchbend, controlchange, createNoteFunctions, noteFunctionKeys } from './trackerpattern.js';
-import { SEQ_MSG_LOOP, SEQ_MSG_START_RECORDING, SEQ_MSG_STOP_RECORDING } from './sequenceconstants.js';
+import { SEQ_MSG_LOOP, SEQ_MSG_START_RECORDING, SEQ_MSG_STOP_RECORDING, SEQ_MSG_BROADCAST_SEND, SEQ_MSG_BROADCAST_WAIT } from './sequenceconstants.js';
 import { setVideoSchedule } from '../visualizer/videoscheduler.js';
 
 let songmessages = [];
@@ -58,6 +58,28 @@ function stopVideo(name) {
     addedVideo[name].schedule[addedVideo[name].schedule.length - 1].stopTime = currentTime();
 }
 
+// Emit a named signal on the BroadcastChannel at the current song time.
+// Used together with broadcastWait in another window (or another song) to
+// coordinate playback across windows.
+function broadcastSend(name) {
+    songmessages.push({
+        time: currentTime(),
+        message: [SEQ_MSG_BROADCAST_SEND],
+        name,
+    });
+}
+
+// Park the sequencer at this point until a matching broadcastSend arrives.
+// Stale signals received before the wait engages are ignored. Manually
+// clicking the play checkbox also bypasses the wait.
+function broadcastWait(name) {
+    songmessages.push({
+        time: currentTime(),
+        message: [SEQ_MSG_BROADCAST_WAIT],
+        name,
+    });
+}
+
 const noteFunctions = createNoteFunctions();
 const songargs = {
     'output': output,
@@ -87,6 +109,8 @@ const songargs = {
     'stopRecording': stopRecording,
     'startVideo': startVideo,
     'stopVideo': stopVideo,
+    'broadcastSend': broadcastSend,
+    'broadcastWait': broadcastWait,
     'definePartStart': (partName) => songParts[partName] = { startTime: currentTime() },
     'definePartEnd': (partName) => songParts[partName].endTime = currentTime(),
     'mute': (channel) => muted[channel] = true,

--- a/wasmaudioworklet/synth1/audioworklet/broadcast-signal.spec.js
+++ b/wasmaudioworklet/synth1/audioworklet/broadcast-signal.spec.js
@@ -1,0 +1,89 @@
+import { waitForAppReady } from '../../app.js';
+import { songsourceeditor, synthsourceeditor } from '../../editorcontroller.js';
+
+// Minimal synth that turns noteons into a steady sine — we don't measure
+// pitch here, we only use noteon arrival as the "did the sequencer run?"
+// signal via a tracing wrapper on the worklet's midireceiver.
+const synthsource = `
+import { midichannels, MidiChannel, MidiVoice, SineOscillator, Envelope, notefreq } from './globalimports';
+
+class SimpleSine extends MidiVoice {
+    osc: SineOscillator = new SineOscillator();
+    env: Envelope = new Envelope(0.0, 0.0, 1.0, 0.1);
+    noteon(note: u8, velocity: u8): void {
+        super.noteon(note, velocity);
+        this.osc.frequency = notefreq(note);
+        this.env.attack();
+    }
+    noteoff(): void { this.env.release(); }
+    isDone(): boolean { return this.env.isDone(); }
+    nextframe(): void {
+        const signal = this.osc.next() * this.env.next() * this.velocity / 256;
+        this.channel.signal.add(signal, signal);
+    }
+}
+export function initializeMidiSynth(): void {
+    midichannels[0] = new MidiChannel(1, (ch) => new SimpleSine(ch));
+}
+export function postprocess(): void {}
+`;
+
+// Song waits on 'go' at the very start, then plays one note. If the wait
+// works, no noteon should reach the synth until we deliver the signal.
+const waitSongSource = `
+setBPM(120);
+broadcastWait('go');
+await createTrack(0).steps(4, [
+    c5, , , ,
+]);
+`;
+
+async function pollUntil(check, timeoutMs = 5000, intervalMs = 50) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (check()) return;
+        await new Promise(r => setTimeout(r, intervalMs));
+    }
+    throw new Error('timeout waiting for condition');
+}
+
+describe('broadcast send/wait', function () {
+    this.timeout(60000);
+
+    let appElement;
+
+    this.beforeAll(async () => {
+        document.documentElement.appendChild(document.createElement('app-javascriptmusic'));
+        await waitForAppReady();
+        appElement = document.getElementsByTagName('app-javascriptmusic')[0].shadowRoot;
+    });
+    this.afterAll(async () => {
+        window.stopaudio();
+        window.audioworkletnode = undefined;
+        document.documentElement.removeChild(document.querySelector('app-javascriptmusic'));
+    });
+
+    it('parks on broadcastWait, resumes when matching signal arrives', async () => {
+        songsourceeditor.doc.setValue(waitSongSource);
+        synthsourceeditor.doc.setValue(synthsource);
+
+        // Start playback. The sequencer's first event is the wait, so it
+        // should pause itself almost immediately and the auto-pause is
+        // mirrored to the checkbox by the UI handler registered at init.
+        appElement.querySelector('#startaudiobutton').click();
+        const checkbox = appElement.querySelector('#toggleSongPlayCheckbox');
+        await pollUntil(() => checkbox.checked === false);
+
+        // Non-matching signal: nothing changes.
+        const peerChannel = new BroadcastChannel('concert-sync');
+        peerChannel.postMessage({ name: 'not-the-one' });
+        await new Promise(r => setTimeout(r, 100));
+        assert.equal(checkbox.checked, false, 'non-matching signal must not resume');
+
+        // Matching signal: checkbox flips back.
+        peerChannel.postMessage({ name: 'go' });
+        await pollUntil(() => checkbox.checked === true);
+
+        peerChannel.close();
+    });
+});

--- a/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
+++ b/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
@@ -16,6 +16,18 @@ export let audioworkletnode;
 
 let workerMessageHandler;
 
+// Handlers the host can register to react to broadcast wait/resume events
+// emitted by the worklet. Registered before startaudio runs, so the port
+// listener attached inside connectAudioWorklet can dispatch immediately
+// (otherwise the broadcastWaiting message at song start can fire before
+// the host has a chance to attach its own listener).
+let broadcastWaitingHandler = null;
+let broadcastResumedHandler = null;
+export function setBroadcastUiHandlers(onWaiting, onResumed) {
+    broadcastWaitingHandler = onWaiting;
+    broadcastResumedHandler = onResumed;
+}
+
 export function onmidi(data) {
     audioworkletnode.port.postMessage({
         midishortmsg: data
@@ -49,6 +61,35 @@ async function connectAudioWorklet(context, wasm_synth_bytes, sequencedata, togg
         outputChannelCount: [2]
     });
     awn.port.start();
+
+    // BroadcastChannel coordinates broadcastSend/broadcastWait events
+    // across windows so e.g. one song can hold on a `waitForSignal`
+    // until another window emits the matching name. Skip in offline
+    // rendering — no other window is listening, and offline render uses
+    // a fresh worklet per export.
+    // The port listener for *all* broadcast traffic (channel-out, UI-in)
+    // is attached here, before wasm is sent — by the time the worklet
+    // hits its first wait it may already be the very first onprocess()
+    // tick, so a listener attached later (e.g. after createAudioWorklet
+    // returns) would miss the message.
+    if (!(context instanceof (OfflineAudioContext))) {
+        const channel = new BroadcastChannel('concert-sync');
+        channel.onmessage = (e) => {
+            if (e.data && typeof e.data.name === 'string') {
+                awn.port.postMessage({ broadcastReceived: e.data.name });
+            }
+        };
+        awn.port.addEventListener('message', (e) => {
+            if (!e.data) return;
+            if (typeof e.data.broadcastSend === 'string') {
+                channel.postMessage({ name: e.data.broadcastSend });
+            } else if (typeof e.data.broadcastWaiting === 'string' && broadcastWaitingHandler) {
+                broadcastWaitingHandler(e.data.broadcastWaiting);
+            } else if (typeof e.data.broadcastResumed === 'string' && broadcastResumedHandler) {
+                broadcastResumedHandler(e.data.broadcastResumed);
+            }
+        });
+    }
 
     const wmh = new WorkerMessageHandler(awn.port);
 

--- a/wasmaudioworklet/synth1/audioworklet/midisynthaudioworkletprocessor.js
+++ b/wasmaudioworklet/synth1/audioworklet/midisynthaudioworkletprocessor.js
@@ -7,6 +7,12 @@ export function AssemblyScriptMidiSynthAudioWorkletProcessorModule() {
       this.processorActive = true;
       this.playMidiSequence = true;
       AudioWorkletGlobalScope.midisequencer.currentFrame = 0;
+      // Sequencer fires this from inside onprocess when a SEQ_MSG_BROADCAST_SEND
+      // event is hit. Wire it to a port message so the main thread can
+      // forward to its BroadcastChannel.
+      AudioWorkletGlobalScope.midisequencer.broadcastSender = (name) => {
+        this.port.postMessage({ broadcastSend: name });
+      };
 
       this.port.onmessage = async (msg) => {
         if (msg.data.wasm) {
@@ -49,6 +55,22 @@ export function AssemblyScriptMidiSynthAudioWorkletProcessorModule() {
           this.playMidiSequence = msg.data.toggleSongPlay;
           if (msg.data.toggleSongPlay === false) {
             this.allNotesOff();
+          }
+          // Manual play overrides a pending broadcast wait — the user
+          // explicitly asked for playback to resume, bypass the signal.
+          if (msg.data.toggleSongPlay === true) {
+            AudioWorkletGlobalScope.midisequencer.waitingForSignal = null;
+          }
+        }
+
+        if (msg.data.broadcastReceived !== undefined) {
+          // Only unblock if we're actually parked on this exact name —
+          // stale signals from before the wait engaged are ignored.
+          const seq = AudioWorkletGlobalScope.midisequencer;
+          if (seq.waitingForSignal === msg.data.broadcastReceived) {
+            seq.waitingForSignal = null;
+            this.playMidiSequence = true;
+            this.port.postMessage({ broadcastResumed: msg.data.broadcastReceived });
           }
         }
 
@@ -102,7 +124,16 @@ export function AssemblyScriptMidiSynthAudioWorkletProcessorModule() {
 
       if (this.wasmInstance) {
         if (this.playMidiSequence) {
-          AudioWorkletGlobalScope.midisequencer.onprocess();
+          const seq = AudioWorkletGlobalScope.midisequencer;
+          const wasWaiting = seq.waitingForSignal;
+          seq.onprocess();
+          // Newly hit a wait this tick — flip playback off so the UI can
+          // reflect the pause, and silence any held notes.
+          if (!wasWaiting && seq.waitingForSignal) {
+            this.playMidiSequence = false;
+            this.allNotesOff();
+            this.port.postMessage({ broadcastWaiting: seq.waitingForSignal });
+          }
         }
         this.wasmInstance.fillSampleBuffer();
         output[0].set(new Float32Array(this.wasmInstance.memory.buffer,


### PR DESCRIPTION
## Summary

Adds two DSL primitives to `song.js` so songs can coordinate playback across browser windows:

- `broadcastWait('name')` parks the sequencer at that point. The play checkbox unchecks itself and the song clock freezes.
- `broadcastSend('name')` emits a named signal at the current song position.

Same-origin tabs share a `BroadcastChannel('concert-sync')`, so e.g. window A plays a song that ends with `broadcastSend('next-up')`, while window B's song begins with `broadcastWait('next-up')` — and the handoff happens at the moment A's song reaches that event.

Motivation: split a live set across multiple tabs. Each tab has its own `AudioContext` / audio thread, so the unavoidable `WebAssembly.instantiate` glitch (see #129) on save happens off the playing tab's thread.

## Behaviour

- Stale signals are ignored — only broadcasts that arrive *after* the wait engaged unblock it.
- Manual play (clicking the checkbox) and seek (`setCurrentTime`) both clear a pending wait — the user-initiated action wins.
- Replacing the song (`setSequenceData`) also clears any pending wait — the new song's wait events haven't been encountered yet.
- The wait/resume mirrors to the play checkbox via a handler registered at `initAudioWorkletNode` time, so it lands before the worklet's first port message could fire.

## Out of scope (for now)

Only the midi-synth path (`midisynthaudioworkletprocessor.js` + the JS-side sequencer in `audioworkletprocessorsequencer.js`). Pattern-seq, Sointu, Protracker, and WAM paths run their sequencer state inside wasm and have no JS-side event dispatch to intercept — would be a separate ~1 day of work and only worth doing if those paths get used for the multi-window flow.

## Test plan

- [x] `e2e/broadcast-signal.spec.js` (Playwright, two pages in one context): receiver parks on wait, sender plays through and emits at the end, receiver resumes.
- [x] `synth1/audioworklet/broadcast-signal.spec.js` (wtr, Chromium + Firefox): wait/resume side-effect on the play checkbox in a single page.
- [x] Existing `midisynthaudioworklet.spec.js`, `songcompiler.spec.js`, `recording.spec.js` — no regression.
- [x] Manual two-tab session confirmed by user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)