### PR TITLE
claude-bridge: per-tab isolation, bidirectional sync, binary support, IDE IntelliSense

### DIFF
--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -44,7 +44,6 @@
 
 import { WebSocketServer } from 'ws';
 import { writeFile, readFile, mkdir, symlink, lstat, rm } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { watch } from 'node:fs';
 import { dirname, resolve, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -129,29 +128,40 @@ async function setupSubdirScaffolding(absSubdir) {
     }
 
     const tsconfigPath = join(absSubdir, 'tsconfig.json');
-    if (!existsSync(tsconfigPath)) {
-        // Relative path back to wasmaudioworklet/node_modules from work/<o>/<r>/
-        // is four levels up: ../../../../wasmaudioworklet/node_modules/...
-        const tsconfig = {
-            compilerOptions: {
-                baseUrl: '.',
-                allowJs: true,
-                checkJs: false,
-                noEmit: true,
-                moduleResolution: 'node',
-                target: 'es2020',
-                strict: false,
-                skipLibCheck: true,
-                preserveSymlinks: true,
-            },
-            include: ['**/*.ts', '**/*.d.ts'],
-            files: [
-                '../../../../wasmaudioworklet/node_modules/assemblyscript/std/assembly/index.d.ts',
-            ],
-            exclude: ['node_modules'],
-        };
+    // Absolute path to the AS std declarations — `f32`, `StaticArray<T>`,
+    // `Mathf`, etc. The previous relative form was off by one
+    // (`../../../..` landed in `tools/`, missing the repo root), so the
+    // IDE saw none of the AS built-ins and lit every file up with errors.
+    // work/ is gitignored so absolute paths don't hurt portability.
+    const asTypesPath = resolve(REPO_ROOT, 'wasmaudioworklet/node_modules/assemblyscript/std/assembly/index.d.ts');
+    const tsconfig = {
+        compilerOptions: {
+            baseUrl: '.',
+            allowJs: true,
+            checkJs: false,
+            noEmit: true,
+            moduleResolution: 'node',
+            target: 'es2020',
+            strict: false,
+            skipLibCheck: true,
+            // Preserve symlinks so files reached via the per-subdir
+            // mixes/synth/etc. symlinks keep that path for THEIR own
+            // imports — otherwise TS resolves through to the real engine
+            // tree and `../mixes/…` from those files no longer lines up.
+            preserveSymlinks: true,
+        },
+        include: ['**/*.ts', '**/*.d.ts'],
+        files: [asTypesPath],
+        exclude: ['node_modules'],
+    };
+    const desired = JSON.stringify(tsconfig, null, 2);
+    // Idempotent overwrite — fixes drift if a previous bridge version
+    // wrote a stale/incorrect path.
+    let existing = null;
+    try { existing = await readFile(tsconfigPath, 'utf8'); } catch (_) {}
+    if (existing !== desired) {
         try {
-            await writeFile(tsconfigPath, JSON.stringify(tsconfig, null, 2));
+            await writeFile(tsconfigPath, desired);
         } catch (e) {
             process.stderr.write(`[claude-bridge] tsconfig write failed in ${absSubdir}: ${e.message}\n`);
         }

--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -20,7 +20,7 @@
 // events that match are our own work and skipped.
 
 import { WebSocketServer } from 'ws';
-import { writeFile, readFile, mkdir, symlink, lstat, readdir, rm } from 'node:fs/promises';
+import { writeFile, readFile, mkdir, symlink, lstat } from 'node:fs/promises';
 import { watch } from 'node:fs';
 import { dirname, resolve, join, sep, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -172,24 +172,22 @@ wss.on('connection', (ws) => {
 
 async function handleTreeDump(msg) {
     if (!Array.isArray(msg.files)) return;
-    // Clear any OPFS-managed leftover before laying down the fresh snapshot,
-    // so work/ always matches what the browser actually has in OPFS — no
-    // stale files from previous sessions / other songs.
-    const cleared = await clearOpfsContents();
-    if (cleared > 0) {
-        process.stderr.write(`[claude-bridge] tree_dump: cleared ${cleared} stale entry/entries\n`);
-    }
+    // Upsert only — don't wipe. Files added to work/ from the host side
+    // (gitignored binaries, user notes, etc.) would otherwise vanish on the
+    // next tree_dump if OPFS doesn't have them. Trade-off: stale files from
+    // an earlier song/repo stick around until manually removed.
     let written = 0;
+    let unchanged = 0;
     for (const f of msg.files) {
         if (!isSafeRelPath(f.path)) continue;
         try {
-            await writeMirrorFile(f.path, f.content, !!f.binary);
-            written++;
+            const wrote = await writeMirrorFile(f.path, f.content, !!f.binary);
+            if (wrote) written++; else unchanged++;
         } catch (e) {
             process.stderr.write(`[claude-bridge] tree_dump: skipped ${f.path}: ${e.message}\n`);
         }
     }
-    process.stderr.write(`[claude-bridge] tree_dump: wrote ${written}/${msg.files.length} file(s)\n`);
+    process.stderr.write(`[claude-bridge] tree_dump: wrote ${written}, unchanged ${unchanged}, of ${msg.files.length}\n`);
 }
 
 // Paths in work/ that the bridge considers OPFS-managed (i.e. round-trip
@@ -200,30 +198,6 @@ function isOpfsManagedPath(relPath) {
     if (relPath === '_state.json' || relPath === 'tsconfig.json') return false;
     if (relPath.startsWith('synth1/assembly/') || relPath === 'synth1/assembly') return false;
     return true;
-}
-
-// Remove every OPFS-managed file/dir under work/ so a fresh tree_dump
-// produces a 1:1 mirror. Bridge-private files (tsconfig.json,
-// _state.json) and the (currently empty) `synth1/assembly/` path stay.
-async function clearOpfsContents() {
-    let removed = 0;
-    let entries;
-    try { entries = await readdir(WORK_DIR, { withFileTypes: true }); } catch (_e) { return 0; }
-    for (const entry of entries) {
-        const relPath = entry.name;
-        if (!isOpfsManagedPath(relPath)) continue;
-        const full = join(WORK_DIR, entry.name);
-        try {
-            await rm(full, { recursive: true, force: true });
-            removed++;
-        } catch (e) {
-            process.stderr.write(`[claude-bridge] could not remove ${relPath}: ${e.message}\n`);
-        }
-    }
-    // Tracking state is invalidated by the wipe.
-    mirroredFiles.clear();
-    lastWritten.clear();
-    return removed;
 }
 
 function handleEditorState(msg) {
@@ -247,19 +221,22 @@ function isSafeRelPath(p) {
 
 async function writeMirrorFile(opfsPath, content, binary) {
     if (!isSafeRelPath(opfsPath)) throw new Error(`unsafe path: ${opfsPath}`);
-    // Mirror at the OPFS path — work/ matches OPFS 1:1.
     const filePath = join(WORK_DIR, opfsPath);
-    await mkdir(dirname(filePath), { recursive: true });
-    if (binary) {
-        const buf = Buffer.from(content, 'base64');
-        lastWritten.set(filePath, content); // store base64 form for compare
-        mirroredFiles.set(filePath, opfsPath);
-        await writeFile(filePath, buf);
-    } else {
+    // Skip identical re-writes so we don't touch mode/mtime — otherwise
+    // wasm-git shows spurious "modified" entries in git status.
+    const existing = await readFile(filePath).catch(() => null);
+    const existingEncoded = existing
+        ? (binary ? existing.toString('base64') : existing.toString('utf8'))
+        : null;
+    mirroredFiles.set(filePath, opfsPath);
+    if (existingEncoded === content) {
         lastWritten.set(filePath, content);
-        mirroredFiles.set(filePath, opfsPath);
-        await writeFile(filePath, content);
+        return false;
     }
+    await mkdir(dirname(filePath), { recursive: true });
+    lastWritten.set(filePath, content);
+    await writeFile(filePath, binary ? Buffer.from(content, 'base64') : content);
+    return true;
 }
 
 async function writeState() {

--- a/tools/claude-bridge/relay.js
+++ b/tools/claude-bridge/relay.js
@@ -1,41 +1,61 @@
 #!/usr/bin/env node
-// Local relay that mirrors the web app's OPFS-backed wasm-git working tree to
-// `tools/claude-bridge/work/`. Claude Code (or any host-side editor) edits the
-// files there with its normal tools; the relay syncs both directions over
-// WebSocket.
+// Local relay that mirrors each browser tab's OPFS-backed wasm-git working
+// tree to a per-tab subfolder under `tools/claude-bridge/work/`. Claude
+// Code (or any host-side editor) edits the files there with its normal
+// tools; the relay syncs both directions over WebSocket.
+//
+// Per-tab isolation: the layout is
+//     work/<origin>/<repoName>/<repo-tree>
+// where `origin` is the browser host:port and `repoName` is the OPFS repo
+// directory (typically the gitrepo URL query). The client sends both as a
+// `hello` message immediately on connect; the relay derives the subdir
+// from that and any further messages for that client are scoped to it.
+// Tabs on different origins or repos therefore can't trample each other.
+//
+// OPFS is the source of truth. The host mirror is a view on it. Both
+// sides can edit, both sides can delete — the relay propagates either
+// direction:
+//   - host write/delete → relay → client → OPFS
+//   - OPFS write/delete → client tree_dump → relay → host mirror
 //
 // Protocol (browser <-> relay, JSON over WS):
 //   browser -> relay
+//     { type: 'hello', origin, repoName }
+//         First message; assigns this connection a subdir.
 //     { type: 'tree_dump', files: [{ path, content, binary }] }
-//         Full snapshot — sent on connect once the wasm-git client is ready.
+//         Full snapshot of the OPFS tree. The relay diffs against the
+//         subdir's previously-known path set and removes any host files
+//         that have dropped out of OPFS — that's how OPFS deletions
+//         propagate.
 //     { type: 'file_changed', path, content, binary }
 //         A single file write originating in the browser.
 //     { type: 'editor_state', editor, path, cursor, selection, language }
 //         Editor cursor/selection metadata. Persisted to `_state.json`.
 //   relay -> browser
 //     { type: 'apply_file', path, content, binary }
-//         A single mirror-file changed in `work/` (e.g. by Claude Code).
+//         A single mirror file changed in this client's subdir.
+//     { type: 'apply_delete', path }
+//         A single mirror file was deleted in this client's subdir.
 //
 // Echo prevention: every write records the bytes in `lastWritten`; fs.watch
-// events that match are our own work and skipped.
+// events that match are our own work and skipped. Likewise, `recentDeletes`
+// holds paths we removed in response to an OPFS-side drop, so the matching
+// fs.watch unlink event doesn't bounce back as `apply_delete`.
 
 import { WebSocketServer } from 'ws';
-import { writeFile, readFile, mkdir, symlink, lstat } from 'node:fs/promises';
+import { writeFile, readFile, mkdir, symlink, lstat, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { watch } from 'node:fs';
-import { dirname, resolve, join, sep, relative } from 'node:path';
+import { dirname, resolve, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WORK_DIR = resolve(__dirname, 'work');
-const STATE_FILE = join(WORK_DIR, '_state.json');
 const WS_PORT = Number(process.env.CLAUDE_BRIDGE_PORT) || 17890;
 
-// On-disk location of the wasm-music AS runtime. The synth source at
-// `work/<name>.ts` imports things like `../mixes/globalimports`, and TS
-// does NOT consult tsconfig `paths` for relative imports — so to make
-// those resolve we drop a few symlinks one level above `work/` (i.e. into
-// the bridge package directory itself), and the user's file's `..`
-// traversal lands on them. work/ itself stays a clean OPFS mirror.
+// Engine source root. Per-subdir symlinks point at these so user files
+// like `synth.ts` can do `import {…} from '../mixes/globalimports'` and
+// have it resolve in the editor.
 const REPO_ROOT = resolve(__dirname, '../..');
 const AS_LIB_ROOT = resolve(REPO_ROOT, 'wasmaudioworklet/synth1/assembly');
 const RUNTIME_LINKS = [
@@ -48,90 +68,96 @@ const RUNTIME_LINKS = [
     'fx',
     'mixes',
 ];
-
-// Editor cursor/selection per editor id, persisted to _state.json.
-let activeEditor = null;
-const editorMeta = {}; // id -> { path, cursor, selection, language, language }
-// Echo guard: text content (or base64 for binary) we last wrote per absolute path.
-const lastWritten = new Map();
-// Mirror files we've written, mapped back to their OPFS path. Watcher events
-// for paths NOT in this map (e.g. host edits inside the symlinked AS runtime)
-// are ignored — only bridge-owned files round-trip to the browser.
-const mirroredFiles = new Map(); // absMirrorPath -> opfsPath
+// Names the bridge owns at the root of each subdir — never round-trip
+// these to OPFS, and skip them in fs.watch.
+const BRIDGE_PRIVATE = new Set([
+    ...RUNTIME_LINKS,
+    '_state.json',
+    'tsconfig.json',
+]);
 
 await mkdir(WORK_DIR, { recursive: true });
-await setupRuntimeLinks();
-await writeTsconfig();
 
-// Drop symlinks for the AS runtime modules at the bridge-package level —
-// one directory above WORK_DIR — so relative imports like
-// `../mixes/globalimports` from `work/<synth>.ts` land on them. Symlinks
-// for things that change (the faust mirror) point back into work/.
-async function setupRuntimeLinks() {
+// Per-subdir state shared across all tabs of the same origin+repo.
+//   knownFromOpfs : paths the relay knows are (or have been) in OPFS, so it
+//                   can detect host-side deletions of OPFS-managed files
+//                   vs. host-only files (never round-tripped) and tell
+//                   them apart.
+//   clients       : set of WS connections bound to this subdir.
+const subdirState = new Map(); // absSubdir -> { knownFromOpfs, clients, editorMeta, activeEditor }
+// Per-WS connection metadata — assigned on `hello`.
+const wsMeta = new WeakMap(); // ws -> { subdir, origin, repoName }
+
+// Echo guards. fs.watch fires after our own writes; skip those.
+const lastWritten = new Map(); // absPath -> encoded content
+const recentDeletes = new Set(); // absPath set briefly after our own unlinks
+
+// macOS/Linux differ on what filenames are safe. Strip the few characters
+// that cause path-handling headaches; everything else passes through.
+function sanitizeSegment(s) {
+    return String(s).replace(/[/\\:*?"<>|]/g, '_').replace(/^\.+/, '_');
+}
+
+function getOrCreateSubdirState(absSubdir) {
+    let s = subdirState.get(absSubdir);
+    if (!s) {
+        s = {
+            knownFromOpfs: new Set(),
+            clients: new Set(),
+            editorMeta: {},
+            activeEditor: null,
+        };
+        subdirState.set(absSubdir, s);
+    }
+    return s;
+}
+
+// Drop runtime symlinks + tsconfig + .gitignore into a subdir at first use
+// so the IDE can resolve `../mixes/…` etc. from files inside.
+async function setupSubdirScaffolding(absSubdir) {
+    await mkdir(absSubdir, { recursive: true });
+
     for (const rel of RUNTIME_LINKS) {
-        const link = join(__dirname, rel);
-        const target = join(AS_LIB_ROOT, rel);
+        const link = join(absSubdir, rel);
         const st = await lstat(link).catch(() => null);
-        if (st) continue; // already in place (symlink, dir, or file) — don't overwrite
+        if (st) continue;
         try {
-            await symlink(target, link);
+            await symlink(join(AS_LIB_ROOT, rel), link);
         } catch (e) {
-            process.stderr.write(`[claude-bridge] symlink ${rel} failed: ${e.message}\n`);
+            process.stderr.write(`[claude-bridge] symlink ${rel} failed in ${absSubdir}: ${e.message}\n`);
         }
     }
-    // faust/ lives inside work/ as part of the OPFS mirror. Make it
-    // reachable via `..` from work/ files too.
-    const faustLink = join(__dirname, 'faust');
-    const stFaust = await lstat(faustLink).catch(() => null);
-    if (!stFaust) {
+
+    const tsconfigPath = join(absSubdir, 'tsconfig.json');
+    if (!existsSync(tsconfigPath)) {
+        // Relative path back to wasmaudioworklet/node_modules from work/<o>/<r>/
+        // is four levels up: ../../../../wasmaudioworklet/node_modules/...
+        const tsconfig = {
+            compilerOptions: {
+                baseUrl: '.',
+                allowJs: true,
+                checkJs: false,
+                noEmit: true,
+                moduleResolution: 'node',
+                target: 'es2020',
+                strict: false,
+                skipLibCheck: true,
+                preserveSymlinks: true,
+            },
+            include: ['**/*.ts', '**/*.d.ts'],
+            files: [
+                '../../../../wasmaudioworklet/node_modules/assemblyscript/std/assembly/index.d.ts',
+            ],
+            exclude: ['node_modules'],
+        };
         try {
-            await symlink(join(WORK_DIR, 'faust'), faustLink);
+            await writeFile(tsconfigPath, JSON.stringify(tsconfig, null, 2));
         } catch (e) {
-            process.stderr.write(`[claude-bridge] faust symlink failed: ${e.message}\n`);
+            process.stderr.write(`[claude-bridge] tsconfig write failed in ${absSubdir}: ${e.message}\n`);
         }
     }
 }
 
-// Minimal tsconfig.json so the editor picks up the AS built-in types
-// (straight from the upstream `assemblyscript` package's declaration
-// file — no hand-maintained shim) and uses Node module resolution. No
-// `paths` — TS ignores them for relative imports; the symlinks one
-// level above work/ do the resolution.
-async function writeTsconfig() {
-    const tsconfig = {
-        compilerOptions: {
-            baseUrl: '.',
-            allowJs: true,
-            checkJs: false,
-            noEmit: true,
-            moduleResolution: 'node',
-            target: 'es2020',
-            // AS allows things TS rejects (boolean<->number casts, etc.);
-            // we want IntelliSense, not a strict TS lint of AS source.
-            strict: false,
-            skipLibCheck: true,
-            // Preserve symlinks so a file reached through
-            // `tools/claude-bridge/faust/...` (sibling symlink) keeps that
-            // path for its OWN relative imports — otherwise TS resolves
-            // it back to `work/faust/...` and `../../../mixes/...` no
-            // longer points at the on-disk AS runtime.
-            preserveSymlinks: true,
-        },
-        include: ['**/*.ts', '**/*.d.ts'],
-        // Pull in AS's own type declarations for f32 / StaticArray / Mathf
-        // / etc. straight from the engine's installed `assemblyscript`
-        // package.
-        files: ['../../../wasmaudioworklet/node_modules/assemblyscript/std/assembly/index.d.ts'],
-        exclude: ['node_modules'],
-    };
-    try {
-        await writeFile(join(WORK_DIR, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
-    } catch (e) {
-        process.stderr.write(`[claude-bridge] could not write tsconfig.json: ${e.message}\n`);
-    }
-}
-
-const clients = new Set();
 const wss = new WebSocketServer({ port: WS_PORT });
 
 wss.on('listening', () => {
@@ -140,8 +166,7 @@ wss.on('listening', () => {
 });
 
 wss.on('connection', (ws) => {
-    clients.add(ws);
-    process.stderr.write(`[claude-bridge] client connected (${clients.size} total)\n`);
+    process.stderr.write(`[claude-bridge] client connected (awaiting hello)\n`);
 
     ws.on('message', async (data) => {
         let msg;
@@ -152,13 +177,22 @@ wss.on('connection', (ws) => {
             return;
         }
         try {
+            if (msg.type === 'hello') {
+                await handleHello(ws, msg);
+                return;
+            }
+            const meta = wsMeta.get(ws);
+            if (!meta) {
+                process.stderr.write(`[claude-bridge] message before hello: ${msg.type}\n`);
+                return;
+            }
             if (msg.type === 'tree_dump') {
-                await handleTreeDump(msg);
+                await handleTreeDump(meta.subdir, msg);
             } else if (msg.type === 'file_changed') {
-                await writeMirrorFile(msg.path, msg.content, !!msg.binary);
+                await handleFileChanged(meta.subdir, msg);
             } else if (msg.type === 'editor_state') {
-                handleEditorState(msg);
-                await writeState();
+                handleEditorState(meta.subdir, msg);
+                await writeState(meta.subdir);
             }
         } catch (e) {
             process.stderr.write(`[claude-bridge] handler failed (${msg.type}): ${e.message}\n`);
@@ -166,52 +200,85 @@ wss.on('connection', (ws) => {
     });
 
     ws.on('close', () => {
-        clients.delete(ws);
+        const meta = wsMeta.get(ws);
+        if (meta) {
+            const s = subdirState.get(meta.subdir);
+            if (s) s.clients.delete(ws);
+            wsMeta.delete(ws);
+        }
     });
 });
 
-async function handleTreeDump(msg) {
+async function handleHello(ws, msg) {
+    const origin = sanitizeSegment(msg.origin || '_unknown_origin');
+    const repoName = sanitizeSegment(msg.repoName || '_unknown_repo');
+    const subdir = join(WORK_DIR, origin, repoName);
+    await setupSubdirScaffolding(subdir);
+    const s = getOrCreateSubdirState(subdir);
+    s.clients.add(ws);
+    wsMeta.set(ws, { subdir, origin, repoName });
+    process.stderr.write(`[claude-bridge] hello — ${origin}/${repoName} (${s.clients.size} client(s) in subdir)\n`);
+}
+
+async function handleTreeDump(subdir, msg) {
     if (!Array.isArray(msg.files)) return;
-    // Upsert only — don't wipe. Files added to work/ from the host side
-    // (gitignored binaries, user notes, etc.) would otherwise vanish on the
-    // next tree_dump if OPFS doesn't have them. Trade-off: stale files from
-    // an earlier song/repo stick around until manually removed.
+    const s = getOrCreateSubdirState(subdir);
+    const newPaths = new Set();
     let written = 0;
     let unchanged = 0;
     for (const f of msg.files) {
         if (!isSafeRelPath(f.path)) continue;
+        if (BRIDGE_PRIVATE.has(f.path.split('/')[0])) continue; // refuse to overwrite scaffolding
+        newPaths.add(f.path);
         try {
-            const wrote = await writeMirrorFile(f.path, f.content, !!f.binary);
+            const wrote = await writeMirrorFile(subdir, f.path, f.content, !!f.binary);
             if (wrote) written++; else unchanged++;
         } catch (e) {
             process.stderr.write(`[claude-bridge] tree_dump: skipped ${f.path}: ${e.message}\n`);
         }
     }
-    process.stderr.write(`[claude-bridge] tree_dump: wrote ${written}, unchanged ${unchanged}, of ${msg.files.length}\n`);
+    // OPFS → host deletion: anything we previously knew about but isn't in
+    // this dump has been removed from OPFS. Delete from the mirror too.
+    let deleted = 0;
+    for (const oldPath of s.knownFromOpfs) {
+        if (newPaths.has(oldPath)) continue;
+        try {
+            const abs = join(subdir, oldPath);
+            recentDeletes.add(abs);
+            setTimeout(() => recentDeletes.delete(abs), 1000);
+            await rm(abs, { force: true });
+            deleted++;
+        } catch (e) {
+            process.stderr.write(`[claude-bridge] tree_dump: could not delete ${oldPath}: ${e.message}\n`);
+        }
+    }
+    s.knownFromOpfs = newPaths;
+    process.stderr.write(
+        `[claude-bridge] tree_dump: ${msg.files.length} files (wrote ${written}, unchanged ${unchanged}, deleted ${deleted})\n`
+    );
 }
 
-// Paths in work/ that the bridge considers OPFS-managed (i.e. round-trip
-// to the browser). Bridge-private files like _state.json, tsconfig.json
-// — plus anything under synth1/assembly/ if a stray host-side write
-// somehow lands there — stay out.
-function isOpfsManagedPath(relPath) {
-    if (relPath === '_state.json' || relPath === 'tsconfig.json') return false;
-    if (relPath.startsWith('synth1/assembly/') || relPath === 'synth1/assembly') return false;
-    return true;
+async function handleFileChanged(subdir, msg) {
+    if (!isSafeRelPath(msg.path)) return;
+    if (BRIDGE_PRIVATE.has(msg.path.split('/')[0])) return;
+    const s = getOrCreateSubdirState(subdir);
+    s.knownFromOpfs.add(msg.path);
+    await writeMirrorFile(subdir, msg.path, msg.content, !!msg.binary);
 }
 
-function handleEditorState(msg) {
+function handleEditorState(subdir, msg) {
     if (!msg.editor) return;
-    editorMeta[msg.editor] = {
+    const s = getOrCreateSubdirState(subdir);
+    s.editorMeta[msg.editor] = {
         path: msg.path ?? null,
         cursor: msg.cursor ?? null,
         selection: msg.selection ?? null,
         language: msg.language ?? null,
     };
-    activeEditor = msg.editor;
+    s.activeEditor = msg.editor;
 }
 
-// Reject paths that escape WORK_DIR or use Windows separators / abs paths.
+// Reject paths that escape the subdir or use Windows separators / abs paths.
 function isSafeRelPath(p) {
     if (typeof p !== 'string' || p.length === 0) return false;
     if (p.startsWith('/') || p.includes('\\')) return false;
@@ -219,16 +286,15 @@ function isSafeRelPath(p) {
     return true;
 }
 
-async function writeMirrorFile(opfsPath, content, binary) {
+async function writeMirrorFile(subdir, opfsPath, content, binary) {
     if (!isSafeRelPath(opfsPath)) throw new Error(`unsafe path: ${opfsPath}`);
-    const filePath = join(WORK_DIR, opfsPath);
+    const filePath = join(subdir, opfsPath);
     // Skip identical re-writes so we don't touch mode/mtime — otherwise
-    // wasm-git shows spurious "modified" entries in git status.
+    // wasm-git would show spurious "modified" entries in git status.
     const existing = await readFile(filePath).catch(() => null);
     const existingEncoded = existing
         ? (binary ? existing.toString('base64') : existing.toString('utf8'))
         : null;
-    mirroredFiles.set(filePath, opfsPath);
     if (existingEncoded === content) {
         lastWritten.set(filePath, content);
         return false;
@@ -239,48 +305,53 @@ async function writeMirrorFile(opfsPath, content, binary) {
     return true;
 }
 
-async function writeState() {
-    const state = { activeEditor, editors: editorMeta };
+async function writeState(subdir) {
+    const s = getOrCreateSubdirState(subdir);
+    const state = { activeEditor: s.activeEditor, editors: s.editorMeta };
     try {
-        await writeFile(STATE_FILE, JSON.stringify(state, null, 2));
+        await writeFile(join(subdir, '_state.json'), JSON.stringify(state, null, 2));
     } catch (e) {
         process.stderr.write(`[claude-bridge] state write failed: ${e.message}\n`);
     }
 }
 
-// Recursive watch of WORK_DIR. macOS supports recursive natively; on Linux,
-// fs.watch with recursive is best-effort. Files already tracked in
-// `mirroredFiles` round-trip back to the browser; new files dropped into
-// the OPFS namespace by the host (e.g. a new `.dsp` in `work/faust/...`)
-// are adopted and broadcast too. Anything outside the OPFS namespace
-// (private bridge files, synth1/assembly/* if anything slips in) is
-// ignored.
+// Recursive watch of WORK_DIR. Each event's filename is relative to
+// WORK_DIR — first two segments are <origin>/<repoName>. We look up the
+// subdir's state and broadcast to its clients only.
 watch(WORK_DIR, { recursive: true }, async (_eventType, filename) => {
     if (!filename) return;
     const relPath = filename.split(sep).join('/');
-    if (!isSafeRelPath(relPath)) return;
-    if (!isOpfsManagedPath(relPath)) return;
+    const parts = relPath.split('/');
+    if (parts.length < 3) return; // events at work/, work/<origin>/ — no subdir yet
+    const subdir = join(WORK_DIR, parts[0], parts[1]);
+    const opfsPath = parts.slice(2).join('/');
+    if (!isSafeRelPath(opfsPath)) return;
+    if (BRIDGE_PRIVATE.has(opfsPath.split('/')[0])) return;
 
-    const filePath = join(WORK_DIR, relPath);
-    let opfsPath = mirroredFiles.get(filePath);
-    if (!opfsPath) {
-        // New host-side file — adopt it under its mirror path.
-        opfsPath = relPath;
-    }
+    const filePath = join(subdir, opfsPath);
+    const s = subdirState.get(subdir);
+    if (!s) return; // no client has identified itself for this subdir yet
+
+    if (recentDeletes.has(filePath)) return; // our own delete
 
     let buf;
     try {
         buf = await readFile(filePath);
     } catch (_e) {
-        return; // file may have been deleted/replaced mid-event
+        // File no longer exists → treat as delete.
+        if (lastWritten.has(filePath)) lastWritten.delete(filePath);
+        if (!s.knownFromOpfs.has(opfsPath)) return; // host-only file, never sent to OPFS
+        s.knownFromOpfs.delete(opfsPath);
+        broadcastApplyDelete(s, opfsPath);
+        return;
     }
 
     const binary = isLikelyBinary(opfsPath);
     const encoded = binary ? buf.toString('base64') : buf.toString('utf8');
     if (lastWritten.get(filePath) === encoded) return; // our own write
     lastWritten.set(filePath, encoded);
-    mirroredFiles.set(filePath, opfsPath);
-    broadcastApplyFile(opfsPath, encoded, binary);
+    s.knownFromOpfs.add(opfsPath);
+    broadcastApplyFile(s, opfsPath, encoded, binary);
 });
 
 const BINARY_EXTS = new Set([
@@ -294,13 +365,24 @@ function isLikelyBinary(p) {
     return BINARY_EXTS.has(ext);
 }
 
-function broadcastApplyFile(path, content, binary) {
+function broadcastApplyFile(s, path, content, binary) {
     const payload = JSON.stringify({ type: 'apply_file', path, content, binary });
     let delivered = 0;
-    for (const c of clients) {
+    for (const c of s.clients) {
         if (c.readyState !== c.OPEN) continue;
         c.send(payload);
         delivered++;
     }
     process.stderr.write(`[claude-bridge] apply_file ${path} → ${delivered} client(s)\n`);
+}
+
+function broadcastApplyDelete(s, path) {
+    const payload = JSON.stringify({ type: 'apply_delete', path });
+    let delivered = 0;
+    for (const c of s.clients) {
+        if (c.readyState !== c.OPEN) continue;
+        c.send(payload);
+        delivered++;
+    }
+    process.stderr.write(`[claude-bridge] apply_delete ${path} → ${delivered} client(s)\n`);
 }

--- a/wasmaudioworklet/claude-bridge-client.js
+++ b/wasmaudioworklet/claude-bridge-client.js
@@ -32,8 +32,12 @@ class ClaudeBridgeClient {
         this.reconnectTimer = null;
         this.warned = false;
         this.url = `ws://localhost:${DEFAULT_PORT}`;
-        this.git = null; // { listfiles, readfile, writefileandstage }
+        this.git = null; // { listfiles, readfile, writefileandstage, unlinkfile }
         this.treeSynced = false;
+        // Repo identity: origin (host:port) + repoName (OPFS repo dir name).
+        // The relay uses these to isolate this tab into work/<origin>/<repo>/
+        // so other tabs (different repos / origins) don't share state.
+        this.identity = null; // { origin, repoName }
     }
 
     start() {
@@ -41,8 +45,15 @@ class ClaudeBridgeClient {
         this._connect();
     }
 
-    attachGitRepo({ listfiles, readfile, writefileandstage }) {
-        this.git = { listfiles, readfile, writefileandstage };
+    setRepoIdentity({ origin, repoName }) {
+        this.identity = { origin, repoName };
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+            this._sendHello();
+        }
+    }
+
+    attachGitRepo({ listfiles, readfile, writefileandstage, unlinkfile }) {
+        this.git = { listfiles, readfile, writefileandstage, unlinkfile };
         if (this.ws && this.ws.readyState === WebSocket.OPEN) {
             this._sendTreeDump().catch((e) => console.warn('[claude-bridge] tree_dump failed', e));
         }
@@ -85,6 +96,9 @@ class ClaudeBridgeClient {
         this.ws.addEventListener('open', () => {
             this.warned = false;
             this.treeSynced = false;
+            // Identify the repo first; relay needs to know the subdir before
+            // any tree_dump / file_changed arrives.
+            this._sendHello();
             if (this.git) {
                 this._sendTreeDump().catch((e) => console.warn('[claude-bridge] tree_dump failed', e));
             }
@@ -106,7 +120,11 @@ class ClaudeBridgeClient {
         this.ws.addEventListener('message', (ev) => {
             let msg;
             try { msg = JSON.parse(ev.data); } catch (_e) { return; }
-            if (msg.type === 'apply_file') this._applyFile(msg).catch((e) => console.warn('[claude-bridge] apply_file failed', e));
+            if (msg.type === 'apply_file') {
+                this._applyFile(msg).catch((e) => console.warn('[claude-bridge] apply_file failed', e));
+            } else if (msg.type === 'apply_delete') {
+                this._applyDelete(msg).catch((e) => console.warn('[claude-bridge] apply_delete failed', e));
+            }
         });
     }
 
@@ -116,6 +134,18 @@ class ClaudeBridgeClient {
             this.reconnectTimer = null;
             this._connect();
         }, RECONNECT_MS);
+    }
+
+    _sendHello() {
+        if (!this.identity) return;
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        try {
+            this.ws.send(JSON.stringify({
+                type: 'hello',
+                origin: this.identity.origin,
+                repoName: this.identity.repoName,
+            }));
+        } catch (_e) { /* close handler will reconnect */ }
     }
 
     async _sendTreeDump() {
@@ -198,6 +228,18 @@ class ClaudeBridgeClient {
         } catch (_e) { /* ditto */ }
     }
 
+    // A mirror file was deleted on the host — propagate to OPFS.
+    async _applyDelete(msg) {
+        const path = msg.path;
+        if (!path || !this.git || typeof this.git.unlinkfile !== 'function') return;
+        try {
+            await this.git.unlinkfile(path);
+            console.info(`[claude-bridge] applied delete ${path}`);
+        } catch (e) {
+            console.warn('[claude-bridge] unlinkfile failed', path, e?.message || e);
+        }
+    }
+
     // A mirror file changed in work/ — write it back into OPFS and, if any
     // open editor is showing that path, refresh its buffer.
     async _applyFile(msg) {
@@ -206,7 +248,9 @@ class ClaudeBridgeClient {
         if (this.git) {
             try {
                 const payload = msg.binary ? base64ToBytes(msg.content) : msg.content;
-                await this.git.writefileandstage(path, payload);
+                // Bridge writes stay unstaged so "Discard changes" can roll
+                // them back — staging happens in bulk at commit time.
+                await this.git.writefileandstage(path, payload, { stage: false });
             } catch (e) {
                 console.warn('[claude-bridge] writefileandstage failed', path, e?.message || e);
             }

--- a/wasmaudioworklet/claude-bridge-client.js
+++ b/wasmaudioworklet/claude-bridge-client.js
@@ -128,13 +128,14 @@ class ClaudeBridgeClient {
             try {
                 const binary = isLikelyBinary(path);
                 if (binary) {
-                    // wasm-git readfile returns strings; skip binaries until we
-                    // have a clean way to pull raw bytes from OPFS.
-                    continue;
+                    const bytes = await this.git.readfile(path, undefined, { binary: true });
+                    if (!(bytes instanceof Uint8Array)) continue;
+                    files.push({ path, content: bytesToBase64(bytes), binary: true });
+                } else {
+                    const content = await this.git.readfile(path);
+                    if (typeof content !== 'string') continue;
+                    files.push({ path, content, binary: false });
                 }
-                const content = await this.git.readfile(path);
-                if (typeof content !== 'string') continue;
-                files.push({ path, content, binary: false });
             } catch (e) {
                 console.warn('[claude-bridge] tree_dump skip', path, e?.message || e);
             }
@@ -202,14 +203,16 @@ class ClaudeBridgeClient {
     async _applyFile(msg) {
         const path = msg.path;
         if (!path) return;
-        // Update OPFS via wasm-git (text only for now).
-        if (this.git && !msg.binary) {
+        if (this.git) {
             try {
-                await this.git.writefileandstage(path, msg.content);
+                const payload = msg.binary ? base64ToBytes(msg.content) : msg.content;
+                await this.git.writefileandstage(path, payload);
             } catch (e) {
                 console.warn('[claude-bridge] writefileandstage failed', path, e?.message || e);
             }
         }
+        // Binary files don't surface in editors; nothing more to do.
+        if (msg.binary) return;
         // Refresh any editor currently showing this path.
         for (const [id, entry] of this.editors) {
             const editorPath = typeof entry.getPath === 'function' ? entry.getPath() : entry.getPath;
@@ -223,6 +226,22 @@ class ClaudeBridgeClient {
             this._lastSentForEditor.set(id, { path, content: msg.content });
         }
     }
+}
+
+function bytesToBase64(bytes) {
+    let s = '';
+    const chunk = 0x8000; // avoid call-stack blow-up on large files
+    for (let i = 0; i < bytes.length; i += chunk) {
+        s += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return btoa(s);
+}
+
+function base64ToBytes(b64) {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
 }
 
 export const claudeBridge = new ClaudeBridgeClient();

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -7,7 +7,7 @@ import './webaudiomodules/preseteditor.js';
 import { setInstrumentNames, appendToSubtoolbar1 } from './app.js';
 import { toggleSpinner } from './common/ui/progress-spinner.js';
 
-import { readfile, writefileandstage, initWASMGitClient, addRemoteSyncListener, getConfig, listfiles } from './wasmgit/wasmgitclient.js';
+import { readfile, writefileandstage, unlinkfile, initWASMGitClient, addRemoteSyncListener, getConfig, listfiles } from './wasmgit/wasmgitclient.js';
 import { transpileDspSource } from './faust/browser-transpile.js';
 import { createPatternToolsGlobal } from './pattern_tools.js';
 import { modal, modalPrompt, modalAlert } from './common/ui/modal.js';
@@ -765,11 +765,16 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
 
         console.log(`loaded from gist ${gistid}: ${songfilename}`);
     } else if (gitrepoparam) {
-        gitrepoconfig = await initWASMGitClient(gitrepoparam.split('=')[1]);
+        const repoName = gitrepoparam.split('=')[1];
+        gitrepoconfig = await initWASMGitClient(repoName);
         appendToSubtoolbar1(document.createElement('wasmgit-ui'));
         // wasm-git is ready — connect the bridge and pull the full tree.
+        // Repo identity lets the relay isolate this tab into its own
+        // work/<origin>/<repo>/ subdir, so multiple tabs on different
+        // repos/origins don't fight over a shared mirror.
         claudeBridge.start();
-        claudeBridge.attachGitRepo({ listfiles, readfile, writefileandstage });
+        claudeBridge.setRepoIdentity({ origin: location.host, repoName });
+        claudeBridge.attachGitRepo({ listfiles, readfile, writefileandstage, unlinkfile });
 
         addRemoteSyncListener(async () => {
             // After a pull/commit, re-sync the bridge's mirror.

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -1,5 +1,5 @@
 import { loadScript, loadCSS } from './common/scriptloader.js';
-import { addedAudio, compileSong as compileMidiSong, convertEventListToByteArraySequence, createMultipatternSequence, getSongParts, instrumentNames as midiInstrumentNames } from './midisequencer/songcompiler.js';
+import { addedAudio, compileSong as compileMidiSong, convertEventListToByteArraySequence, createMultipatternSequence, getSongParts, instrumentNames as midiInstrumentNames, setOpfsBinaryReader } from './midisequencer/songcompiler.js';
 import { insertMidiRecording } from './midisequencer/editorfunctions.js';
 import { postSong as wamPostSong, exportWAMAudio } from './webaudiomodules/wammanager.js';
 import { insertRecording as insertRecording4klang } from './4klangsequencer/editorfunctions.js';
@@ -775,6 +775,10 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
         claudeBridge.start();
         claudeBridge.setRepoIdentity({ origin: location.host, repoName });
         claudeBridge.attachGitRepo({ listfiles, readfile, writefileandstage, unlinkfile });
+        // Let the song compiler resolve `addImage('foo.png')` etc. against
+        // OPFS without itself importing the wasm-git client — the embeddable
+        // songcompiler bundle stays free of bridge/wasm-git dependencies.
+        setOpfsBinaryReader((path) => readfile(path, 10000, { binary: true }));
 
         addRemoteSyncListener(async () => {
             // After a pull/commit, re-sync the bridge's mirror.

--- a/wasmaudioworklet/midisequencer/songcompiler.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.js
@@ -4,9 +4,11 @@ import { SEQ_MSG_LOOP, SEQ_MSG_START_RECORDING, SEQ_MSG_STOP_RECORDING, SEQ_MSG_
 import { setVideoSchedule } from '../visualizer/videoscheduler.js';
 
 // Map a URL to one suitable for assignment to <img>/<video>.src.
-// Repo-relative paths (no protocol, no leading slash) are read from OPFS via
-// the wasmgit client and exposed as blob URLs so they can be loaded by the
-// browser. Absolute and data: URLs are passed through unchanged.
+// Repo-relative paths (no protocol, no leading slash) are read via the host-
+// registered OPFS reader (see `setOpfsBinaryReader` below) and exposed as
+// blob URLs so the browser can load them. Absolute and data: URLs pass
+// through unchanged. The reader is injected rather than imported directly
+// so the embeddable songcompiler bundle doesn't drag in the wasm-git client.
 const MIME_BY_EXT = {
     jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
     gif: 'image/gif', webp: 'image/webp', svg: 'image/svg+xml',
@@ -21,11 +23,17 @@ function isRepoRelative(url) {
         && !url.startsWith('/')
         && !url.startsWith('//');
 }
+let _opfsBinaryReader = null;
+// Host registers an OPFS reader: `(path) => Promise<Uint8Array>`. The
+// editor wires this up to wasm-git's readfile; the embeddable bundle
+// leaves it null and falls through to literal URLs.
+export function setOpfsBinaryReader(reader) {
+    _opfsBinaryReader = reader;
+}
 async function resolveMediaUrl(url) {
-    if (!isRepoRelative(url)) return url;
+    if (!isRepoRelative(url) || !_opfsBinaryReader) return url;
     try {
-        const { readfile } = await import('../wasmgit/wasmgitclient.js');
-        const bytes = await readfile(url, 10000, { binary: true });
+        const bytes = await _opfsBinaryReader(url);
         if (!bytes) return url;
         const ext = url.split('.').pop().toLowerCase();
         const type = MIME_BY_EXT[ext] || 'application/octet-stream';

--- a/wasmaudioworklet/midisequencer/songcompiler.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.js
@@ -3,6 +3,39 @@ import { TrackerPattern, pitchbend, controlchange, createNoteFunctions, noteFunc
 import { SEQ_MSG_LOOP, SEQ_MSG_START_RECORDING, SEQ_MSG_STOP_RECORDING, SEQ_MSG_BROADCAST_SEND, SEQ_MSG_BROADCAST_WAIT } from './sequenceconstants.js';
 import { setVideoSchedule } from '../visualizer/videoscheduler.js';
 
+// Map a URL to one suitable for assignment to <img>/<video>.src.
+// Repo-relative paths (no protocol, no leading slash) are read from OPFS via
+// the wasmgit client and exposed as blob URLs so they can be loaded by the
+// browser. Absolute and data: URLs are passed through unchanged.
+const MIME_BY_EXT = {
+    jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+    gif: 'image/gif', webp: 'image/webp', svg: 'image/svg+xml',
+    mp4: 'video/mp4', webm: 'video/webm',
+    wav: 'audio/wav', mp3: 'audio/mpeg', flac: 'audio/flac',
+    ogg: 'audio/ogg', m4a: 'audio/mp4', aac: 'audio/aac',
+};
+function isRepoRelative(url) {
+    return typeof url === 'string'
+        && url.length > 0
+        && !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url) // no scheme
+        && !url.startsWith('/')
+        && !url.startsWith('//');
+}
+async function resolveMediaUrl(url) {
+    if (!isRepoRelative(url)) return url;
+    try {
+        const { readfile } = await import('../wasmgit/wasmgitclient.js');
+        const bytes = await readfile(url, 10000, { binary: true });
+        if (!bytes) return url;
+        const ext = url.split('.').pop().toLowerCase();
+        const type = MIME_BY_EXT[ext] || 'application/octet-stream';
+        return URL.createObjectURL(new Blob([bytes], { type }));
+    } catch (e) {
+        console.warn(`Could not resolve repo-relative media url '${url}' via OPFS, falling back to literal:`, e.message);
+        return url;
+    }
+}
+
 let songmessages = [];
 export let instrumentNames = [];
 
@@ -121,7 +154,7 @@ const songargs = {
             addedAudio.push(new Promise(async (resolve, reject) => {
                 const audioObj = { url: url };
                 try {
-                    const buf = await fetch(url)
+                    const buf = await fetch(await resolveMediaUrl(url))
                         .then(response => response.arrayBuffer())
                         .then(buffer => new AudioContext().decodeAudioData(buffer));
 
@@ -139,18 +172,21 @@ const songargs = {
         if (!addedVideo[name]) {
             const videoElement = document.createElement('video');
             videoElement.crossOrigin = 'anonymous';
-            videoElement.src = url;
             videoElement.autoplay = false;
             videoElement.muted = true;
+            // Register the entry before awaiting so sync startVideo() calls
+            // later in the song can find { schedule: [] } even if the OPFS
+            // blob-URL resolve hasn't settled yet.
             addedVideo[name] = { videoElement, schedule: [] };
+            videoElement.src = await resolveMediaUrl(url);
         }
     },
     'addImage': async (name, url, cache = true) => {
         if (!cache || !addedVideo[name]) {
             const imageElement = new Image();
             imageElement.crossOrigin = 'anonymous';
-            imageElement.src = url;
             addedVideo[name] = { imageElement, schedule: [] };
+            imageElement.src = await resolveMediaUrl(url);
         }
     },
     'note': (noteNumber, duration, velocity, offset) =>

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -259,9 +259,12 @@ export function updateCommitAndSyncButtonState(changes) {
 }
 
 // Pass a string for text files or a Uint8Array (or ArrayBuffer) for binary files.
-// The worker writes the bytes verbatim and then runs `git add`, which is a
-// silent no-op for paths matched by the repo's .gitignore.
-export async function writefileandstage(filename, contents) {
+// The worker writes the bytes verbatim and (by default) runs `git add`, which
+// is a silent no-op for paths matched by the repo's .gitignore.
+// Pass `{ stage: false }` to skip the auto-stage — used by the claude-bridge
+// so bridge-side edits show up as unstaged changes that "Discard changes"
+// can roll back via `git reset --hard HEAD`.
+export async function writefileandstage(filename, contents, { stage = true } = {}) {
     const isBinary = contents instanceof Uint8Array || contents instanceof ArrayBuffer;
     const payload = isBinary && contents instanceof ArrayBuffer ? new Uint8Array(contents) : contents;
     worker.postMessage({
@@ -269,7 +272,21 @@ export async function writefileandstage(filename, contents) {
         filename: filename,
         contents: payload,
         binary: isBinary,
+        stage,
     });
+    const result = await new Promise((resolve) =>
+        workerMessageListeners.push((msg) => msg.data.dircontents && msg.data.repoHasChanges !== undefined ? resolve(msg.data) : true)
+    );
+    updateCommitAndSyncButtonState(result.repoHasChanges);
+    return result.dircontents;
+}
+
+// Remove a file from OPFS. Idempotent — silent if the file doesn't exist.
+// The deletion is left unstaged; `git add -A` at commit time picks it up,
+// and "Discard changes" (git reset --hard HEAD) can restore the file. Used
+// by the claude-bridge for host→OPFS delete propagation.
+export async function unlinkfile(filename) {
+    worker.postMessage({ command: 'unlinkfile', filename });
     const result = await new Promise((resolve) =>
         workerMessageListeners.push((msg) => msg.data.dircontents && msg.data.repoHasChanges !== undefined ? resolve(msg.data) : true)
     );

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -208,10 +208,11 @@ export async function readfile(filename, timeoutMs = 10000, { binary = false } =
         workerMessageListeners.push((msg) => {
             if (msg.data.filename === filename) {
                 clearTimeout(timer);
-                resolve(msg.data.filecontents);
-            } else if (msg.data.error && !msg.data.id) {
-                clearTimeout(timer);
-                reject(new Error(msg.data.error));
+                if (msg.data.error) {
+                    reject(new Error(msg.data.error));
+                } else {
+                    resolve(msg.data.filecontents);
+                }
             } else {
                 return true;
             }

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -195,10 +195,11 @@ export async function commitAndSyncRemote(commitmessage) {
     return dircontents;
 }
 
-export async function readfile(filename, timeoutMs = 10000) {
+export async function readfile(filename, timeoutMs = 10000, { binary = false } = {}) {
     worker.postMessage({
         command: 'readfile',
-        filename: filename
+        filename: filename,
+        binary
     });
     return await new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
@@ -256,11 +257,17 @@ export function updateCommitAndSyncButtonState(changes) {
     }
 }
 
+// Pass a string for text files or a Uint8Array (or ArrayBuffer) for binary files.
+// The worker writes the bytes verbatim and then runs `git add`, which is a
+// silent no-op for paths matched by the repo's .gitignore.
 export async function writefileandstage(filename, contents) {
+    const isBinary = contents instanceof Uint8Array || contents instanceof ArrayBuffer;
+    const payload = isBinary && contents instanceof ArrayBuffer ? new Uint8Array(contents) : contents;
     worker.postMessage({
         command: 'writefileandstage',
         filename: filename,
-        contents: contents
+        contents: payload,
+        binary: isBinary,
     });
     const result = await new Promise((resolve) =>
         workerMessageListeners.push((msg) => msg.data.dircontents && msg.data.repoHasChanges !== undefined ? resolve(msg.data) : true)

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -117,9 +117,14 @@ onmessage = async (msg) => {
     }
     // WASMFS+OPFS does not truncate on writeFile — open with O_TRUNC, write, close
     const fd = FS.open(msg.data.filename, 577); // O_WRONLY | O_CREAT | O_TRUNC
-    const data = new TextEncoder().encode(msg.data.contents);
+    // Binary writes pass a Uint8Array straight through; text writes get encoded.
+    const data = msg.data.binary
+      ? (msg.data.contents instanceof Uint8Array ? msg.data.contents : new Uint8Array(msg.data.contents))
+      : new TextEncoder().encode(msg.data.contents);
     FS.write(fd, data, 0, data.length, 0);
     FS.close(fd);
+    // `git add` is a no-op for paths matched by .gitignore — that's how we keep
+    // bridge-synced binaries (images, samples) out of the actual git history.
     callMainInDir(['add', '--verbose', msg.data.filename]);
     console.log(currentRepoDir, 'persisted via OPFS');
     postMessage({ dircontents: readdir(), repoHasChanges: repoHasChanges() });
@@ -271,9 +276,10 @@ onmessage = async (msg) => {
   } else if (msg.data.command === 'readfile') {
     try {
       ensureChdir(currentRepoDir);
+      const options = msg.data.binary ? undefined : { encoding: 'utf8' };
       postMessage({
         filename: msg.data.filename,
-        filecontents: FS.readFile(msg.data.filename, { encoding: 'utf8' })
+        filecontents: FS.readFile(msg.data.filename, options)
       });
     } catch (e) {
       postMessage({ 'error': JSON.stringify(e) });

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -182,6 +182,10 @@ onmessage = async (msg) => {
         // Create symlink workaround for WASMFS getcwd() bug
         try { FS.symlink(currentRepoDir, '/' + repoName); } catch (e) { }
         ensureChdir(currentRepoDir);
+        // WASMFS+OPFS has no real Unix mode bits — every file stat's as
+        // 0o755, so git would otherwise flag every file as a mode change
+        // (100644 → 100755) on every diff. Idempotent re-set is fine.
+        try { callMainInDir(['config', 'core.fileMode', 'false']); } catch (_) {}
         postMessage({ dircontents: readdir() });
         console.log(currentRepoDir, 'restored from OPFS');
       } else {
@@ -235,6 +239,10 @@ onmessage = async (msg) => {
     // Create symlink workaround for WASMFS getcwd() bug
     try { FS.symlink(currentRepoDir, '/' + repoName); } catch (e) { }
     ensureChdir(currentRepoDir);
+    // WASMFS+OPFS reports 0o755 for everything (no real mode bits), so
+    // git would surface a 100644 → 100755 mode change for every file
+    // without this.
+    try { callMainInDir(['config', 'core.fileMode', 'false']); } catch (_) {}
 
     console.log(currentRepoDir, 'persisted via OPFS');
     postMessage({ dircontents: readdir() });

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -89,11 +89,13 @@ onmessage = async (msg) => {
     } catch (e) {
 
     }
-    if (stdout.indexOf('Changes to be committed:') > -1) {
-      return true;
-    } else {
-      return false;
-    }
+    // Stage-on-commit means unstaged edits + untracked files also count as
+    // pending changes. Only ignored files (matched by .gitignore) stay
+    // invisible here, which is the right behavior for bridge-synced
+    // binaries we don't want to commit.
+    return stdout.indexOf('Changes to be committed:') > -1
+      || stdout.indexOf('Changes not staged for commit:') > -1
+      || stdout.indexOf('Untracked files:') > -1;
   }
 
   function readdir() {
@@ -136,12 +138,28 @@ onmessage = async (msg) => {
       const fd = FS.open(msg.data.filename, 577); // O_WRONLY | O_CREAT | O_TRUNC
       FS.write(fd, data, 0, data.length, 0);
       FS.close(fd);
-      // `git add` is a no-op for paths matched by .gitignore — that's how we
-      // keep bridge-synced binaries (images, samples) out of the actual git
-      // history.
-      callMainInDir(['add', '--verbose', msg.data.filename]);
+      // Caller can opt out of immediate staging (the bridge does), so that
+      // bridge-side edits show up as unstaged working-tree changes and the
+      // "Discard changes" button can roll them back via `git reset --hard`.
+      // Editor saves still stage immediately so the Commit & Sync indicator
+      // surfaces the change.
+      if (msg.data.stage !== false) {
+        callMainInDir(['add', '--verbose', msg.data.filename]);
+      }
       console.log(currentRepoDir, 'persisted via OPFS');
     }
+    postMessage({ dircontents: readdir(), repoHasChanges: repoHasChanges() });
+  } else if (msg.data.command === 'unlinkfile') {
+    // Just remove from the working tree; don't touch the index. That leaves
+    // tracked deletions as unstaged "deleted" entries, so "Discard changes"
+    // (git reset --hard HEAD) can restore them. The actual `git rm` is
+    // handled at commit time by `git add -A`. Idempotent — missing file is
+    // treated as success so bridge-initiated deletes don't fail on retry.
+    ensureChdir(currentRepoDir);
+    try {
+      FS.unlink(msg.data.filename);
+      console.log(currentRepoDir, 'unlinked via OPFS', msg.data.filename);
+    } catch (_) { /* already gone */ }
     postMessage({ dircontents: readdir(), repoHasChanges: repoHasChanges() });
   } else if (msg.data.command === 'dir') {
     postMessage({ id: msg.data.id, dircontents: readdir() });
@@ -151,7 +169,11 @@ onmessage = async (msg) => {
     if (repoHasChanges()) {
       callMainInDir(['config', 'user.name', username]);
       callMainInDir(['config', 'user.email', useremail]);
-
+      // Stage everything (new files, modifications, deletions). Respects
+      // .gitignore so bridge-synced binaries stay out. This is the single
+      // point where bridge-side and editor-side edits both get staged
+      // before the commit.
+      callMainInDir(['add', '-A']);
       callMainInDir(['commit', '-m', msg.data.commitmessage]);
     }
 

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -115,18 +115,33 @@ onmessage = async (msg) => {
       dirAcc += (i === 0 ? '' : '/') + segments[i];
       try { FS.mkdir(dirAcc); } catch (_) { /* exists */ }
     }
-    // WASMFS+OPFS does not truncate on writeFile — open with O_TRUNC, write, close
-    const fd = FS.open(msg.data.filename, 577); // O_WRONLY | O_CREAT | O_TRUNC
-    // Binary writes pass a Uint8Array straight through; text writes get encoded.
     const data = msg.data.binary
       ? (msg.data.contents instanceof Uint8Array ? msg.data.contents : new Uint8Array(msg.data.contents))
       : new TextEncoder().encode(msg.data.contents);
-    FS.write(fd, data, 0, data.length, 0);
-    FS.close(fd);
-    // `git add` is a no-op for paths matched by .gitignore — that's how we keep
-    // bridge-synced binaries (images, samples) out of the actual git history.
-    callMainInDir(['add', '--verbose', msg.data.filename]);
-    console.log(currentRepoDir, 'persisted via OPFS');
+    // Skip identical re-writes so we don't touch mode/mtime — otherwise the
+    // bridge bouncing a same-content file back into OPFS would surface as a
+    // bogus "modified" entry in git status.
+    let identical = false;
+    try {
+      const existing = FS.readFile(msg.data.filename);
+      if (existing.length === data.length) {
+        identical = true;
+        for (let i = 0; i < data.length; i++) {
+          if (existing[i] !== data[i]) { identical = false; break; }
+        }
+      }
+    } catch (_) { /* new file */ }
+    if (!identical) {
+      // WASMFS+OPFS does not truncate on writeFile — open with O_TRUNC, write, close
+      const fd = FS.open(msg.data.filename, 577); // O_WRONLY | O_CREAT | O_TRUNC
+      FS.write(fd, data, 0, data.length, 0);
+      FS.close(fd);
+      // `git add` is a no-op for paths matched by .gitignore — that's how we
+      // keep bridge-synced binaries (images, samples) out of the actual git
+      // history.
+      callMainInDir(['add', '--verbose', msg.data.filename]);
+      console.log(currentRepoDir, 'persisted via OPFS');
+    }
     postMessage({ dircontents: readdir(), repoHasChanges: repoHasChanges() });
   } else if (msg.data.command === 'dir') {
     postMessage({ id: msg.data.id, dircontents: readdir() });
@@ -282,7 +297,10 @@ onmessage = async (msg) => {
         filecontents: FS.readFile(msg.data.filename, options)
       });
     } catch (e) {
-      postMessage({ 'error': JSON.stringify(e) });
+      // Echo the filename so the client-side readfile listener only rejects
+      // the matching call. Without it, concurrent readfile() Promise.all
+      // chains would all reject on any single ENOENT.
+      postMessage({ filename: msg.data.filename, error: JSON.stringify(e) });
     }
   } else if (msg.data.command === 'log') {
     callAndCaptureOutput(['log']);


### PR DESCRIPTION
## Summary

Substantial rework of the local Claude/VSCode → OPFS bridge so it survives multi-tab use, propagates deletions both ways, and lets editors see proper TypeScript IntelliSense across the per-tab mirror tree.

- **Binary OPFS round-trip + repo-relative media URLs.** wasm-git `readfile` / `writefileandstage` learn a `{ binary: true }` option that passes `Uint8Array` bytes verbatim. The bridge client uses this to mirror binary files (images, samples, …) base64-framed through tree_dump / apply_file. `git add` is a silent no-op for paths matched by `.gitignore`, which is how bridge-synced binaries stay out of git history. Songcompiler's `addImage` / `addVideo` / `addAudio` then resolve repo-relative URLs to blob URLs read from OPFS.

- **Stop wiping host mirror; skip identical writes both ways.** The old `clearOpfsContents()` on every tree_dump wiped host-added gitignored files. Replaced with upsert-only + content-equality skip — wasm-git no longer shows spurious "modified" entries from the bridge bouncing same-content files.

- **`core.fileMode=false`** on clone + synclocal. WASMFS+OPFS reports `0o755` for every file, so git would otherwise flag the entire tree as `100644 → 100755` in every diff.

- **Per-origin/repo subdirs.** Layout is now `work/<origin>/<repoName>/<opfs-tree>`. Client sends `{ type: 'hello', origin, repoName }` on connect; the relay derives the subdir and routes all later messages to it. Multiple tabs on different origins/repos can't trample each other.

- **Bidirectional deletes.** wasm-git gets an `unlinkfile` command. Host→OPFS: fs.watch unlink fires `apply_delete`. OPFS→host: tree_dump diff detects paths that fell out of OPFS and `rm`s them from the mirror. Restart-safe: the bridge's known-set starts empty, so the first post-restart tree_dump never deletes anything from the host mirror.

- **Bridge writes stay unstaged.** `writefileandstage` takes a `{ stage }` option (default true, so editor saves still auto-stage). The bridge passes `stage: false` so its writes show up as unstaged modifications and "Discard changes" (`git reset --hard HEAD`) rolls them back. `commitpullpush` runs `git add -A` before commit so editor + bridge changes both land (respecting `.gitignore` for bridge binaries). `repoHasChanges` now also picks up unstaged + untracked entries so the Commit & Sync indicator surfaces bridge edits.

- **IDE IntelliSense in the new layout.** Per-subdir runtime symlinks (`mixes`, `synth`, `midi`, `environment.ts`, …) and a `tsconfig.json` are dropped inside each subdir at first use so `../mixes/…`-style imports resolve. The tsconfig points at the AS standard-library declarations via an absolute path (the relative form was off by one and pointed at a non-existent `tools/wasmaudioworklet/…`). Tsconfig is overwritten idempotently so future bridge upgrades propagate without manual cleanup.

## Test plan

- [x] Verified per-tab subdir layout end-to-end with two browser tabs (different repos)
- [x] Host edits in `work/<origin>/<repo>/…` round-trip into OPFS; deleting a file in the mirror unlinks it in OPFS
- [x] OPFS-side deletions (e.g. wasm-git discard or branch switch) propagate to the host mirror via the next tree_dump
- [x] No spurious mode-bit diffs in the Commit & Sync UI
- [x] IDE IntelliSense resolves `f32`, `StaticArray<T>`, `MidiVoice`, etc. for files under `work/<origin>/<repo>/`
- [x] Bridge restart while files exist locally: OPFS-only files NOT in tree_dump survive (no accidental host-side delete)
- [x] "Discard changes" rolls back bridge-side modifications since they're left unstaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)