### PR TITLE
faust transpiler: recognise StaticArray<T> SIG-class fields

### DIFF
--- a/wasmaudioworklet/e2e/saxophony-transpile.spec.js
+++ b/wasmaudioworklet/e2e/saxophony-transpile.spec.js
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Focused repro: call browser-transpile.js's transpileDspSource() directly
+// in the page context, with the user-reported saxophony.dsp as input.
+// No wasm-git / NEAR / service-worker setup — we want to isolate libfaust-wasm
+// behavior from the rest of the editor pipeline.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAXOPHONY_DSP_PATH = resolve(
+    __dirname,
+    '../../tools/claude-bridge/work/localhost_8080/ifc2026-concert.gitfactory.testnet/faust/physicalmodeling/faust-stk/saxophony.dsp'
+);
+const SAXOPHONY_DSP = readFileSync(SAXOPHONY_DSP_PATH, 'utf-8');
+
+test('saxophony.dsp transpiles in the browser via libfaust-wasm', async ({ page }) => {
+    const consoleMessages = [];
+    page.on('console', (m) => consoleMessages.push(`[${m.type()}] ${m.text()}`));
+    page.on('pageerror', (e) => consoleMessages.push(`[pageerror] ${e.message}`));
+
+    // Just need an origin that serves browser-transpile.js — no repo flow.
+    await page.goto('http://localhost:8080');
+
+    const result = await page.evaluate(async (dspSource) => {
+        try {
+            const bt = await import('./faust/browser-transpile.js');
+            const out = await bt.transpileDspSource(
+                dspSource,
+                'physicalmodeling/faust-stk/saxophony.dsp',
+                {} // no sibling libs — saxophony.dsp is alone in its folder
+            );
+            return { ok: true, className: out.className, ts: out.ts };
+        } catch (e) {
+            return { ok: false, message: e.message, stack: e.stack };
+        }
+    }, SAXOPHONY_DSP);
+
+    if (!result.ok) {
+        console.log('TRANSPILE FAILED — error message:');
+        console.log(result.message);
+        console.log('--- stack ---');
+        console.log(result.stack);
+        console.log('--- browser console (last 50 lines) ---');
+        console.log(consoleMessages.slice(-50).join('\n'));
+    } else {
+        console.log('Transpiled OK:', result.className, '— ts length', result.ts.length);
+    }
+
+    expect(result.ok).toBe(true);
+    expect(result.className).toBe('Saxophony');
+    expect(result.ts.length).toBeGreaterThan(1000);
+
+    // Regression: the SIG-table init function must declare every local
+    // helper array (sig0_iVec*, sig0_iRec*) before referencing it.
+    // Previously the regex only matched `i32[]` and missed
+    // `StaticArray<i32>`, so the body wrote to sig0_iVec3 without
+    // declaring it, then AS failed with TS2304.
+    const sigInitMatch = result.ts.match(/function\s+\w*_?initSIG0Tables\s*\([^)]*\)\s*:\s*void\s*\{([\s\S]*?)\n\}/);
+    expect(sigInitMatch, 'transpile output is missing an initSIG0Tables() function').not.toBeNull();
+    const sigInitBody = sigInitMatch[1];
+    const referencedHelpers = Array.from(sigInitBody.matchAll(/\bsig0_(\w+)\b/g)).map(m => m[1]);
+    for (const name of new Set(referencedHelpers)) {
+        const declRe = new RegExp(`\\b(?:const|let)\\s+sig0_${name}\\b`);
+        expect(declRe.test(sigInitBody), `sig0_${name} is referenced but not declared inside initSIG0Tables()`).toBe(true);
+    }
+});

--- a/wasmaudioworklet/faust/transpile-core.js
+++ b/wasmaudioworklet/faust/transpile-core.js
@@ -452,16 +452,26 @@ export function reshapeSIGInit(parsed, clsName, tablePrefix, sigPrefix) {
     }
 
     for (const sigClass of parsed.sigClasses) {
-        // Extract fields from SIG class (initializer is optional)
-        const sigFieldRegex = /^\s+(\w+):\s*(f32|i32)(\[\])?\s*(?:=\s*([^;]+))?;/gm;
+        // Extract fields from SIG class. libfaust's ASC backend emits two
+        // shapes:
+        //   • scalar:   "name: i32;" or "name: f32 = 1.0;"
+        //   • array:    "name: StaticArray<i32> = new StaticArray<i32>(N);"
+        //               or the legacy "name: i32[] = …;" form
+        // Both forms have to land as locals in _initSIG0Tables(); without
+        // the StaticArray branch the array helpers were referenced but
+        // never declared (TS2304).
+        const sigFieldRegex = /^\s+(\w+):\s*(?:StaticArray<(f32|i32)>|(f32|i32)(\[\])?)\s*(?:=\s*([^;]+))?;/gm;
         let m;
         while ((m = sigFieldRegex.exec(sigClass.body)) !== null) {
             const fieldName = m[1];
-            const type = m[2];
-            const isArray = !!m[3];
-            const init = m[4] ? m[4].trim() : null;
+            const staticArrayInner = m[2]; // set when type is StaticArray<T>
+            const scalarType = m[3];       // set when type is f32|i32 (with optional [])
+            const legacyArray = !!m[4];
+            const init = m[5] ? m[5].trim() : null;
             if (fieldName === 'fSampleRate') continue;
 
+            const type = staticArrayInner || scalarType;
+            const isArray = !!staticArrayInner || legacyArray;
             const localName = `sig0_${fieldName}`;
             if (isArray && init) {
                 const sizeMatch = init.match(/new\s+(?:Static)?Array<\w+>\((\d+)\)/);


### PR DESCRIPTION
## Summary

- Fix `transpile-core.js`'s SIG-class field regex to recognise libfaust-wasm ASC's `StaticArray<T> = new StaticArray<T>(N);` form (in addition to the legacy `i32[]`). Without this, helper arrays referenced inside the generated `_initSIG0Tables()` were never declared, and AS compiled with `TS2304: Cannot find name 'sig0_iVec3'` (or similar) for any DSP that uses SIG tables — saxophony.dsp and other faust-stk physical-modeling instruments being the visible cases.
- Add a focused Playwright regression test that drives `browser-transpile.js` with `saxophony.dsp` and structurally asserts every `sig0_*` referenced inside `_initSIG0Tables()` has a matching `const`/`let` declaration in the same scope. Future libfaust syntax shifts that re-break this will fail with a specific actionable message rather than a downstream AS error.

## Test plan

- [x] `npx playwright test e2e/saxophony-transpile.spec.js` — passes with the fix
- [x] Verified the test fails (with the expected `sig0_iVec3 is referenced but not declared inside initSIG0Tables()` assertion) when the regex change is reverted
- [x] Existing `e2e/faust2as-compilation.spec.js` dx7 + piano1 tests still pass (clarinet failure is pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)