### PR TITLE
add "Optimize AssemblyScript" toolbar toggle + DX7 NRPN→patch porting tool

### DIFF
--- a/examples/dx7/sequence-to-patches.js
+++ b/examples/dx7/sequence-to-patches.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// DX7 NRPN sequence → typed-field patch generator.
+//
+// Read an existing song that uses `nrpn(beat, idx, value)` blocks to load
+// DX7 patches (e.g. examples/dx7/dx7-sequence.js or its descendants),
+// and emit the equivalent typed-field assignments for the per-algorithm
+// .ts files produced by `faust2asc.js` in --for-editor mode (modular,
+// one .ts per .dsp — see faust/dx7/).
+//
+// Why bother:
+//   - The old `--bundle` workflow set patches via `nrpn(beat, idx, val)`
+//     calls inside the song. Each call resolves to controlchange(99, MSB)
+//     + controlchange(98, LSB) + controlchange(6, value), and the
+//     bundle's switch scales `value` to the field's Faust-native range
+//     internally (e.g. 0-127 → 0-7 for feedback).
+//   - In the modular workflow the song just plays notes, and patches go
+//     in synth.ts as direct field assignments. Each assignment must use
+//     the *scaled* value, not the raw NRPN value — assigning 0-127 to a
+//     0-7 field crashes the DSP with `unreachable` on the first note.
+//
+// What this does:
+//   1. Parse `nrpn(0, IDX, VAL)` calls per `createTrack(N).play([...])`
+//      block in the source song to get the raw NRPN settings per channel.
+//   2. Parse each algorithm's transpiled .ts to extract the per-NRPN
+//      scaling expression from its `_setParam` switch (e.g.
+//      `<f32>value / 127.0 * 7`).
+//   3. Evaluate the scaling expression at codegen time with the raw
+//      value, skip params whose scaled value matches the field's init
+//      default, and emit `channel.fieldName = <f32>SCALED;`.
+//
+// Output goes to stdout. Pipe / paste into synth.ts (inside
+// `initializeMidiSynth()`). The script doesn't write to your repo
+// directly — you stitch its output together with the surrounding mix
+// boilerplate (imports, masterMe, drum-kit factory, postprocess).
+//
+// Usage:
+//   node sequence-to-patches.js \
+//       --src   path/to/source-song.js \
+//       --faust path/to/repo/faust/dx7 \
+//       [--map  '0:epiano:dx7_alg5:Dx7Alg5,1:bass:dx7_alg16:Dx7Alg16,...']
+//       [--drum '4:0=kickRouter:dx7_alg17:Dx7Alg17,4:144=snareRouter:...,4:288=hatRouter:...']
+//
+// Defaults reproduce the dx7template / IFC concert layout: ch 0-3 are
+// melodic, ch 4 is a combined drum kit with kick/snare/hat router
+// channels at NRPN offsets 0/144/288 in the source.
+
+import fs from 'fs';
+import path from 'path';
+
+// ── CLI parsing ────────────────────────────────────────────────
+
+function getArg(name, fallback = null) {
+    const idx = process.argv.indexOf(name);
+    if (idx < 0) return fallback;
+    return process.argv[idx + 1] ?? fallback;
+}
+
+const SRC = getArg('--src', path.join(import.meta.dirname, 'dx7-sequence.js'));
+const FAUST_DIR = getArg('--faust', null);
+if (!FAUST_DIR) {
+    console.error('error: --faust <dir> required (path to repo\'s faust/dx7/ folder with the transpiled .ts files)');
+    process.exit(1);
+}
+
+const DEFAULT_MAP = '0:epiano:dx7_alg5:Dx7Alg5,1:bass:dx7_alg16:Dx7Alg16,2:strings:dx7_alg2:Dx7Alg2,3:bells:dx7_alg5_bells:Dx7Alg5Bells';
+const DEFAULT_DRUM = '4:0=kickRouter:dx7_alg17:Dx7Alg17,4:144=snareRouter:dx7_alg21:Dx7Alg21,4:288=hatRouter:dx7_alg5_hat:Dx7Alg5Hat';
+
+const melodic = getArg('--map', DEFAULT_MAP).split(',').map(s => {
+    const [ch, name, alg, cls] = s.split(':');
+    return { ch: +ch, name, alg, cls, srcChannel: +ch, isRouter: false };
+});
+const drums = getArg('--drum', DEFAULT_DRUM).split(',').map(s => {
+    // shape: "<srcCh>:<offset>=<name>:<alg>:<cls>"
+    const [head, alg, cls] = s.split(':');
+    // wait — colons are also separators for the head. parse manually:
+    const parts = s.split(':');
+    const srcChannel = +parts[0];
+    const offsetEq = parts[1];                                // e.g. "0=kickRouter"
+    const eq = offsetEq.indexOf('=');
+    const nrpnOffset = +offsetEq.slice(0, eq);
+    const name = offsetEq.slice(eq + 1);
+    return { srcChannel, nrpnOffset, name, alg: parts[2], cls: parts[3], isRouter: true };
+});
+
+// ── Per-algorithm scaling map ──────────────────────────────────
+
+function readChannelMap(tsPath) {
+    const src = fs.readFileSync(tsPath, 'utf8');
+    const map = {};
+    // Capture field declarations: doc comment with init + NRPN, then the
+    // typed field on the next line.
+    const fieldRe = /\/\*\* ([^\[]+)\[init: (-?[0-9.e+\-]+),[^\*]*· NRPN (\d+) \*\/\s*\n\s*(\w+):\s*f32/g;
+    let m;
+    while ((m = fieldRe.exec(src))) {
+        map[+m[3]] = { name: m[4], init: parseFloat(m[2]), scaleExpr: null };
+    }
+    // Scaling lives in `private _setParam(param: u16, value: u8)` — not
+    // the outer controlchange switch (which handles CC 99/98/6 and would
+    // collide with NRPN indices like 99 in our case-statement match).
+    const setParamStart = src.indexOf('private _setParam(');
+    if (setParamStart < 0) throw new Error(`no _setParam in ${tsPath}`);
+    const setParamRegion = src.slice(setParamStart);
+    const caseRe = /case (\d+): this\.(\w+) = ([^;]+); break;/g;
+    while ((m = caseRe.exec(setParamRegion))) {
+        const nrpn = +m[1];
+        const expr = m[3].replace(/<f32>/g, '');
+        if (map[nrpn]) {
+            if (map[nrpn].name !== m[2]) throw new Error(`NRPN ${nrpn}: field name mismatch ${map[nrpn].name} vs ${m[2]}`);
+            map[nrpn].scaleExpr = expr;
+        }
+    }
+    return map;
+}
+
+const evalScale = (expr, value) => Function('value', `return ${expr};`)(value);
+
+// ── Source NRPN block per channel ──────────────────────────────
+
+function readChannelNrpnBlock(seqSrc, channel) {
+    const startMarker = `createTrack(${channel}).play([`;
+    const start = seqSrc.indexOf(startMarker);
+    if (start < 0) return {};       // channel not configured via play() block — likely no NRPN setup
+    const end = seqSrc.indexOf(']);', start);
+    const block = seqSrc.slice(start, end);
+    const re = /nrpn\(\s*0\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/g;
+    const out = {};
+    let m;
+    while ((m = re.exec(block))) out[+m[1]] = +m[2];
+    return out;
+}
+
+// ── Emit ───────────────────────────────────────────────────────
+
+const seqSrc = fs.readFileSync(SRC, 'utf8');
+const EPS = 0.001;
+
+function fmt(n) {
+    return Math.abs(n - Math.round(n)) < 1e-3
+        ? String(Math.round(n))
+        : n.toFixed(4).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function emitBlock(spec) {
+    const map = readChannelMap(path.join(FAUST_DIR, spec.alg + '.ts'));
+    const srcNrpns = readChannelNrpnBlock(seqSrc, spec.srcChannel);
+    const offset = spec.nrpnOffset || 0;
+    if (spec.isRouter) {
+        console.log(`    // ${spec.name.replace(/Router$/, '')} patch (${spec.cls}, params on ${spec.name}):`);
+    } else {
+        console.log(`    // --- ch ${spec.ch}: ${spec.name} (${spec.cls}) ---`);
+        console.log(`    const ${spec.name} = new ${spec.cls}Channel(10, (ch: MidiChannel) => new ${spec.cls}(ch));`);
+        console.log(`    midichannels[${spec.ch}] = ${spec.name};`);
+    }
+    let n = 0;
+    for (const idx of Object.keys(srcNrpns).map(Number).sort((a, b) => a - b)) {
+        const local = idx - offset;
+        const slot = map[local];
+        if (!slot || !slot.scaleExpr) continue;
+        const scaled = evalScale(slot.scaleExpr, srcNrpns[idx]);
+        if (Math.abs(scaled - slot.init) < EPS) continue;
+        console.log(`    ${spec.name}.${slot.name} = <f32>${fmt(scaled)};`);
+        n++;
+    }
+    console.log(`    // (${n} non-default params)`);
+    console.log('');
+}
+
+for (const spec of melodic) emitBlock(spec);
+for (const spec of drums)   emitBlock(spec);

--- a/examples/dx7/sequence-to-patches.js
+++ b/examples/dx7/sequence-to-patches.js
@@ -87,32 +87,12 @@ const drums = getArg('--drum', DEFAULT_DRUM).split(',').map(s => {
 function readChannelMap(tsPath) {
     const src = fs.readFileSync(tsPath, 'utf8');
     const map = {};
-    // Capture field/global declarations. Doc-comment shape is consistent
-    // (`/** Feedback [init: 0, ...] · NRPN 0 */`) but the line after it
-    // can be one of three forms depending on transpiler vintage:
-    //
-    //   `<niceName>: f32 = ...;`                   (typed channel field)
-    //   `let _<ClassName>_<niceName>: f32 = ...;`  (module-level global)
-    //   `@inline get<Cap>(): f32 { return _<ClassName>_<niceName>; }`
-    //
-    // We capture `niceName` from whichever form we see. The init value
-    // comes from the doc comment.
-    const fieldRe = new RegExp(
-        '/\\*\\* ([^\\[]+)\\[init: (-?[0-9.e+\\-]+),[^\\*]*· NRPN (\\d+) \\*/' +
-            '\\s*\\n\\s*' +
-            '(?:' +
-              '(\\w+):\\s*f32' +              // capture[4]: typed-field name
-              '|' +
-              'let\\s+_\\w+_(\\w+):\\s*f32' + // capture[5]: global → niceName
-              '|' +
-              '@inline\\s+(?:get|set)\\w+\\([^)]*\\)[^{]*\\{\\s*(?:return\\s+)?_\\w+_(\\w+)' + // capture[6]
-            ')',
-        'g'
-    );
+    // Capture field declarations: doc comment with init + NRPN, then the
+    // typed `<niceName>: f32` field on the next line.
+    const fieldRe = /\/\*\* ([^\[]+)\[init: (-?[0-9.e+\-]+),[^\*]*· NRPN (\d+) \*\/\s*\n\s*(\w+):\s*f32/g;
     let m;
     while ((m = fieldRe.exec(src))) {
-        const niceName = m[4] ?? m[5] ?? m[6];
-        map[+m[3]] = { name: niceName, init: parseFloat(m[2]), scaleExpr: null };
+        map[+m[3]] = { name: m[4], init: parseFloat(m[2]), scaleExpr: null };
     }
     // Scaling lives in `private _setParam(param: u16, value: u8)` — not
     // the outer controlchange switch (which handles CC 99/98/6 and would
@@ -120,17 +100,12 @@ function readChannelMap(tsPath) {
     const setParamStart = src.indexOf('private _setParam(');
     if (setParamStart < 0) throw new Error(`no _setParam in ${tsPath}`);
     const setParamRegion = src.slice(setParamStart);
-    // Two LHS shapes:
-    //   case N: this.<niceName> = EXPR;          (effect mode, fields on channel)
-    //   case N: _<ClassName>_<niceName> = EXPR;  (voice mode, module global)
-    // Both forms map back to the same `niceName` via either capture group.
-    const caseRe = /case (\d+): (?:this\.(\w+)|_\w+_(\w+)) = ([^;]+); break;/g;
+    const caseRe = /case (\d+): this\.(\w+) = ([^;]+); break;/g;
     while ((m = caseRe.exec(setParamRegion))) {
         const nrpn = +m[1];
-        const name = m[2] ?? m[3];
-        const expr = m[4].replace(/<f32>/g, '');
+        const expr = m[3].replace(/<f32>/g, '');
         if (map[nrpn]) {
-            if (map[nrpn].name !== name) throw new Error(`NRPN ${nrpn}: field name mismatch ${map[nrpn].name} vs ${name}`);
+            if (map[nrpn].name !== m[2]) throw new Error(`NRPN ${nrpn}: field name mismatch ${map[nrpn].name} vs ${m[2]}`);
             map[nrpn].scaleExpr = expr;
         }
     }
@@ -183,13 +158,7 @@ function emitBlock(spec) {
         if (!slot || !slot.scaleExpr) continue;
         const scaled = evalScale(slot.scaleExpr, srcNrpns[idx]);
         if (Math.abs(scaled - slot.init) < EPS) continue;
-        // Emit as a plain @inline setter method call (`channel.setFeedback(v)`),
-        // not field assignment (`channel.feedback = v`). AS's @inline directive
-        // takes effect on plain methods at optimizeLevel 0 but not on accessor
-        // get/set; using field-assignment syntax would inflate the wasm by
-        // hundreds of materialized accessor functions and choke real-time audio.
-        const cap = slot.name.charAt(0).toUpperCase() + slot.name.slice(1);
-        console.log(`    ${spec.name}.set${cap}(<f32>${fmt(scaled)});`);
+        console.log(`    ${spec.name}.${slot.name} = <f32>${fmt(scaled)};`);
         n++;
     }
     console.log(`    // (${n} non-default params)`);

--- a/examples/dx7/sequence-to-patches.js
+++ b/examples/dx7/sequence-to-patches.js
@@ -87,12 +87,32 @@ const drums = getArg('--drum', DEFAULT_DRUM).split(',').map(s => {
 function readChannelMap(tsPath) {
     const src = fs.readFileSync(tsPath, 'utf8');
     const map = {};
-    // Capture field declarations: doc comment with init + NRPN, then the
-    // typed field on the next line.
-    const fieldRe = /\/\*\* ([^\[]+)\[init: (-?[0-9.e+\-]+),[^\*]*· NRPN (\d+) \*\/\s*\n\s*(\w+):\s*f32/g;
+    // Capture field/global declarations. Doc-comment shape is consistent
+    // (`/** Feedback [init: 0, ...] · NRPN 0 */`) but the line after it
+    // can be one of three forms depending on transpiler vintage:
+    //
+    //   `<niceName>: f32 = ...;`                   (typed channel field)
+    //   `let _<ClassName>_<niceName>: f32 = ...;`  (module-level global)
+    //   `@inline get<Cap>(): f32 { return _<ClassName>_<niceName>; }`
+    //
+    // We capture `niceName` from whichever form we see. The init value
+    // comes from the doc comment.
+    const fieldRe = new RegExp(
+        '/\\*\\* ([^\\[]+)\\[init: (-?[0-9.e+\\-]+),[^\\*]*· NRPN (\\d+) \\*/' +
+            '\\s*\\n\\s*' +
+            '(?:' +
+              '(\\w+):\\s*f32' +              // capture[4]: typed-field name
+              '|' +
+              'let\\s+_\\w+_(\\w+):\\s*f32' + // capture[5]: global → niceName
+              '|' +
+              '@inline\\s+(?:get|set)\\w+\\([^)]*\\)[^{]*\\{\\s*(?:return\\s+)?_\\w+_(\\w+)' + // capture[6]
+            ')',
+        'g'
+    );
     let m;
     while ((m = fieldRe.exec(src))) {
-        map[+m[3]] = { name: m[4], init: parseFloat(m[2]), scaleExpr: null };
+        const niceName = m[4] ?? m[5] ?? m[6];
+        map[+m[3]] = { name: niceName, init: parseFloat(m[2]), scaleExpr: null };
     }
     // Scaling lives in `private _setParam(param: u16, value: u8)` — not
     // the outer controlchange switch (which handles CC 99/98/6 and would
@@ -100,12 +120,17 @@ function readChannelMap(tsPath) {
     const setParamStart = src.indexOf('private _setParam(');
     if (setParamStart < 0) throw new Error(`no _setParam in ${tsPath}`);
     const setParamRegion = src.slice(setParamStart);
-    const caseRe = /case (\d+): this\.(\w+) = ([^;]+); break;/g;
+    // Two LHS shapes:
+    //   case N: this.<niceName> = EXPR;          (effect mode, fields on channel)
+    //   case N: _<ClassName>_<niceName> = EXPR;  (voice mode, module global)
+    // Both forms map back to the same `niceName` via either capture group.
+    const caseRe = /case (\d+): (?:this\.(\w+)|_\w+_(\w+)) = ([^;]+); break;/g;
     while ((m = caseRe.exec(setParamRegion))) {
         const nrpn = +m[1];
-        const expr = m[3].replace(/<f32>/g, '');
+        const name = m[2] ?? m[3];
+        const expr = m[4].replace(/<f32>/g, '');
         if (map[nrpn]) {
-            if (map[nrpn].name !== m[2]) throw new Error(`NRPN ${nrpn}: field name mismatch ${map[nrpn].name} vs ${m[2]}`);
+            if (map[nrpn].name !== name) throw new Error(`NRPN ${nrpn}: field name mismatch ${map[nrpn].name} vs ${name}`);
             map[nrpn].scaleExpr = expr;
         }
     }
@@ -158,7 +183,13 @@ function emitBlock(spec) {
         if (!slot || !slot.scaleExpr) continue;
         const scaled = evalScale(slot.scaleExpr, srcNrpns[idx]);
         if (Math.abs(scaled - slot.init) < EPS) continue;
-        console.log(`    ${spec.name}.${slot.name} = <f32>${fmt(scaled)};`);
+        // Emit as a plain @inline setter method call (`channel.setFeedback(v)`),
+        // not field assignment (`channel.feedback = v`). AS's @inline directive
+        // takes effect on plain methods at optimizeLevel 0 but not on accessor
+        // get/set; using field-assignment syntax would inflate the wasm by
+        // hundreds of materialized accessor functions and choke real-time audio.
+        const cap = slot.name.charAt(0).toUpperCase() + slot.name.slice(1);
+        console.log(`    ${spec.name}.set${cap}(<f32>${fmt(scaled)});`);
         n++;
     }
     console.log(`    // (${n} non-default params)`);

--- a/wasmaudioworklet/app.html.js
+++ b/wasmaudioworklet/app.html.js
@@ -37,6 +37,13 @@ export default /*html*/ `<link rel="stylesheet" href="https://cdnjs.cloudflare.c
       <span>visualizer</span>
     </label>
 
+    &nbsp;
+
+    <label title="optimize AssemblyScript on save (slower compile, faster wasm — needed for heavy DSPs like master_me)">
+      <input id="toggleOptimizeAsCheckbox" type="checkbox" />
+      <span>Optimize AssemblyScript</span>
+    </label>
+
     <div style="flex-grow: 1"></div>
     <button id="exportbutton" onclick="compileSong(true)" title="Export">&#x21E9;</button>
   </div>

--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -198,6 +198,23 @@ export function initAudioWorkletNode(componentRoot) {
         }
     };
 
+    // Wire the "Optimize AssemblyScript" checkbox. Persists to localStorage
+    // so the choice survives reloads. The worker reads the same key on
+    // every compile, so the checkbox effectively toggles -O0 (fast compile,
+    // bloated wasm) vs -O1 (slower compile, hot loops inlined — needed for
+    // heavy DSPs like master_me).
+    const optimizeAsCheckbox = componentRoot.getElementById('toggleOptimizeAsCheckbox');
+    if (optimizeAsCheckbox) {
+        const stored = localStorage.getItem('asOptimizeLevel');
+        // Default to 1 (current production setting). Treat any truthy non-zero
+        // value as "optimize on".
+        const initialLevel = stored !== null ? Number(stored) : 1;
+        optimizeAsCheckbox.checked = initialLevel >= 1;
+        optimizeAsCheckbox.addEventListener('change', () => {
+            localStorage.setItem('asOptimizeLevel', optimizeAsCheckbox.checked ? '1' : '0');
+        });
+    }
+
     window.toggleVisualizer = (status) => {
         if (status) {
             setUseDefaultVisualizer(true);

--- a/wasmaudioworklet/faust/transpile-core.js
+++ b/wasmaudioworklet/faust/transpile-core.js
@@ -610,14 +610,39 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     const channelClassName = clsName + 'Channel';
     const hasChannelClass = hasEffect || ccParams.length > 0;
 
-    // Reference expressions used inside the transpiled DSP body for each
-    // param. Voice DSP code runs in the voice class and reaches the channel
-    // via `this.typedChannel`; effect DSP code runs in the channel class
-    // itself, so it uses plain `this.<name>`.
-    const voiceParamRefs = new Map();
-    const effectParamRefs = new Map();
+    // Storage strategy for voice-mode UI params: each param lives as a
+    // module-level `let <globalName>: f32` and the voice's per-sample
+    // process body reads it directly. The matching channel class still
+    // exposes the param as a `get`/`set` accessor named `<niceName>` so
+    // `synth.ts` can write `channel.feedback = 6.0` — but that setter
+    // writes through to the module global, so all voices see the new
+    // value with no `this.typedChannel.X` double-deref in the hot loop.
+    //
+    // Why module globals: at AS optimizeLevel 0 (the wasmaudioworklet
+    // live-compile setting) reading `this.typedChannel.feedback` doesn't
+    // inline — every access is two memory loads (typedChannel pointer,
+    // then field). Per-sample × dozens of params × dozens of voices is
+    // enough to choke real-time audio on a busy CPU. A statically-known
+    // global address is one load and the optimizer can keep it in a
+    // register. See faust2as.js (the C backend) which has used this
+    // pattern since the start.
+    //
+    // Caveat: all instances of `<className>Channel` share the same
+    // module globals, so a song with two instances of the same channel
+    // class would see them interfere. In practice MidiSynth uses one
+    // channel instance per algorithm per song, so this is fine.
+    //
+    // Effect-mode DSP runs inside the channel class itself, so its
+    // params still live as plain `this.<name>` fields (one instance,
+    // no hot-loop indirection).
+    const globalNamePrefix = '_' + clsName + '_';
+    const paramGlobals = new Map();              // niceName -> module-global name
+    const voiceParamRefs = new Map();            // Faust field name -> reference in voice body
+    const effectParamRefs = new Map();           // Faust field name -> reference in effect body
     for (const p of ccParams) {
-        voiceParamRefs.set(p.field, `this.typedChannel.${p.niceName}`);
+        const globalName = globalNamePrefix + p.niceName;
+        paramGlobals.set(p.niceName, globalName);
+        voiceParamRefs.set(p.field, globalName);
         effectParamRefs.set(p.field, `this.${p.niceName}`);
     }
     // Aliased as `globalFields` for compatibility with reshapeASLine.
@@ -655,19 +680,12 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     }
     voiceClass.push('    private silentSamples: i32 = 0;');
     voiceClass.push('    private releaseSamples: i32 = 0;');
-    if (hasChannelClass) {
-        // Typed back-reference so nextframe() can read per-instance UI params
-        // off the channel without a virtual call. Zero-cost reinterpret cast.
-        voiceClass.push(`    typedChannel!: ${channelClassName};`);
-    }
     voiceClass.push('');
 
-    // Constructor
+    // Constructor — UI params live in module globals (see paramGlobals
+    // above), so the voice doesn't keep a typed reference to the channel.
     voiceClass.push('    constructor(channel: MidiChannel) {');
     voiceClass.push('        super(channel);');
-    if (hasChannelClass) {
-        voiceClass.push(`        this.typedChannel = changetype<${channelClassName}>(changetype<usize>(channel));`);
-    }
     if (parsed.sigClasses.length > 0) {
         voiceClass.push(`        ${voiceSigPrefix}_initSIG0Tables();`);
     }
@@ -787,10 +805,16 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     voiceClass.push('    }');
     voiceClass.push('}');
 
-    // Module-level globals for UI params are gone — each param now lives as
-    // a public field on the channel class. `voiceGlobals` stays as an empty
-    // array to keep the return-shape stable for assembly.
+    // Module-level storage for each UI param (see comment in Step 4).
+    // Voice DSP body reads these directly. The channel class's
+    // `<niceName>` accessor (emitted in Step 8) mirrors them so user code
+    // can still do `channel.feedback = 6.0`.
     const voiceGlobals = [];
+    for (const p of ccParams) {
+        const def = parsed.defaults[p.field] != null ? parsed.defaults[p.field] : `<f32>(${p.init})`;
+        voiceGlobals.push(`${paramDocComment(p)}`);
+        voiceGlobals.push(`let ${paramGlobals.get(p.niceName)}: f32 = ${def};`);
+    }
 
     // === Step 7: Generate effect code sections ===
 
@@ -1014,13 +1038,15 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     const voiceCCParams = ccParams.filter(p => p.cc !== undefined);
     if (!hasEffect && (voiceCCParams.length > 0 || (useNRPN && ccParams.length > 0))) {
         voiceChannelClass.push(`export class ${channelClassName} extends MidiChannel {`);
-        // Public, per-instance UI param fields. Each carries a doc comment
-        // with init/min/max/step + CC or NRPN address so editor hover serves
-        // as the missing Faust UI.
+        // Each UI param is exposed as a get/set accessor that mirrors the
+        // module-level storage emitted above. Lets user code in synth.ts
+        // keep the typed-field ergonomics (`channel.feedback = 6.0`) while
+        // the per-sample voice path reads the global directly.
         for (const p of ccParams) {
-            const def = parsed.defaults[p.field] != null ? parsed.defaults[p.field] : `<f32>(${p.init})`;
+            const g = paramGlobals.get(p.niceName);
             voiceChannelClass.push(paramDocComment(p));
-            voiceChannelClass.push(`    ${p.niceName}: f32 = ${def};`);
+            voiceChannelClass.push(`    get ${p.niceName}(): f32 { return ${g}; }`);
+            voiceChannelClass.push(`    set ${p.niceName}(value: f32) { ${g} = value; }`);
         }
         voiceChannelClass.push('');
         if (useNRPN) {
@@ -1038,7 +1064,10 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
             voiceChannelClass.push('        }');
             voiceChannelClass.push('    }');
             voiceChannelClass.push('');
-            generateNRPNSetParam(voiceChannelClass, ccParams);
+            // NRPN handler writes directly into the module globals — same
+            // storage the voice body reads from — so the existing
+            // controlchange(99/98/6) path stays a no-allocation pass-through.
+            generateNRPNSetParam(voiceChannelClass, ccParams, paramGlobals);
         } else {
             voiceChannelClass.push('    controlchange(controller: u8, value: u8): void {');
             voiceChannelClass.push('        super.controlchange(controller, value);');
@@ -1048,7 +1077,7 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
                 const minStr = p.min === 0 ? '' : `${p.min} + `;
                 const rangeStr = range === 1 ? '' : ` * ${range}`;
                 voiceChannelClass.push(`            case ${p.cc}:`);
-                voiceChannelClass.push(`                this.${p.niceName} = ${minStr}<f32>value / 127.0${rangeStr};`);
+                voiceChannelClass.push(`                ${paramGlobals.get(p.niceName)} = ${minStr}<f32>value / 127.0${rangeStr};`);
                 voiceChannelClass.push('                break;');
             }
             voiceChannelClass.push('        }');
@@ -1089,7 +1118,13 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
 // NRPN helpers
 // ---------------------------------------------------------------------------
 
-export function generateNRPNSetParam(lines, ccParams) {
+// When `globalNames` is provided (Map of niceName → module-global name),
+// the generated `_setParam` writes through to the globals — same pattern
+// the legacy C-backend transpiler uses. Voice-mode passes this map so the
+// per-sample DSP body can read the globals directly. Effect mode omits it,
+// in which case the assignment targets `this.<niceName>` on the channel
+// (effect params live as per-instance fields).
+export function generateNRPNSetParam(lines, ccParams, globalNames = null) {
     lines.push('    private _setParam(param: u16, value: u8): void {');
     lines.push('        switch (param) {');
     for (const p of ccParams) {
@@ -1097,7 +1132,8 @@ export function generateNRPNSetParam(lines, ccParams) {
         const range = p.max - p.min;
         const minStr = p.min === 0 ? '' : `${p.min} + `;
         const rangeStr = range === 1 ? '' : ` * ${range}`;
-        lines.push(`            case ${p.nrpn}: this.${p.niceName} = ${minStr}<f32>value / 127.0${rangeStr}; break;`);
+        const lhs = globalNames ? globalNames.get(p.niceName) : `this.${p.niceName}`;
+        lines.push(`            case ${p.nrpn}: ${lhs} = ${minStr}<f32>value / 127.0${rangeStr}; break;`);
     }
     lines.push('        }');
     lines.push('    }');

--- a/wasmaudioworklet/faust/transpile-core.js
+++ b/wasmaudioworklet/faust/transpile-core.js
@@ -610,39 +610,14 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     const channelClassName = clsName + 'Channel';
     const hasChannelClass = hasEffect || ccParams.length > 0;
 
-    // Storage strategy for voice-mode UI params: each param lives as a
-    // module-level `let <globalName>: f32` and the voice's per-sample
-    // process body reads it directly. The matching channel class still
-    // exposes the param as a `get`/`set` accessor named `<niceName>` so
-    // `synth.ts` can write `channel.feedback = 6.0` — but that setter
-    // writes through to the module global, so all voices see the new
-    // value with no `this.typedChannel.X` double-deref in the hot loop.
-    //
-    // Why module globals: at AS optimizeLevel 0 (the wasmaudioworklet
-    // live-compile setting) reading `this.typedChannel.feedback` doesn't
-    // inline — every access is two memory loads (typedChannel pointer,
-    // then field). Per-sample × dozens of params × dozens of voices is
-    // enough to choke real-time audio on a busy CPU. A statically-known
-    // global address is one load and the optimizer can keep it in a
-    // register. See faust2as.js (the C backend) which has used this
-    // pattern since the start.
-    //
-    // Caveat: all instances of `<className>Channel` share the same
-    // module globals, so a song with two instances of the same channel
-    // class would see them interfere. In practice MidiSynth uses one
-    // channel instance per algorithm per song, so this is fine.
-    //
-    // Effect-mode DSP runs inside the channel class itself, so its
-    // params still live as plain `this.<name>` fields (one instance,
-    // no hot-loop indirection).
-    const globalNamePrefix = '_' + clsName + '_';
-    const paramGlobals = new Map();              // niceName -> module-global name
-    const voiceParamRefs = new Map();            // Faust field name -> reference in voice body
-    const effectParamRefs = new Map();           // Faust field name -> reference in effect body
+    // Reference expressions used inside the transpiled DSP body for each
+    // param. Voice DSP code runs in the voice class and reaches the channel
+    // via `this.typedChannel`; effect DSP code runs in the channel class
+    // itself, so it uses plain `this.<name>`.
+    const voiceParamRefs = new Map();
+    const effectParamRefs = new Map();
     for (const p of ccParams) {
-        const globalName = globalNamePrefix + p.niceName;
-        paramGlobals.set(p.niceName, globalName);
-        voiceParamRefs.set(p.field, globalName);
+        voiceParamRefs.set(p.field, `this.typedChannel.${p.niceName}`);
         effectParamRefs.set(p.field, `this.${p.niceName}`);
     }
     // Aliased as `globalFields` for compatibility with reshapeASLine.
@@ -680,12 +655,19 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     }
     voiceClass.push('    private silentSamples: i32 = 0;');
     voiceClass.push('    private releaseSamples: i32 = 0;');
+    if (hasChannelClass) {
+        // Typed back-reference so nextframe() can read per-instance UI params
+        // off the channel without a virtual call. Zero-cost reinterpret cast.
+        voiceClass.push(`    typedChannel!: ${channelClassName};`);
+    }
     voiceClass.push('');
 
-    // Constructor — UI params live in module globals (see paramGlobals
-    // above), so the voice doesn't keep a typed reference to the channel.
+    // Constructor
     voiceClass.push('    constructor(channel: MidiChannel) {');
     voiceClass.push('        super(channel);');
+    if (hasChannelClass) {
+        voiceClass.push(`        this.typedChannel = changetype<${channelClassName}>(changetype<usize>(channel));`);
+    }
     if (parsed.sigClasses.length > 0) {
         voiceClass.push(`        ${voiceSigPrefix}_initSIG0Tables();`);
     }
@@ -805,16 +787,10 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     voiceClass.push('    }');
     voiceClass.push('}');
 
-    // Module-level storage for each UI param (see comment in Step 4).
-    // Voice DSP body reads these directly. The channel class's
-    // `<niceName>` accessor (emitted in Step 8) mirrors them so user code
-    // can still do `channel.feedback = 6.0`.
+    // Module-level globals for UI params are gone — each param now lives as
+    // a public field on the channel class. `voiceGlobals` stays as an empty
+    // array to keep the return-shape stable for assembly.
     const voiceGlobals = [];
-    for (const p of ccParams) {
-        const def = parsed.defaults[p.field] != null ? parsed.defaults[p.field] : `<f32>(${p.init})`;
-        voiceGlobals.push(`${paramDocComment(p)}`);
-        voiceGlobals.push(`let ${paramGlobals.get(p.niceName)}: f32 = ${def};`);
-    }
 
     // === Step 7: Generate effect code sections ===
 
@@ -1038,30 +1014,13 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     const voiceCCParams = ccParams.filter(p => p.cc !== undefined);
     if (!hasEffect && (voiceCCParams.length > 0 || (useNRPN && ccParams.length > 0))) {
         voiceChannelClass.push(`export class ${channelClassName} extends MidiChannel {`);
-        // Each UI param is exposed as a pair of `@inline` plain methods
-        // (`getFeedback()` / `setFeedback(v)`) that mirror the
-        // module-level storage emitted above. User code in synth.ts
-        // reads / writes patches with `channel.setFeedback(6.0)` while
-        // the per-sample voice path reads the underlying global
-        // directly.
-        //
-        // Why plain methods, not `get`/`set` accessor syntax: at AS
-        // optimizeLevel 0 (wasmaudioworklet's live-compile default), AS
-        // honors `@inline` on plain methods but NOT on accessor
-        // getters/setters — every `channel.feedback = X` call ends up
-        // emitting the setter as a real wasm function and pulls in the
-        // matching getter and a fan-out of sibling-class accessors.
-        // For a 144-param synth like DX7 across 7 algorithm channels
-        // that's ~2000 extra wasm functions and a per-sample indirection
-        // hit big enough to choke real-time playback. The plain `@inline
-        // setX` is folded into a single global-store at the call site —
-        // same hot-path code as if user code wrote the global directly.
+        // Public, per-instance UI param fields. Each carries a doc comment
+        // with init/min/max/step + CC or NRPN address so editor hover serves
+        // as the missing Faust UI.
         for (const p of ccParams) {
-            const g = paramGlobals.get(p.niceName);
-            const cap = p.niceName.charAt(0).toUpperCase() + p.niceName.slice(1);
+            const def = parsed.defaults[p.field] != null ? parsed.defaults[p.field] : `<f32>(${p.init})`;
             voiceChannelClass.push(paramDocComment(p));
-            voiceChannelClass.push(`    @inline get${cap}(): f32 { return ${g}; }`);
-            voiceChannelClass.push(`    @inline set${cap}(value: f32): void { ${g} = value; }`);
+            voiceChannelClass.push(`    ${p.niceName}: f32 = ${def};`);
         }
         voiceChannelClass.push('');
         if (useNRPN) {
@@ -1079,10 +1038,7 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
             voiceChannelClass.push('        }');
             voiceChannelClass.push('    }');
             voiceChannelClass.push('');
-            // NRPN handler writes directly into the module globals — same
-            // storage the voice body reads from — so the existing
-            // controlchange(99/98/6) path stays a no-allocation pass-through.
-            generateNRPNSetParam(voiceChannelClass, ccParams, paramGlobals);
+            generateNRPNSetParam(voiceChannelClass, ccParams);
         } else {
             voiceChannelClass.push('    controlchange(controller: u8, value: u8): void {');
             voiceChannelClass.push('        super.controlchange(controller, value);');
@@ -1092,7 +1048,7 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
                 const minStr = p.min === 0 ? '' : `${p.min} + `;
                 const rangeStr = range === 1 ? '' : ` * ${range}`;
                 voiceChannelClass.push(`            case ${p.cc}:`);
-                voiceChannelClass.push(`                ${paramGlobals.get(p.niceName)} = ${minStr}<f32>value / 127.0${rangeStr};`);
+                voiceChannelClass.push(`                this.${p.niceName} = ${minStr}<f32>value / 127.0${rangeStr};`);
                 voiceChannelClass.push('                break;');
             }
             voiceChannelClass.push('        }');
@@ -1133,13 +1089,7 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
 // NRPN helpers
 // ---------------------------------------------------------------------------
 
-// When `globalNames` is provided (Map of niceName → module-global name),
-// the generated `_setParam` writes through to the globals — same pattern
-// the legacy C-backend transpiler uses. Voice-mode passes this map so the
-// per-sample DSP body can read the globals directly. Effect mode omits it,
-// in which case the assignment targets `this.<niceName>` on the channel
-// (effect params live as per-instance fields).
-export function generateNRPNSetParam(lines, ccParams, globalNames = null) {
+export function generateNRPNSetParam(lines, ccParams) {
     lines.push('    private _setParam(param: u16, value: u8): void {');
     lines.push('        switch (param) {');
     for (const p of ccParams) {
@@ -1147,8 +1097,7 @@ export function generateNRPNSetParam(lines, ccParams, globalNames = null) {
         const range = p.max - p.min;
         const minStr = p.min === 0 ? '' : `${p.min} + `;
         const rangeStr = range === 1 ? '' : ` * ${range}`;
-        const lhs = globalNames ? globalNames.get(p.niceName) : `this.${p.niceName}`;
-        lines.push(`            case ${p.nrpn}: ${lhs} = ${minStr}<f32>value / 127.0${rangeStr}; break;`);
+        lines.push(`            case ${p.nrpn}: this.${p.niceName} = ${minStr}<f32>value / 127.0${rangeStr}; break;`);
     }
     lines.push('        }');
     lines.push('    }');

--- a/wasmaudioworklet/faust/transpile-core.js
+++ b/wasmaudioworklet/faust/transpile-core.js
@@ -1038,15 +1038,30 @@ export function transpileDsp({ asSource, effectAsSource = null, clsName, sourceF
     const voiceCCParams = ccParams.filter(p => p.cc !== undefined);
     if (!hasEffect && (voiceCCParams.length > 0 || (useNRPN && ccParams.length > 0))) {
         voiceChannelClass.push(`export class ${channelClassName} extends MidiChannel {`);
-        // Each UI param is exposed as a get/set accessor that mirrors the
-        // module-level storage emitted above. Lets user code in synth.ts
-        // keep the typed-field ergonomics (`channel.feedback = 6.0`) while
-        // the per-sample voice path reads the global directly.
+        // Each UI param is exposed as a pair of `@inline` plain methods
+        // (`getFeedback()` / `setFeedback(v)`) that mirror the
+        // module-level storage emitted above. User code in synth.ts
+        // reads / writes patches with `channel.setFeedback(6.0)` while
+        // the per-sample voice path reads the underlying global
+        // directly.
+        //
+        // Why plain methods, not `get`/`set` accessor syntax: at AS
+        // optimizeLevel 0 (wasmaudioworklet's live-compile default), AS
+        // honors `@inline` on plain methods but NOT on accessor
+        // getters/setters — every `channel.feedback = X` call ends up
+        // emitting the setter as a real wasm function and pulls in the
+        // matching getter and a fan-out of sibling-class accessors.
+        // For a 144-param synth like DX7 across 7 algorithm channels
+        // that's ~2000 extra wasm functions and a per-sample indirection
+        // hit big enough to choke real-time playback. The plain `@inline
+        // setX` is folded into a single global-store at the call site —
+        // same hot-path code as if user code wrote the global directly.
         for (const p of ccParams) {
             const g = paramGlobals.get(p.niceName);
+            const cap = p.niceName.charAt(0).toUpperCase() + p.niceName.slice(1);
             voiceChannelClass.push(paramDocComment(p));
-            voiceChannelClass.push(`    get ${p.niceName}(): f32 { return ${g}; }`);
-            voiceChannelClass.push(`    set ${p.niceName}(value: f32) { ${g} = value; }`);
+            voiceChannelClass.push(`    @inline get${cap}(): f32 { return ${g}; }`);
+            voiceChannelClass.push(`    @inline set${cap}(value: f32): void { ${g} = value; }`);
         }
         voiceChannelClass.push('');
         if (useNRPN) {

--- a/wasmaudioworklet/synth1/browsercompilerwebworker.js
+++ b/wasmaudioworklet/synth1/browsercompilerwebworker.js
@@ -201,18 +201,18 @@ onmessage = async function (msg) {
 
             assemblyscriptsynthsources[mix_source] = synthsource;
             lastFaustFingerprint = faustFingerprint;
-            // optimizeLevel: 1 (not 0). At -O0, AS emits per-private-field
-            // get/set accessor wasm functions and routes every `this.X`
-            // read through them — for DSPs like master_me with hundreds of
-            // internal state variables, that's ~1400 extra wasm functions
-            // and per-sample function-call overhead big enough to choke
-            // real-time playback. -O1 inlines the accessors and hoists
-            // invariant property loads out of hot loops, fixing it.
-            // Compile time goes from ~80ms to ~600ms for typical songs
-            // and ~200ms→~1700ms for a heavy 7-channel DX7 set — still
-            // interactive for live-coding.
+            // optimizeLevel from the "Optimize AssemblyScript" toolbar
+            // checkbox (via localStorage, forwarded by the main thread).
+            // Default 1. -O0 makes the compile blazing fast (~80ms) but
+            // produces 2-4× larger wasm because AS emits per-private-field
+            // get/set accessor functions and routes every `this.X` read
+            // through them — fine for light DSPs, but heavy ones like
+            // master_me end up choking real-time playback. -O1 inlines
+            // the accessors and hoists invariant property loads out of
+            // hot loops; compile takes 0.5-1.7s but the wasm is honest.
+            const liveOpt = typeof msg.data.optimizeLevel === 'number' ? msg.data.optimizeLevel : 1;
             const { stderr, text, binary } = await compileAssemblyScript(assemblyscriptsynthsources,
-                { "runtime": "stub", "optimizeLevel": 1, "shrinkLevel": 0 },
+                { "runtime": "stub", "optimizeLevel": liveOpt, "shrinkLevel": 0 },
                 index_source);
 
             postMessage({

--- a/wasmaudioworklet/synth1/browsercompilerwebworker.js
+++ b/wasmaudioworklet/synth1/browsercompilerwebworker.js
@@ -201,8 +201,18 @@ onmessage = async function (msg) {
 
             assemblyscriptsynthsources[mix_source] = synthsource;
             lastFaustFingerprint = faustFingerprint;
+            // optimizeLevel: 1 (not 0). At -O0, AS emits per-private-field
+            // get/set accessor wasm functions and routes every `this.X`
+            // read through them — for DSPs like master_me with hundreds of
+            // internal state variables, that's ~1400 extra wasm functions
+            // and per-sample function-call overhead big enough to choke
+            // real-time playback. -O1 inlines the accessors and hoists
+            // invariant property loads out of hot loops, fixing it.
+            // Compile time goes from ~80ms to ~600ms for typical songs
+            // and ~200ms→~1700ms for a heavy 7-channel DX7 set — still
+            // interactive for live-coding.
             const { stderr, text, binary } = await compileAssemblyScript(assemblyscriptsynthsources,
-                { "runtime": "stub", "optimizeLevel": 0, "shrinkLevel": 0 },
+                { "runtime": "stub", "optimizeLevel": 1, "shrinkLevel": 0 },
                 index_source);
 
             postMessage({

--- a/wasmaudioworklet/synth1/browsersynthcompiler.js
+++ b/wasmaudioworklet/synth1/browsersynthcompiler.js
@@ -28,11 +28,19 @@ export async function compileWebAssemblySynth(synthsource, song, samplerate, exp
                     resolve(null);
                 }
             };
+            // Pick up the live-compile optimize level from localStorage so
+            // the "Optimize AssemblyScript" toolbar checkbox can flip
+            // between fast-compile (-O0) and small-wasm (-O1) without an
+            // app reload. Export compiles ignore this and always use -O3.
+            const storedOpt = typeof localStorage !== 'undefined'
+                ? localStorage.getItem('asOptimizeLevel') : null;
+            const optimizeLevel = storedOpt !== null ? Number(storedOpt) : 1;
             worker.postMessage({
                 synthsource: synthsource,
                 samplerate: samplerate,
                 song: song,
                 exportmode: exportmode,
+                optimizeLevel,
                 // Map of basename -> .ts contents for transpiled faust sources
                 // from wasm-git's faust/ folder. Injected as faust/<name>.ts
                 // into the AS sources map so the user's mix can do


### PR DESCRIPTION
Two unrelated additions for the IFC 2026 concert work.

## 1. "Optimize AssemblyScript" toolbar checkbox

A new checkbox next to *visualizer* that toggles the live-compile optimization level between `-O0` (fast compile, bloated wasm) and `-O1` (slower compile, inlined hot paths). Default: on (`-O1`, matching the previous hard-coded value). Choice persists in `localStorage.asOptimizeLevel` so it survives reloads.

**Why it matters:** at `-O0`, AS emits get/set accessor wasm functions for every private class field and routes every `this.X` read through them. For light DSPs (a sine synth) the cost is negligible. For heavy DSPs like `master_me` (~700 internal Faust state fields, hundreds of per-sample reads) it adds ~1400 extra wasm functions and per-sample function-call overhead big enough to choke real-time playback. At `-O1` AS inlines the accessors and hoists invariant property loads out of hot loops.

| Live compile (concert songs) | -O0 | -O1 |
| --- | --- | --- |
| monstertheme | 84 ms | 910 ms |
| noiseandmadness | 75 ms | 640 ms |
| dx7template (7-channel DX7) | 203 ms | 1708 ms |

Letting the user flip this on a session-by-session basis means:
- Rapid-iteration sessions on light DSPs stay fast.
- Heavy concert songs can opt into the slower compile when needed for playback headroom.

Export compiles still always use `-O3` regardless of the checkbox.

### Wiring

- `app.html.js` — new `<input id="toggleOptimizeAsCheckbox">` next to the existing toolbar toggles.
- `audioworkletnode.js` — initializes the checkbox from `localStorage` on app boot, writes the new value on change.
- `synth1/browsersynthcompiler.js` — reads `localStorage.asOptimizeLevel` on every compile, forwards `optimizeLevel` to the worker.
- `synth1/browsercompilerwebworker.js` — honors `msg.data.optimizeLevel`, falls back to `1`.

## 2. `examples/dx7/sequence-to-patches.js`

Codegen tool that translates an NRPN-style DX7 song (e.g. `examples/dx7/dx7-sequence.js`) into typed-field patch assignments for a per-DSP modular transpile. Reads each transpiled algorithm's `_setParam` switch to extract the per-NRPN scaling expression and evaluates it at codegen time, emitting `channel.feedback = <f32>6.0079;` style lines.

Companion to the existing `examples/dx7/parse-rom.js`:

```
.syx → parse-rom.js → NRPN block (paste into song) → sequence-to-patches.js → typed-field block (paste into synth.ts)
```

Used to port `examples/dx7/dx7-sequence.js`'s full ROM1A patch set into the IFC 2026 concert's modular DX7 synth.

## Path not taken

This PR originally landed transpiler changes that emitted module globals for voice UI params (commit `aaba684`) and then `@inline` plain methods on the channel class (commit `12a69f3`) to dodge the `-O0` accessor overhead. Both worked in isolation but the module-globals approach forecloses multi-instance reuse, and neither solved the `master_me` problem — that DSP's overhead lives in its own private fields, not in transpiler-emitted channel params. Commit `67f1991` reverts both transpiler changes; the `-O1` bump is the actual fix (since extended in `1942a91` to be user-configurable). The transpiler ends up unchanged from master; the patch-generator tool remains.

## Test plan

- [x] Existing wtr suite (`npx wtr`): 51 passed / 3 skipped on Chromium.
- [x] All 7 IFC 2026 concert songs compile at `-O1` (offline asc check); sizes 13 KB–216 KB.
- [x] Faust2as compilation spec: dx7 + piano1 pass. Clarinet failure is pre-existing on master (unrelated transpiler bug).
- [ ] Manual: toggle the checkbox during a session, save a song, confirm compile time changes appropriately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)