### PR TITLE
fix sequencer/visualizer OOB exposed by broadcast at end of song

### DIFF
--- a/wasmaudioworklet/e2e/broadcast-signal.spec.js
+++ b/wasmaudioworklet/e2e/broadcast-signal.spec.js
@@ -30,24 +30,40 @@ export function initializeMidiSynth(): void {
 export function postprocess(): void {}
 `;
 
-// Sender song plays through, then emits 'go' at the end — the realistic
-// concert flow where one song finishes and hands off to the next.
-const senderSong = `
+// --- Song variants ---------------------------------------------------------
+
+const waitAtStartThenNotes = (name) => `
 setBPM(120);
-await createTrack(0).steps(4, [
-    c5, , , ,
-]);
-broadcastSend('go');
+broadcastWait('${name}');
+await createTrack(0).steps(4, [c5, , , ,]);
 `;
 
-// Receiver song parks on 'go' as its first event.
-const receiverSong = `
+const notesThenSend = (name) => `
 setBPM(120);
-broadcastWait('go');
-await createTrack(0).steps(4, [
-    c5, , , ,
-]);
+await createTrack(0).steps(4, [c5, , , ,]);
+broadcastSend('${name}');
 `;
+
+const notesSendMidThenMore = (name) => `
+setBPM(120);
+await createTrack(0).steps(4, [c5, , , ,]);
+broadcastSend('${name}');
+await createTrack(0).steps(4, [e5, , , ,]);
+`;
+
+const notesWaitMidThenMore = (name) => `
+setBPM(120);
+await createTrack(0).steps(4, [c5, , , ,]);
+broadcastWait('${name}');
+await createTrack(0).steps(4, [e5, , , ,]);
+`;
+
+const plainNotes = `
+setBPM(120);
+await createTrack(0).steps(4, [c5, , , ,]);
+`;
+
+// --- helpers ---------------------------------------------------------------
 
 async function waitForReady(page) {
     await page.waitForFunction(() => {
@@ -67,6 +83,13 @@ async function setSongAndSynth(page, song, synth) {
     }, { song, synth });
 }
 
+async function setSongOnly(page, song) {
+    await page.evaluate((song) => {
+        document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror.setValue(song);
+    }, song);
+}
+
 async function isPlayChecked(page) {
     return page.evaluate(() =>
         document.querySelector('app-javascriptmusic').shadowRoot
@@ -81,43 +104,236 @@ async function clickInsideApp(page, selector) {
     }, selector);
 }
 
+// Set up a parallel BroadcastChannel listener in the page that captures
+// every message — useful for asserting send timing or counting.
+async function startBroadcastTap(page) {
+    await page.evaluate(() => {
+        window.__broadcastTap = [];
+        window.__broadcastChannel = new BroadcastChannel('concert-sync');
+        window.__broadcastChannel.onmessage = (e) => {
+            window.__broadcastTap.push({ name: e.data && e.data.name, at: performance.now() });
+        };
+    });
+}
+
+async function getBroadcastTap(page) {
+    return page.evaluate(() => window.__broadcastTap.slice());
+}
+
+// Start both tabs on the same shared app and have them both reach the
+// "audio worklet is up and song is loaded" state. The synth is the same
+// in both — but on the second tab the compile worker may say "no
+// changes" (it's still a fresh worker per tab so it actually compiles
+// once per page, but content-addressed cache lookups can short-circuit).
+async function bootBothTabs(context, baseURL, receiverSong, senderSong) {
+    const receiver = await context.newPage();
+    const sender = await context.newPage();
+
+    receiver.on('console', (m) => console.log('[recv]', m.type(), m.text()));
+    receiver.on('pageerror', (e) => console.log('[recv-error]', e.message));
+    sender.on('console', (m) => console.log('[send]', m.type(), m.text()));
+    sender.on('pageerror', (e) => console.log('[send-error]', e.message));
+
+    await receiver.goto(baseURL);
+    await sender.goto(baseURL);
+    await waitForReady(receiver);
+    await waitForReady(sender);
+
+    await setSongAndSynth(receiver, receiverSong, synthSource);
+    await setSongAndSynth(sender, senderSong, synthSource);
+
+    return { receiver, sender };
+}
+
+// --- specs -----------------------------------------------------------------
+
 test.describe('broadcast send/wait across windows', () => {
-    test('receiver parks on broadcastWait, sender emits matching signal, receiver resumes', async ({ context, baseURL }) => {
-        const receiver = await context.newPage();
-        const sender = await context.newPage();
+    test('receiver waits at start, sender emits at end of song, receiver resumes', async ({ context, baseURL }) => {
+        const { receiver, sender } = await bootBothTabs(
+            context, baseURL,
+            waitAtStartThenNotes('go'),
+            notesThenSend('go'),
+        );
 
-        // Surface page logs (and stamp them so the two streams don't blur).
-        receiver.on('console', (m) => console.log('[recv]', m.type(), m.text()));
-        receiver.on('pageerror', (e) => console.log('[recv-error]', e.message));
-        sender.on('console', (m) => console.log('[send]', m.type(), m.text()));
-        sender.on('pageerror', (e) => console.log('[send-error]', e.message));
-
-        await receiver.goto(baseURL);
-        await sender.goto(baseURL);
-        await waitForReady(receiver);
-        await waitForReady(sender);
-
-        await setSongAndSynth(receiver, receiverSong, synthSource);
-        await setSongAndSynth(sender, senderSong, synthSource);
-
-        // Start receiver first. It'll compile the synth (slow on first
-        // run), then the sequencer's very first event is the wait — so
-        // the play checkbox should auto-uncheck as the worklet hits it.
         await clickInsideApp(receiver, '#startaudiobutton');
         await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
 
-        // Sanity: receiver stays parked until *something* sends 'go'.
-        // Give it a beat to make sure no spurious resume happens.
         await receiver.waitForTimeout(500);
         expect(await isPlayChecked(receiver)).toBe(false);
 
-        // Start sender. Its song plays through its 4 steps (~500ms at
-        // 120 BPM) and the final event is broadcastSend('go'), which
-        // travels: worklet → main thread → BroadcastChannel → receiver's
-        // main thread → receiver's worklet. Receiver's wait clears,
-        // playMidiSequence flips back true, broadcastResumed is posted,
-        // the UI handler re-checks the box.
         await clickInsideApp(sender, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(true);
+    });
+
+    test('sender emits mid-song (not at end), receiver still resumes', async ({ context, baseURL }) => {
+        // Sender plays 4 notes, sends 'go', plays 4 more notes. The send
+        // fires in the middle so we verify the signal isn't tied to
+        // sender's song completion.
+        const { receiver, sender } = await bootBothTabs(
+            context, baseURL,
+            waitAtStartThenNotes('go'),
+            notesSendMidThenMore('go'),
+        );
+
+        await clickInsideApp(receiver, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
+
+        await clickInsideApp(sender, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(true);
+    });
+
+    test('receiver waits mid-song (after some notes), sender emits at end', async ({ context, baseURL }) => {
+        // Receiver plays 4 notes, then parks on wait. So the auto-pause
+        // doesn't happen immediately; we have to wait for the notes to
+        // play first (~500ms at 120 BPM) before the checkbox flips off.
+        const { receiver, sender } = await bootBothTabs(
+            context, baseURL,
+            notesWaitMidThenMore('go'),
+            notesThenSend('go'),
+        );
+
+        await clickInsideApp(receiver, '#startaudiobutton');
+        // Should auto-uncheck *eventually* (after the first 4 notes play).
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
+
+        await clickInsideApp(sender, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(true);
+    });
+
+    test('stale send (before wait engaged) is ignored, fresh send after wait resumes', async ({ context, baseURL }) => {
+        // Sender song is just bare notes — no broadcast — so we drive the
+        // broadcast manually from the test to control timing precisely.
+        const { receiver, sender } = await bootBothTabs(
+            context, baseURL,
+            waitAtStartThenNotes('go'),
+            plainNotes,
+        );
+
+        // Emit 'go' from a *third* page-level BroadcastChannel BEFORE
+        // receiver has started — the receiver hasn't engaged its wait
+        // yet, so this must be discarded.
+        await startBroadcastTap(receiver);
+        await sender.evaluate(() => {
+            const ch = new BroadcastChannel('concert-sync');
+            ch.postMessage({ name: 'go' });
+            ch.close();
+        });
+        await receiver.waitForTimeout(200);
+
+        // Now start receiver. It should park on wait — proving the stale
+        // signal didn't auto-resume it.
+        await clickInsideApp(receiver, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
+        await receiver.waitForTimeout(500);
+        expect(await isPlayChecked(receiver)).toBe(false);
+
+        // Fresh signal *after* the wait engaged — receiver resumes.
+        await sender.evaluate(() => {
+            const ch = new BroadcastChannel('concert-sync');
+            ch.postMessage({ name: 'go' });
+            ch.close();
+        });
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(true);
+    });
+
+    test('manual play (checkbox toggle) overrides a pending wait', async ({ context, baseURL }) => {
+        const { receiver, sender } = await bootBothTabs(
+            context, baseURL,
+            waitAtStartThenNotes('go'),
+            plainNotes,
+        );
+
+        await clickInsideApp(receiver, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
+
+        // Toggle the play checkbox manually. Should bypass the wait.
+        await receiver.evaluate(() => {
+            const cb = document.querySelector('app-javascriptmusic').shadowRoot
+                .getElementById('toggleSongPlayCheckbox');
+            cb.checked = true;
+            cb.dispatchEvent(new Event('click'));
+        });
+        // The checkbox is now checked — manual override active.
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 5000 }).toBe(true);
+
+        // A *later* matching signal must NOT cause anything weird (the
+        // wait has already been cleared by the manual override, the
+        // sequencer is playing through the song).
+        await sender.evaluate(() => {
+            const ch = new BroadcastChannel('concert-sync');
+            ch.postMessage({ name: 'go' });
+            ch.close();
+        });
+        await receiver.waitForTimeout(500);
+        expect(await isPlayChecked(receiver)).toBe(true);
+    });
+
+    test('alternating handoff: A→B→A→B over multiple rounds via cold-start cycle', async ({ context, baseURL }) => {
+        // Two windows. Round 1: A plays + sends 'r1', B waits on 'r1'
+        // then plays. Round 2: same names but roles swapped via hot-save.
+        // This is the user's reported flow — moving broadcastSend to the
+        // next and broadcastWait to the previous, switching in turns.
+        const { receiver: tabB, sender: tabA } = await bootBothTabs(
+            context, baseURL,
+            waitAtStartThenNotes('r1'),
+            notesThenSend('r1'),
+        );
+
+        // --- Round 1: A is sender, B is waiter ---
+        await clickInsideApp(tabB, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(tabB), { timeout: 60000 }).toBe(false);
+
+        await clickInsideApp(tabA, '#startaudiobutton');
+        await expect.poll(() => isPlayChecked(tabB), { timeout: 60000 }).toBe(true);
+
+        // Wait for both songs to wind down to a steady state.
+        await tabA.waitForTimeout(1500);
+        await tabB.waitForTimeout(1500);
+
+        // --- Round 2: hot-save with roles swapped ---
+        // Tab A now becomes the waiter, Tab B the sender. New signal name
+        // to avoid any chance of stale-signal interference. Save the
+        // waiter first so the wait engages before the sender's signal
+        // can fire (otherwise the signal arrives while waitingForSignal
+        // is still null and is dropped).
+        await setSongOnly(tabA, waitAtStartThenNotes('r2'));
+        await setSongOnly(tabB, notesThenSend('r2'));
+
+        await clickInsideApp(tabA, '#savesongbutton');
+        await expect.poll(() => isPlayChecked(tabA), { timeout: 60000 }).toBe(false);
+
+        await clickInsideApp(tabB, '#savesongbutton');
+        await expect.poll(() => isPlayChecked(tabA), { timeout: 60000 }).toBe(true);
+    });
+
+    test('hot-save: replace a non-broadcast song with a wait song, then signal arrives', async ({ context, baseURL }) => {
+        // Tab is playing a plain song. User saves with a wait song
+        // mid-play. The save flow must result in a parked sequencer
+        // (regardless of whether currentFrame had passed time 0).
+        const { receiver, sender } = await bootBothTabs(
+            context, baseURL,
+            plainNotes,
+            plainNotes,
+        );
+
+        await clickInsideApp(receiver, '#startaudiobutton');
+        await clickInsideApp(sender, '#startaudiobutton');
+
+        // Let the songs play through entirely so currentFrame is past
+        // any events in the wait-song that's about to be saved in.
+        await receiver.waitForTimeout(2000);
+
+        // Now save a wait song into the receiver and a send song into
+        // the sender.
+        await setSongOnly(receiver, waitAtStartThenNotes('hot'));
+        await clickInsideApp(receiver, '#savesongbutton');
+        // We want the wait to engage despite currentFrame being past
+        // time 0. Should auto-uncheck.
+        await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(false);
+
+        await setSongOnly(sender, notesThenSend('hot'));
+        await clickInsideApp(sender, '#savesongbutton');
+
         await expect.poll(() => isPlayChecked(receiver), { timeout: 60000 }).toBe(true);
     });
 });

--- a/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.js
+++ b/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.js
@@ -110,7 +110,14 @@ export function AudioWorkletProcessorSequencerModule() {
         this.sequence[this.sequenceIndex].time < currentTime) {
 
         let loop = false;
-        while (this.sequence[this.sequenceIndex].message[0] < 0 &&
+        // Meta-event cases (recording markers, broadcast send) advance
+        // sequenceIndex from within the switch, so the inner while must
+        // re-check bounds — otherwise reading `.message[0]` on `undefined`
+        // throws and the exception escapes process(), which Chromium
+        // takes as a signal to stop calling the processor.
+        while (this.sequenceIndex < this.sequence.length &&
+            this.sequence[this.sequenceIndex] &&
+            this.sequence[this.sequenceIndex].message[0] < 0 &&
             this.sequence[this.sequenceIndex].time <= currentTime) {
           switch (this.sequence[this.sequenceIndex].message[0]) {
             case SEQ_MSG_LOOP:
@@ -146,6 +153,14 @@ export function AudioWorkletProcessorSequencerModule() {
         if (loop) {
           this.sequenceIndex = 0;
           this.currentFrame = 0;
+          break;
+        }
+
+        // The inner meta loop above can push sequenceIndex past the end
+        // (a broadcast-send / recording marker at the end of the song).
+        // If it did, there's no midi event to fire; the outer loop's
+        // next iteration will re-check the bounds and exit cleanly.
+        if (this.sequenceIndex >= this.sequence.length || !this.sequence[this.sequenceIndex]) {
           break;
         }
 

--- a/wasmaudioworklet/visualizer/midieventlistvisualizer.js
+++ b/wasmaudioworklet/visualizer/midieventlistvisualizer.js
@@ -56,6 +56,14 @@ async function visualizeSongCallback() {
         return;
     }
 
+    // visualizeEventIndex is module state and lastPostedSong can be
+    // swapped to a shorter eventlist between scheduling and firing this
+    // callback (a save while the visualizer is mid-iteration). Clamp
+    // before any indexed access — otherwise eventlist[OOB].time throws.
+    if (visualizeEventIndex >= eventlist.length) {
+        visualizeEventIndex = 0;
+    }
+
     if (currentTime < eventlist[visualizeEventIndex].time) {
         visualizeEventIndex = 0;
     }


### PR DESCRIPTION
## Summary

Two latent bugs that surface when `broadcastSend` is the *last* event in a song — common in the multi-window hand-off pattern.

**1. Sequencer inner meta-event loop crashes the audio thread.** The inner `while` in `onprocess` re-reads `this.sequence[this.sequenceIndex].message[0]` after each switch iteration. `BROADCAST_SEND` / `START_RECORDING` / `STOP_RECORDING` cases all advance `sequenceIndex` from within the switch, so if the consumed entry was the last, the next condition check is `undefined.message[0]` → throws. Chromium reads an exception from `process()` as a signal to stop calling the processor entirely — the audio thread silently dies, so any subsequent save (e.g. a `broadcastWait` song) never gets a chance to engage. Fix: same bounds guard the outer loop has, plus an early break after the meta loop if it consumed all remaining entries.

**2. Visualizer race throws on hot-save with shorter eventlist.** `visualizeEventIndex` is module state. `visualizeSong(newList)` resets it to 0, but if `visualizeSongCallback` is mid-flight (awaiting worklet `currentTime`), the reset can land *after* the callback captured the now-stale `eventlist` reference. Next callback then reads `eventlist[OOB].time`. Fix: clamp the index at the top of the callback.

Both fixes are independent of the broadcast feature but were effectively unreachable before — `START_RECORDING` / `STOP_RECORDING` are normally followed by notes, never at the end of a sequence.

## Test plan

Adds a 7-scenario Playwright suite in `e2e/broadcast-signal.spec.js`:

- [x] Receiver waits at start, sender emits at end → resume
- [x] Sender emits mid-song (not at end) → resume
- [x] Receiver waits mid-song (after notes) → auto-pause after notes, resume on signal
- [x] Stale send (before wait engaged) ignored
- [x] Manual play overrides a pending wait
- [x] Alternating handoff over multiple rounds via hot-save (the regression — bare master fails this)
- [x] Hot-save replaces a non-broadcast song with a wait song; signal arrives → resume

All 7 pass on Chromium. Full `wtr` suite (17 files, 51 passed / 3 skipped on both Chromium + Firefox) clean — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)