### PR TITLE
editor UX: refresh CodeMirror after reveal, paint spinner on every transpile

### DIFF
--- a/wasmaudioworklet/e2e/transpile-spinner.spec.js
+++ b/wasmaudioworklet/e2e/transpile-spinner.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+// Regression: progress spinner is invisible on the *second* (and later)
+// transpileDspSource() calls because the libfaust compiler promise is
+// cached at module scope. On the first call, fetching/instantiating
+// libfaust-wasm yields to the event loop multiple times, so the spinner
+// element is appended, laid out, painted. On subsequent calls the entire
+// transpile completes in microtasks: the <progress-spinner> is appended
+// and removed inside the same animation frame and the browser never paints
+// it. The fix forces one paint frame after toggleSpinner(true).
+//
+// No NEAR sandbox / git needed here — we call transpileDspSource() directly
+// from the page via dynamic import. A ResizeObserver on the spinner element
+// is our "did the browser actually lay it out" probe.
+
+const DSP_A = `import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate) <: _, _;
+`;
+
+const DSP_B = DSP_A.replace('os.sawtooth(freq)', 'os.square(freq)');
+
+const installSpinnerObserver = (page) => page.evaluate(() => {
+    window.__spinnerAdds = 0;
+    window.__spinnerPainted = 0;
+    const ro = new ResizeObserver((entries) => {
+        for (const e of entries) {
+            if (e.contentRect.width > 0 && e.contentRect.height > 0) {
+                window.__spinnerPainted++;
+            }
+        }
+    });
+    const mo = new MutationObserver((muts) => {
+        for (const m of muts) {
+            for (const n of m.addedNodes) {
+                if (n.nodeType === 1 && n.tagName && n.tagName.toLowerCase() === 'progress-spinner') {
+                    window.__spinnerAdds++;
+                    ro.observe(n);
+                }
+            }
+        }
+    });
+    mo.observe(document.documentElement, { childList: true, subtree: true });
+    window.__stopSpinnerObserver = () => { mo.disconnect(); ro.disconnect(); };
+});
+
+const readSpinnerStats = (page) => page.evaluate(() => ({
+    adds: window.__spinnerAdds || 0,
+    painted: window.__spinnerPainted || 0,
+}));
+
+test('progress-spinner paints during every faust transpile, not just the first', async ({ page }) => {
+    page.on('console', (m) => {
+        if (m.type() === 'error' || m.type() === 'warning') console.log('[browser]', m.type(), m.text());
+    });
+    page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+
+    await page.goto('http://localhost:8080');
+    // Wait until the app is far enough along that <progress-spinner> is a
+    // registered custom element (defined in common/ui/progress-spinner.js).
+    await page.waitForFunction(() => !!customElements.get('progress-spinner'),
+        { timeout: 30000 });
+
+    // First transpile — compiler not yet cached, libfaust-wasm fetches.
+    await installSpinnerObserver(page);
+    await page.evaluate(async (src) => {
+        const m = await import('/faust/browser-transpile.js');
+        await m.transpileDspSource(src, 'spinnertest.dsp', {});
+    }, DSP_A);
+    const first = await readSpinnerStats(page);
+    await page.evaluate(() => window.__stopSpinnerObserver && window.__stopSpinnerObserver());
+
+    // Second transpile — compiler cached. Without the fix the spinner
+    // toggle-on / toggle-off happens entirely in microtasks and the user
+    // never sees it.
+    await installSpinnerObserver(page);
+    await page.evaluate(async (src) => {
+        const m = await import('/faust/browser-transpile.js');
+        await m.transpileDspSource(src, 'spinnertest.dsp', {});
+    }, DSP_B);
+    const second = await readSpinnerStats(page);
+    await page.evaluate(() => window.__stopSpinnerObserver && window.__stopSpinnerObserver());
+
+    console.log('first:', first, 'second:', second);
+
+    expect(first.adds).toBeGreaterThan(0);
+    expect(first.painted).toBeGreaterThan(0);
+    expect(second.adds).toBeGreaterThan(0);
+    expect(second.painted).toBeGreaterThan(0);
+});

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -114,6 +114,16 @@ export async function initEditor(componentRoot) {
         getPath: () => currentFaustFilename || null,
     });
 
+    // CodeMirror computes its layout from its container's measured size, so
+    // any cm constructed while display:none stays blank after setValue until
+    // refresh() runs once the container has a real size.
+    const cmByEditor = {
+        editor: () => songsourceeditor,
+        assemblyscripteditor: () => synthsourceeditor,
+        shadereditor: () => shadersourceeditor,
+        fausteditor: () => faustsourceeditor,
+    };
+
     window.toggleEditors = (editorid, checked) => {
         componentRoot.getElementById(editorid).style.display = checked ? 'block' : 'none';
         const editors = componentRoot.querySelectorAll('.editor');
@@ -127,6 +137,14 @@ export async function initEditor(componentRoot) {
         visibleEditors.forEach(editor =>
             editor.style.width = Math.round((1 / visibleEditors.length) * 100) + '%'
         );
+        if (checked) {
+            const cm = cmByEditor[editorid]?.();
+            if (cm) {
+                // Defer to after the browser has applied the display:block —
+                // refresh() reads the now-visible container's measured size.
+                requestAnimationFrame(() => cm.refresh());
+            }
+        }
     };
 
     toggleEditors('presetsui', false);

--- a/wasmaudioworklet/faust/browser-transpile.js
+++ b/wasmaudioworklet/faust/browser-transpile.js
@@ -87,6 +87,13 @@ function isStereoEffect(asSource) {
 // Throws on faust compilation error.
 export async function transpileDspSource(dspSource, dspBaseName, libsByPath = {}) {
     toggleSpinner(true);
+    // Force a real paint between attach and the (often microtask-only,
+    // when the compiler is cached) work. A single RAF fires *before* the
+    // paint, so by the time the promise resolves the microtask drain has
+    // already removed the spinner — the user sees nothing. Double-RAF
+    // guarantees one full render step commits a layout + paint while the
+    // spinner is in the DOM.
+    await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
     try {
         const { compiler, fs: faustFS } = await getCompiler();
         mountSiblings(faustFS, libsByPath);


### PR DESCRIPTION
## Summary
- **CodeMirror layout on first reveal**: `toggleEditors` now calls `cm.refresh()` after `requestAnimationFrame` for the song / synth / shader / faust editors. The faust editor always starts hidden, so its initial `setValue` ran into a 0-height container and CodeMirror never measured viewport — the editor looked blank with the dropdown showing the first file selected, until the user manually switched files.
- **Spinner only painted on the first transpile**: `transpileDspSource` awaits a double-RAF after `toggleSpinner(true)` so the browser commits a real layout + paint while `<progress-spinner>` is in the DOM. The libfaust compiler promise is cached at module scope, so every Cmd-S after the first ran entirely in microtasks: spinner attached and detached inside a single frame, no feedback.
- **Regression test**: `e2e/transpile-spinner.spec.js` exercises `transpileDspSource()` directly from the page (no NEAR sandbox needed). Uses a `ResizeObserver` on the spinner element as a "did the browser actually lay this out" probe — a plain `MutationObserver` would have missed the second-call invisibility because the element *is* appended, just never painted.

## Test plan
- [x] `npx playwright test e2e/transpile-spinner.spec.js` — passes (`first: { adds: 1, painted: 1 }, second: { adds: 1, painted: 1 }`)
- [ ] Toggle faust checkbox in a repo with `.dsp` files — editor shows source on first reveal, no need to switch files first
- [ ] Save (Cmd-S) a faust file twice in a row — spinner visible during the transpile both times

🤖 Generated with [Claude Code](https://claude.com/claude-code)