### PR TITLE
make app boot resilient to stale gitrepo state

### DIFF
--- a/wasmaudioworklet/app.js
+++ b/wasmaudioworklet/app.js
@@ -3,6 +3,7 @@ import { initAudioWorkletNode } from './audioworkletnode.js';
 import { initVisualizer, setCurrentTimeSeconds as setVisualizerCurrentTimeSeconds } from './visualizer/defaultvisualizer.js';
 import { initEditor } from './editorcontroller.js';
 import { toggleSpinner } from './common/ui/progress-spinner.js';
+import { modalAlert } from './common/ui/modal.js';
 import apphtml from './app.html.js';
 
 let componentRoot;
@@ -31,9 +32,9 @@ customElements.define('app-javascriptmusic',
         // unreachable, etc.) instead of leaving the spinner up forever.
         console.error('initEditor failed:', e);
         toggleSpinner(false);
-        alert('App failed to initialize: ' + (e && e.message ? e.message : e) +
-          '\n\nThe spinner is cleared but the editor may not be fully usable. ' +
-          'See the console for details.');
+        await modalAlert('App failed to initialize',
+          (e && e.message ? e.message : String(e)) +
+          '\n\nThe spinner is cleared but the editor may not be fully usable. See the console for details.');
       }
       enablePlayAndSaveButtons();
 

--- a/wasmaudioworklet/app.js
+++ b/wasmaudioworklet/app.js
@@ -24,7 +24,17 @@ customElements.define('app-javascriptmusic',
       this.shadowRoot.getElementById('copyrighttoyear').innerHTML = new Date().getFullYear();
       initAudioWorkletNode(this.shadowRoot);
       await initVisualizer(this.shadowRoot);
-      await initEditor(this.shadowRoot);
+      try {
+        await initEditor(this.shadowRoot);
+      } catch (e) {
+        // Surface boot failures (stale gitrepo config, OPFS lock, NEAR
+        // unreachable, etc.) instead of leaving the spinner up forever.
+        console.error('initEditor failed:', e);
+        toggleSpinner(false);
+        alert('App failed to initialize: ' + (e && e.message ? e.message : e) +
+          '\n\nThe spinner is cleared but the editor may not be fully usable. ' +
+          'See the console for details.');
+      }
       enablePlayAndSaveButtons();
 
       appReadyPromises.forEach(p => p());

--- a/wasmaudioworklet/common/ui/modal.js
+++ b/wasmaudioworklet/common/ui/modal.js
@@ -28,6 +28,22 @@ export async function modalYesNo(title, question) {
     </p>`);
 }
 
+// Drop-in replacement for window.alert() that uses the in-app modal so
+// the message renders inside the app shell (and doesn't get blocked by
+// browser auto-dismiss heuristics or cross-tab focus rules).
+export async function modalAlert(title, message) {
+    const safeTitle = String(title).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+    const safeMessage = String(message)
+        .replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
+        .replace(/\n/g, '<br>');
+    return modal(`
+    <h3>${safeTitle}</h3>
+    <p>${safeMessage}</p>
+    <p>
+        <button onclick="getRootNode().result(true)">OK</button>
+    </p>`);
+}
+
 export async function modalOkCancel(title, info, cancelText, okText) {
     return modal(`
     <h3>${title}</h3>

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -10,7 +10,7 @@ import { toggleSpinner } from './common/ui/progress-spinner.js';
 import { readfile, writefileandstage, initWASMGitClient, addRemoteSyncListener, getConfig, listfiles } from './wasmgit/wasmgitclient.js';
 import { transpileDspSource } from './faust/browser-transpile.js';
 import { createPatternToolsGlobal } from './pattern_tools.js';
-import { modal, modalPrompt } from './common/ui/modal.js';
+import { modal, modalPrompt, modalAlert } from './common/ui/modal.js';
 import { updateSong, updateSynth, exportToWav } from './synth1/audioworklet/midisynthaudioworklet.js';
 import { compileWebAssemblySynth } from './synth1/browsersynthcompiler.js';
 
@@ -839,7 +839,9 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
             if (!recovered) {
                 // Last resort: surface the failure but don't kill the boot —
                 // empty editors are fine; the user can pull / sync / switch.
-                alert(`Could not load any song from the repo (active was "${gitrepoconfig.songfilename}"). ${e.message}\n\nThe editor will start empty. Try Sync / switch songs from the toolbar once the app loads.`);
+                await modalAlert('Could not load any song from the repo',
+                    `Active was "${gitrepoconfig.songfilename}". ${e.message}\n\n` +
+                    `The editor will start empty. Try Sync / switch songs from the toolbar once the app loads.`);
             }
         }
 

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -801,9 +801,47 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
                 }
             } catch (e) { }
         });
-        storedsongcode = await readfile(gitrepoconfig.songfilename);
-        storedsynthcode = await readfile(gitrepoconfig.synthfilename);
-        storedshadercode = await readfile(gitrepoconfig.fragmentshader);
+        // Load the active song/synth/shader, falling back to the first
+        // allsongs entry if the active selection points at a missing
+        // file (e.g. a stale `changeCurrentSong` write to the config
+        // before the matching files were pulled). Without this, a stale
+        // selection hangs the boot indefinitely behind the spinner.
+        const loadActiveSongFiles = async (cfg) => ({
+            songcode: cfg.songfilename ? await readfile(cfg.songfilename) : null,
+            synthcode: cfg.synthfilename ? await readfile(cfg.synthfilename) : null,
+            shadercode: cfg.fragmentshader ? await readfile(cfg.fragmentshader) : null,
+        });
+        try {
+            const loaded = await loadActiveSongFiles(gitrepoconfig);
+            storedsongcode = loaded.songcode;
+            storedsynthcode = loaded.synthcode;
+            storedshadercode = loaded.shadercode;
+        } catch (e) {
+            console.warn(`Failed to load active song "${gitrepoconfig.songfilename}" / synth "${gitrepoconfig.synthfilename}":`, e.message);
+            const candidates = (gitrepoconfig.allsongs || []).filter(s =>
+                s.songfilename !== gitrepoconfig.songfilename ||
+                s.synthfilename !== gitrepoconfig.synthfilename
+            );
+            let recovered = false;
+            for (const candidate of candidates) {
+                try {
+                    const fallback = { ...gitrepoconfig, ...candidate };
+                    const loaded = await loadActiveSongFiles(fallback);
+                    storedsongcode = loaded.songcode;
+                    storedsynthcode = loaded.synthcode;
+                    storedshadercode = loaded.shadercode;
+                    gitrepoconfig = fallback;
+                    console.warn(`Fell back to "${candidate.name}" (${candidate.songfilename})`);
+                    recovered = true;
+                    break;
+                } catch (e2) { /* try the next one */ }
+            }
+            if (!recovered) {
+                // Last resort: surface the failure but don't kill the boot —
+                // empty editors are fine; the user can pull / sync / switch.
+                alert(`Could not load any song from the repo (active was "${gitrepoconfig.songfilename}"). ${e.message}\n\nThe editor will start empty. Try Sync / switch songs from the toolbar once the app loads.`);
+            }
+        }
 
         // Populate the Faust editor's file dropdown from the wasm-git repo
         // (silent if there's no faust/ folder yet).

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -124,10 +124,24 @@ export async function clone() {
     return await awaitDirContents();
 }
 
-async function awaitDirContents() {
-    return await new Promise((resolve) =>
-        workerMessageListeners.push((msg) => msg.data.dircontents !== undefined ? resolve(msg.data.dircontents) : true)
-    );
+async function awaitDirContents(timeoutMs = 30000) {
+    // Worker can fail silently (clone error, OPFS lock, etc.) and never
+    // post a dircontents reply, which would otherwise hang the boot
+    // spinner forever. Reject after timeoutMs so the caller can surface
+    // the failure instead of blocking the UI.
+    return await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`wasm-git worker did not respond with dircontents within ${timeoutMs}ms`));
+        }, timeoutMs);
+        workerMessageListeners.push((msg) => {
+            if (msg.data.dircontents !== undefined) {
+                clearTimeout(timer);
+                resolve(msg.data.dircontents);
+            } else {
+                return true;
+            }
+        });
+    });
 }
 export async function synclocal() {
     worker.postMessage({
@@ -181,22 +195,27 @@ export async function commitAndSyncRemote(commitmessage) {
     return dircontents;
 }
 
-export async function readfile(filename) {
+export async function readfile(filename, timeoutMs = 10000) {
     worker.postMessage({
         command: 'readfile',
         filename: filename
     });
-    return await new Promise((resolve, reject) =>
+    return await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`readfile(${filename}) timed out after ${timeoutMs}ms — worker not responding`));
+        }, timeoutMs);
         workerMessageListeners.push((msg) => {
             if (msg.data.filename === filename) {
+                clearTimeout(timer);
                 resolve(msg.data.filecontents);
             } else if (msg.data.error && !msg.data.id) {
+                clearTimeout(timer);
                 reject(new Error(msg.data.error));
             } else {
                 return true;
             }
-        })
-    );
+        });
+    });
 }
 
 export async function diff() {


### PR DESCRIPTION
## Summary

When a song selection in OPFS points at a file not present in the clone (e.g. clicked "Switch song" in one session, reloaded before pulling the matching commit), the app boot would hang silently behind the progress spinner — no console error, no alert, no way to recover without nuking site data.

Three independent failure modes, each fixed:

1. **`wasmgitclient.js`** — `awaitDirContents` and `readfile` awaited worker responses with no timeout. Any worker-side failure (clone error, OPFS lock, missing file before the `'error'` branch fired) hung the boot indefinitely. Added per-call timeouts (30s for dir contents, 10s for readfile) that reject with a clear `"worker not responding"` message.

2. **`editorcontroller.js`** — initial readfile calls in the gitrepo boot path had no error handling, so a missing file (stale `synthfilename` pointing at a file added in a later commit the user hasn't pulled yet) caused `initEditor` to throw. The async resync handler a few lines up already wrapped its reads in try/catch; the initial reads now do the same. **Plus**, if the active selection fails, walks `allsongs` and falls back to the first entry that loads cleanly. Last resort: alert the user and continue with empty editors so they can sync / switch songs from the toolbar.

3. **`app.js`** — `initEditor` was awaited bare; any uncaught exception left the spinner up forever. Now wrapped in try/catch that always clears the spinner and alerts the user, then continues to `enablePlayAndSaveButtons` so the UI is at least clickable.

## How it surfaced

Hit during ifc2026 concert-set assembly: a song without a synth.ts was added to `wasmmusic.config.json`, user switched to it in one session (config in OPFS now pointed at the missing file), reload after the matching synth.ts was added remotely but before pulling → spinner hung silently. The recovery path was "open DevTools, clear all site data, reload" — which loses local state.

With these fixes the same scenario falls back to a working song, the user can pull/switch normally, and the worst case is a visible alert instead of a frozen UI.

## Test plan

- [x] Existing wtr suite (`npx wtr`): 17 files, 51 passed / 3 skipped on Chromium + Firefox. No regressions; this strictly adds error paths.
- [ ] Manual: stash a bogus `synthfilename` in `wasmmusic.config.json` (e.g. `"nonexistent/synth.ts"`), reload — should fall back to first `allsongs` entry and boot normally.
- [ ] Manual: same scenario with a single-song repo (no `allsongs` fallback available) — should alert and boot with empty editors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)