### PR TITLE
IFC 2026 talk: reveal.js deck + NEAR git-repo hosting docs

### DIFF
--- a/docs/presentations/ifc2026-plan.md
+++ b/docs/presentations/ifc2026-plan.md
@@ -1,0 +1,348 @@
+# IFC 2026 — Plan
+
+Working document for the **[International Faust Conference 2026](https://ifc26.i3s.univ-cotedazur.fr/)** appearance. Two distinct deliverables:
+
+1. **Talk** — the Faust transpilers (C-backend + ASC-backend).
+2. **Concert** — live coding set drawing from the songs at
+   `~/neargit/webassemblymusic-songs.gitfactory.testnet`.
+
+---
+
+## 0. Logistics (fill in)
+
+- Dates / location: <!-- e.g. dd–dd Mmm 2026, Université Côte d'Azur, Sophia Antipolis -->
+- Talk slot: <!-- date + duration, 20 min? 30 min? -->
+- Concert slot: <!-- date + duration; PA + monitoring details -->
+- Demo machine: <!-- MacBook details, audio interface, MIDI controller? -->
+- Backup plan if internet is unreliable: <!-- record fallback video? offline-capable build? -->
+- Stream / recording rights: <!-- IFC publish video? -->
+
+---
+
+## 1. Talk — Faust transpilers
+
+### 1.1 Introduction — What is WebAssembly Music?
+
+**WebAssembly Music** is an open-source, browser-based live-coding environment
+for music. Music sequences are written in JavaScript; synthesizers are written
+in AssemblyScript and compiled to WebAssembly directly in the browser on every
+save. One synth wasm module handles multi-timbral MIDI synthesis with voice
+allocation, multiple instrument channels, and sample-by-sample rendering.
+AudioWorklet keeps latency low. Synth wasm modules are typically <16 KB.
+
+Architecture diagram: [`wasmaudioworklet/overview.svg`](../../wasmaudioworklet/overview.svg).
+
+#### Why it exists (the pragmatic story)
+
+Origin chain, traceable to the top-level `README.md`:
+
+1. **NodeJS + MIDI controlling ZynAddSubFX.** Songs as JS files. Worked, but
+   the synth was a black box — no way to live-edit timbre alongside the notes.
+2. **4klang** — a compact-but-powerful synth from the 64K-intro demoscene
+   tradition. The README's own framing: *"finally inspired me to attempt
+   writing a synth in WebAssembly running entirely in the browser."* The
+   4klang aesthetic (tiny binaries, code-as-sound) set the engineering taste
+   for what followed.
+3. **WebAssembly synth in the browser, written in AssemblyScript.** First
+   commits July 2018; AudioWorklet integration Nov 2018.
+
+#### Why AssemblyScript
+
+Fast in-browser compile is the deciding factor — none of the alternatives
+close the live-coding loop:
+
+- Rust + wasm-pack / Emscripten + C: toolchain compile times are too slow for
+  "edit synth → hear it" iteration. Great for shipped artifacts; not for a
+  save-and-listen workflow.
+- Hand-written WAT: no abstraction, tedious.
+- **AssemblyScript**: compiles in milliseconds, runs in the browser as a
+  Worker (no host install for users), and the TypeScript-like syntax doesn't
+  hide the wasm — you still control class layout, can drop to raw memory,
+  predictable codegen.
+
+This is the choice that makes everything else possible. Without ms-scale
+compile, the rest of the project's save-and-hear feedback loop doesn't work.
+
+#### Where Faust fits
+
+Faust is a widely adopted DSP language with a mature library of instruments
+(physical models, FM synths, mastering chains). The work in this talk is
+about making those available in WebAssembly Music — **as part of the
+existing multi-timbral synth engine, not as separate AudioWorklet nodes.**
+
+That distinction matters. Faust IDE and the standard `faustwasm` runtime
+approach build each DSP into its own AudioWorklet node with its own
+polyphonic voice management. WebAssembly Music has *one* synth module that
+does voice allocation and channel routing for all instruments together.
+Source-to-source transpilation lets a Faust DSP become an AssemblyScript
+`MidiVoice` subclass — it lives alongside hand-written AS instruments,
+shares voice allocation, shares reverb/delay sends, and shows up to the JS
+sequencer as just another MIDI channel.
+
+#### Where it's been shown
+
+- **WebAssembly Summit 2020** (Google HQ, Mountain View) — [demo video](https://youtu.be/C8j_ieOm4vE)
+- **NEARCON 2021** (Lisbon)
+- **Web Audio Conference 2025** (Paris)
+- Chapter in *Building and Deploying WebAssembly Apps* (BPB Publications, 2025)
+
+This talk is the next iteration: the Faust integration. A previous
+music-tooling project (**Frinika**, Java-based) explored similar code+music
+ideas in a desktop context.
+
+### 1.2 Submitted abstract
+
+> *"Converting Faust to AssemblyScript for WebAssembly Music"* — abstract at
+> `~/Downloads/PeterSalomonsen.pdf`. Headline: `faust2as` transpiles the C
+> backend's output into AssemblyScript classes that plug into the WebAssembly
+> Music MidiVoice/MidiChannel runtime, preserving the fast in-browser AS
+> compile + small-binary pipeline.
+
+The abstract focuses on the **C-backend approach** (`faust2as.js`). Since
+submitting, the project has acquired a **second, in-browser** transpilation
+path using Faust's AssemblyScript backend (`faust2asc.js` + the pure
+`transpile-core.js` reused by `browser-transpile.js`). The talk should cover
+both and contrast them.
+
+### 1.3 Talk outline (draft)
+
+| Time | Section | Notes |
+| ---- | ------- | ----- |
+| ~4 min | **Intro — What is WebAssembly Music + why** (see §1.1) | architecture in one slide, 4klang quote, why AS for live coding, where Faust fits |
+| ~2 min | Why source-to-source vs runtime linking for Faust specifically | one wasm module, shared voice allocation, MidiVoice/MidiChannel integration, tiny binaries preserved |
+| ~5 min | **`faust2as` — C-backend approach** (the abstract) | `faust -lang c` → AS reshape; offline only (Node CLI) |
+| ~5 min | **`faust2asc` + `transpile-core` — ASC-backend approach** (post-abstract work) | `faust -lang asc` via `@psalomo/faustwasm` in the browser → in-place reshape; **no host install needed**; closes the live-coding loop entirely inside the browser |
+| ~1 min | What we get for free in both: typed channel fields with doc comments, CC/NRPN auto-mapping, `transpileEffect` standalone-effect path | |
+| ~10 min | Live demo (see §1.5) | |
+| ~3 min | Q&A | |
+
+### 1.4 The two transpiler paths — at a glance
+
+| | `faust2as.js` (C backend) | `faust2asc.js` + `transpile-core.js` (ASC backend) |
+| --- | --- | --- |
+| Input | C from `faust -lang c` | AssemblyScript from `faust -lang asc` (via faustwasm `@psalomo/faustwasm`) |
+| Where it runs | Node CLI (offline) | Node CLI **and** in-browser (`wasmaudioworklet/faust/browser-transpile.js`) |
+| Reshape work | Parse C, rewrite to AS (`dsp->` → `this.`, `fminf` → `Mathf.min`, `(float)` casts, etc.) | Parse AS, restructure fields & methods to fit `MidiVoice`/`MidiChannel`/`Effect` |
+| UI metadata source | C `buildUserInterface` calls (`ui_interface->declare(...)` for `[symbol:foo]`) | `getJSON()` embedded in the AS output |
+| Generated shape | Same end-state: typed public channel fields with doc comments, `process(...)` / `nextframe()`, CC/NRPN routing | Same |
+| Live-coding ergonomics | Save-and-rebuild needed | True hot-reload — save a `.dsp` in the editor and the AS source is regenerated and recompiled in one shot |
+
+The **convergence** is the headline: both paths emit the same shape, share
+the `paramDocComment` / `deriveNiceName` helpers in `transpile-core.js`, and
+share `transpileEffect` for standalone effects (master_me, zita_rev1, …).
+The ASC path is what makes the whole loop closeable inside the browser.
+
+### 1.5 Live demo plan (draft)
+
+The talk gets one MacBook and (hopefully) PA monitoring. Suggested demo
+sequence — every step should make a sound, every step should be
+explainable from the screen:
+
+1. Open the web app, show the four editors (song, synth, shader, faust).
+2. Type a Faust DSP (a sine + envelope), save → watch the editor
+   transpile, hear the result.
+3. Show the generated AS file: typed channel fields with hover docs.
+4. From AS, set a few params on the new channel directly.
+5. Drop in a DX7 algorithm (`dx7_alg5_bells.dsp`) — show NRPN mapping
+   triggering automatically (>116 params).
+6. Add a stereo effect (`master_me.dsp` or `zita_rev1.dsp`) — show
+   `transpileEffect` shape and the auto-`postprocess()` wiring.
+7. (If time) live tweak: change one DSP block in the .dsp, save, hear
+   the synth update mid-song.
+
+Fallback: a pre-recorded screencast of the same steps in case the
+projector / audio chain misbehaves.
+
+### 1.6 Slide deck
+
+- [ ] Pick a tool: Reveal.js? Keynote? Quarto/Marp? (Prefer something
+      live-codable from this same repo — Reveal-in-this-repo would close
+      the loop nicely.)
+- [ ] Architecture diagram (one slide). Inputs: `.dsp`, `.js` song, `.glsl`.
+      Outputs: WASM synth module + audio.
+- [ ] Side-by-side diagram of the two transpiler paths.
+- [ ] Code snippets — generated channel class before/after PR #125/#127.
+- [ ] Photos / screenshots of past demos for the bio slide.
+
+### 1.7 Open questions / decisions
+
+- [ ] Does the audience want **theory** (how the AS reshape works in
+      detail) or **demo** (here are the sounds you can make)? Probably
+      lean demo — IFC is a music-making conference.
+- [ ] How much of the abstract's specific NRPN/CC discussion to keep vs
+      cut now that we have typed fields making CC less central?
+- [ ] Reference the `transpileEffect` work (PR #127) — that's new since
+      the abstract was submitted; worth mentioning even if briefly.
+
+---
+
+## 2. Concert — seamless multi-song live coding
+
+### 2.1 Set list (candidates, from `~/neargit/webassemblymusic-songs.gitfactory.testnet`)
+
+| Slug | File | Notes / mood |
+| ---- | ---- | ------------ |
+| `swamp` | `swampsong.js` (+ `swampsynth.ts`) | <!-- describe --> |
+| `monstertheme` | `monstertheme/song1.js` | <!-- --> |
+| `veronikaswaltz` | `veronikaswaltz.js` | 3/4 piano waltz |
+| `beautifulflaws` | `beautifulflaws.js` | <!-- --> |
+| `closeproto` | `closeproto/song1.js` (+ `song2.js`, `songcontract.js`?) | <!-- --> |
+| `aliensclose` | `aliensclose.js` | <!-- --> |
+| `much` | `much.js` | currently the repo's default song |
+| `onedayolder` | `onedayolder/song.js` | has its own `synth.ts` |
+
+Decide:
+
+- [ ] Final order (build a story arc — energy, key, tempo)
+- [ ] Approximate duration target (e.g. 30 / 45 / 60 minutes)
+- [ ] Which songs share a synth (`synth.ts`) and which need their own
+      (`swampsynth.ts`, `monstertheme/synth.ts`, `onedayolder/synth.ts`)
+      — affects how easily they can transition
+- [ ] One backup song outside the main arc, in case of stage issues
+
+### 2.2 Seamless playback — chosen approach: quantized save
+
+Decoupling **compile** from **replacement in the audio worklet**: save
+keeps doing what it does today (compile immediately, surface any errors
+right away, commit/stage to wasm-git as configured), but the moment the
+new wasm becomes audible is quantized to a musically meaningful bar /
+beat boundary. While the staged wasm waits for its trigger, the old wasm
+keeps playing uninterrupted — the swap is a one-frame pointer flip in
+the worklet, not a recompile stall.
+
+This generalises beyond song-switching: it's the same machinery for any
+edit (synth, song, shader) where the user wants the change audible *at*
+the bar, not in the middle of a phrase. Live-coding idiom borrowed from
+Tidal Cycles / Sonic Pi.
+
+#### UI
+
+A small dropdown next to the save button. Value selects the
+**quantization divisor `N`**: the swap fires on the next beat whose
+beat number satisfies `(beatNumber + 1) % N == 0`.
+
+The engine doesn't know a song's time signature (a "bar" could be 3, 4,
+6, … beats), so the labels stay numeric — the user picks the modulus
+themselves based on what the current song's meter is:
+
+| Label | N |
+| --- | --- |
+| Now | 0 (sentinel — immediate, the current behaviour) |
+| 1 beat | 1 |
+| 2 beats | 2 |
+| 3 beats | 3 |
+| 4 beats | 4 |
+| 6 beats | 6 |
+| 8 beats | 8 |
+| 12 beats | 12 |
+| 16 beats | 16 |
+| 32 beats | 32 |
+
+Default is **Now** (preserves current behaviour for any user who doesn't
+think about quantization). The dropdown selection is sticky across saves
+so the user picks "8 beats" once and every subsequent save fires at the
+next beat where `(beat+1) % 8 == 0`.
+
+#### Wiring
+
+- **Save handler** (`compileAndPostSong` in `editorcontroller.js` →
+  `audioworkletnode.port.postMessage`): pass `quantizeN` alongside the
+  new wasm + eventlist. No change to compile timing.
+- **Worklet** (`midisynthaudioworklet.js` / `midisynthaudioworkletprocessor.js`):
+  - Receive the new wasm into a `pendingWasm` slot. If a `pendingWasm`
+    already exists, replace it (last-save-wins; no queue).
+  - Instantiate the new wasm instance immediately into a `pendingInstance`
+    so the swap-time work is just a reference flip.
+  - On each frame, after rendering the current sample: check
+    `(currentBeat + 1) % quantizeN == 0` at the frame where the next
+    beat starts → swap `currentInstance ← pendingInstance`, clear
+    pending.
+- **Beat counter**: the engine already has `BPM` and
+  `pattern_size_shift`; the worklet derives sample-to-beat from
+  `SAMPLERATE` and `BPM`. The "current beat" at the head of the next
+  frame is what gets tested.
+
+#### Multiple synths warm
+
+With the quantized-save model, each save's wasm sits in the worklet's
+pending slot. Subsequent saves before the trigger fires *replace* the
+pending slot — only the most recent save wins. That's the right
+default (the user keeps editing right up to the bar boundary). If
+"queue multiple changes in order" turns out to be useful, it can be
+added later.
+
+For the concert specifically, this means: load song A, save → A plays.
+Pull up song B in the editor, save with quantize=`2 bars` → A keeps
+playing for ≤2 bars, then B takes over at the bar. No setlist mode
+needed; no `nextSong()` primitive; the existing save button does it.
+
+#### Scope: just the audioworklet swap timing
+
+Nothing else changes. The song switcher behaves exactly as today —
+it loads source into the editors and that's it. Compile fires only on
+save, also as today. The single new piece is: when the audioworklet
+receives the new wasm + event list, it defers the live replacement
+until the next beat where `(beat+1) % N == 0`. So for the concert:
+pick song B in the switcher, click save with quantize=`8 beats`, and
+song A keeps playing for at most 8 beats while song B is compiled and
+prepared in the worklet, then the swap fires on the next 8-beat
+boundary.
+
+#### Decisions
+
+- [x] Quantization divisor `N` only, no musical labels (engine
+      doesn't know the meter).
+- [x] Dropdown default: **Now**.
+- [x] No unified concert synth.ts.
+- [x] No background pre-compile, no song-switcher changes. The only
+      new behaviour is in the audioworklet: defer the wasm + eventlist
+      replacement until the next beat-divisible-by-N.
+- [ ] Build it as its own PR before the concert.
+
+### 2.3 Performance setup
+
+- [ ] Audio path: laptop → audio interface → PA. Stereo only?
+- [ ] MIDI controller for live input — what's available at the venue,
+      what's worth bringing
+- [ ] Screen routing — what does the audience see? Editor live? Just the
+      shader visualizer? Both?
+- [ ] Lighting / shader sync — does the shader change with each song?
+      (See `shader.glsl` at the repo root — single file, switched
+      manually today.)
+
+### 2.4 Risks + mitigations
+
+- **Network / NEAR git unavailability**: load all songs locally before
+  the show; rely on OPFS state, not on a fresh clone.
+- **Compile stall during transition**: pre-compile the next synth in a
+  background worker.
+- **Out-of-tune drift** between songs in different keys: choose
+  transitions that key-modulate naturally, or insert a one-bar pad/swell.
+- **Editor mistake breaks audio mid-song**: keep a "panic" reset that
+  reloads the last-known-good wasm from a snapshot. (Engine has
+  something like this already — verify.)
+
+### 2.5 Open questions
+
+- [ ] Want to live-code anything *new* during the set, or only play
+      curated material? (Affects how much editor visibility the audience
+      gets.)
+- [ ] Will any of the Faust effects (zita_rev1, master_me) be tweaked
+      live as part of the performance?
+- [ ] Pre-show rehearsal opportunities — at least one full run-through
+      with the same stage gear before the concert.
+
+---
+
+## 3. Next actions
+
+- [ ] Confirm IFC 2026 logistics (date, slots) and fill in §0.
+- [ ] Decide talk vs demo balance (§1.6).
+- [ ] Pick slide tool and draft architecture diagram.
+- [ ] Pick songs and order for §2.1.
+- [ ] Decide seamless-playback approach (§2.2) and prototype it on this
+      repo.
+- [ ] Build a unified "concert synth.ts" or commit to a per-song-switch
+      strategy.
+- [ ] Schedule one full rehearsal end-to-end (talk + concert) at least a
+      week before travel.

--- a/docs/presentations/ifc2026-slides.md
+++ b/docs/presentations/ifc2026-slides.md
@@ -1,0 +1,427 @@
+<!--
+IFC 2026 talk — slide proposal.
+
+Slides are separated by `---` so the file is readable as plain markdown
+and also drops cleanly into Marp / Reveal.js if we pick one of those for
+the actual deck. Each slide is a markdown section; speaker notes live in
+an HTML comment block (`<!-- speaker notes: ... -->`) so they don't
+render but stay close to the slide they belong to.
+
+Source of truth for the content here:
+  - The submitted abstract (~/Downloads/PeterSalomonsen (2).pdf)
+  - Top-level README.md (origin chain, 4klang quote)
+  - wasmaudioworklet/README.md (architecture details)
+  - ifc2026-plan.md §1.1 (the "what / why" framing we agreed on)
+
+Nothing is invented — every concrete claim traces back to one of these.
+The talk targets ~30 min total: ~17 min framing/explanation + ~10 min
+live demo + ~3 min Q&A.
+-->
+
+# IFC 2026 — Slide proposal
+
+Title: *Converting Faust to AssemblyScript for WebAssembly Music*
+
+Author: Peter Salomonsen
+
+Target length: ~30 min (27 content + 3 Q&A)
+
+Slide count: 16
+
+---
+
+## Slide 1 — Title
+
+**Converting Faust to AssemblyScript for WebAssembly Music**
+
+Peter Salomonsen
+petersalomonsen.com · github.com/petersalomonsen/javascriptmusic
+
+IFC 2026 · Université Côte d'Azur
+
+<!--
+Speaker notes:
+  - 20-30s. Hello, name, what we're going to do for the next half hour.
+  - Mention the demo at the end so they know to expect sound.
+-->
+
+---
+
+## Slide 2 — What is WebAssembly Music?
+
+> Browser-based live-coding environment for music.
+> JavaScript sequences. AssemblyScript synthesizers. Compiled to
+> WebAssembly *in the browser* on every save.
+
+- One wasm module → multi-timbral MIDI synth with voice allocation
+- Sample-by-sample processing
+- AudioWorklet for low-latency playback
+- Synth wasm modules typically <16 KB
+
+→ insert `wasmaudioworklet/overview.svg` here as the architecture
+diagram.
+
+<!--
+Speaker notes:
+  - Spend most of this slide on the diagram. The single-wasm-module
+    point is the key one for the Faust integration story later.
+  - Resist the urge to demo here — the demo block is at slide 15.
+-->
+
+---
+
+## Slide 3 — Why does it exist?
+
+The origin chain (from the project's own README):
+
+1. **NodeJS + MIDI** controlling ZynAddSubFX. Songs as JS files. Worked,
+   but the synth was a black box.
+2. **4klang** — compact synth from the 64K demoscene tradition.
+   > *"finally inspired me to attempt writing a synth in WebAssembly
+   > running entirely in the browser."*
+   > — `README.md`
+3. **WebAssembly synth in the browser, written in AssemblyScript.**
+   First commits July 2018. AudioWorklet integration Nov 2018.
+
+<!--
+Speaker notes:
+  - Read the README quote out loud — it's the actual origin statement
+    and grounds everything that follows.
+  - 4klang and the demoscene reference is for taste-setting (tiny
+    binaries, code-as-sound). Don't dwell if the audience isn't with
+    you on it.
+-->
+
+---
+
+## Slide 4 — Why AssemblyScript?
+
+Fast in-browser compile is the deciding factor.
+
+| Alternative                | Why not                                           |
+| -------------------------- | ------------------------------------------------- |
+| Rust + wasm-pack           | Toolchain compile time too slow for "edit → hear" |
+| Emscripten + C             | Same                                              |
+| Hand-written WAT           | No abstraction; tedious                           |
+| **AssemblyScript**         | Compiles in *milliseconds*, runs as a Worker      |
+
+TypeScript-like syntax, but doesn't hide the wasm — class layout, raw
+memory, predictable codegen all still in your hands.
+
+> Without ms-scale compile, the rest of the project's save-and-hear
+> feedback loop doesn't work.
+
+<!--
+Speaker notes:
+  - This is the load-bearing engineering decision. Spend ~45s on it.
+  - If asked: "but isn't Rust faster at runtime?" — yes, marginally,
+    but irrelevant if you can't iterate. Live coding > peak perf.
+-->
+
+---
+
+## Slide 5 — Where Faust fits
+
+Faust = widely adopted DSP language; mature instrument libraries
+(physical models, FM synths, mastering chains).
+
+**This talk:** make Faust instruments available *inside* WebAssembly
+Music — not as separate AudioWorklet nodes, but as part of the
+existing multi-timbral synth engine.
+
+|                         | Faust IDE / `faustwasm` runtime         | WebAssembly Music + transpiler                        |
+| ----------------------- | ---------------------------------------- | ----------------------------------------------------- |
+| Where Faust runs        | Its own AudioWorklet node per DSP        | Same wasm module as the rest of the synth             |
+| Voice management        | Faust's own polyphonic runtime           | Existing `MidiVoice` / `MidiChannel` infrastructure   |
+| Binary size             | ~3 MB Faust compiler runtime per session | Faust DSP compiled into the <100 KB synth module      |
+| Integration             | Faust DSP is an isolated effect node     | Faust DSP is a `MidiVoice` subclass; shares routing   |
+
+<!--
+Speaker notes:
+  - Be respectful about Faust IDE / faustwasm — they're great tools
+    with different goals. Position as "a different choice for a
+    different use case," not "we do it better."
+  - Source-to-source is the architectural commitment that follows
+    from the single-wasm-module design.
+-->
+
+---
+
+## Slide 6 — Two transpiler paths
+
+Both emit the same shape. Different starting languages.
+
+| | `faust2as.js` (the abstract) | `faust2asc.js` (post-abstract) |
+| --- | --- | --- |
+| Faust output stage | `faust -lang c` | `faust -lang asc` (via `@psalomo/faustwasm`) |
+| Where it runs | Node CLI, offline | Node CLI **and in the browser** |
+| Live-coding workflow | Save .dsp → re-run CLI → reload | Save .dsp in the editor → DSP recompiles and hot-swaps |
+
+→ **Both** produce typed AssemblyScript channel classes with public
+UI-param fields, CC/NRPN auto-mapping, doc comments. Indistinguishable
+to the user once compiled.
+
+<!--
+Speaker notes:
+  - Flag that the ASC backend is the new piece since the abstract was
+    submitted. Audience members who read the abstract may expect only
+    the C-backend story; introduce the second path here.
+-->
+
+---
+
+## Slide 7 — faust2as · the C-backend path
+
+The story from the abstract.
+
+```
+faust -lang c your_dsp.dsp  →  C source
+                              ↓  faust2as.js parses & reshapes
+                              ↓
+                              AssemblyScript class extending MidiVoice
+```
+
+Transpiler responsibilities:
+
+- Type conversions (`(float)x` → `<f32>x`, `int` → `i32`)
+- Field access (`dsp->fHslider0` → `this.fHslider0`)
+- C math intrinsics (`fminf` → `Mathf.min`, `expf` → `Mathf.exp`, …)
+- Wave tables, static array declarations
+- UI metadata harvested from `ui_interface->declare(...)` calls
+
+→ Output compiles through the same in-browser AS pipeline as
+hand-written instruments.
+
+<!--
+Speaker notes:
+  - One concrete code-side-by-side here would help — pick a 5-line
+    snippet (e.g. a single Faust slider becoming a `this.feedback`
+    read) for the slide background.
+-->
+
+---
+
+## Slide 8 — UI param mapping (auto)
+
+What you get without writing any glue code:
+
+- **CC mapping**: Faust UI params auto-assigned to sequential MIDI CC
+  numbers, skipping reserved ones (7 volume, 10 pan, 64 sustain, …).
+- **NRPN fallback**: when an instrument has more than 116 controllable
+  params, auto-switch to NRPN encoding (CC 99 / 98 / 6).
+  - DX7 example: 139 params per algorithm → NRPN required.
+- **Typed channel fields**: every param becomes a `f32` field on the
+  channel class with a doc comment carrying its init/min/max/step. The
+  editor's hover docs serve as the missing Faust UI.
+
+```ts
+/** Feedback [init: 0, min: 0, max: 7, step: 1] · NRPN 0 */
+get feedback(): f32 { return _dx7_alg5_feedback; }
+set feedback(value: f32) { _dx7_alg5_feedback = value; }
+```
+
+<!--
+Speaker notes:
+  - The DX7 is the marquee example. Mention that the abstract
+    specifically called this out — NRPN auto-fallback because the
+    DX7 won't fit in CC.
+-->
+
+---
+
+## Slide 9 — faust2asc · the in-browser path
+
+What changed since the abstract was submitted.
+
+```
+your_dsp.dsp  →  faust -lang asc (via @psalomo/faustwasm)
+              ↓     (runs in the browser, no host install)
+              ↓  transpile-core.js parses & restructures
+              ↓
+              AssemblyScript class extending MidiVoice
+              ↓
+              same in-browser AS compile as before → wasm
+```
+
+The whole loop now closes **inside the browser**. Edit a `.dsp` in the
+editor, hit save, the DSP gets re-transpiled and hot-swapped into the
+running synth — no Node CLI, no separate build step.
+
+<!--
+Speaker notes:
+  - The `@psalomo/faustwasm` fork bundles the Faust compiler itself
+    as wasm (~3 MB one-time download). After that, transpilation is
+    pure browser work.
+  - Live-coding workflow loop time: from save → hear is ~1-2 seconds
+    typical, ~3-5s with heavy DSPs like master_me.
+-->
+
+---
+
+## Slide 10 — Convergence: the same end-state
+
+Both paths emit the same AS class shape. Same convergent format means:
+
+- The compiled wasm is identical (modulo Faust backend differences)
+- UI param fields are public + typed → editor hover docs work for both
+- `transpileEffect` standalone-effect path shared between both (used
+  for stereo-in/stereo-out DSPs like reverbs, mastering chains)
+- One shared helper module (`transpile-core.js`) → consistent doc-comment
+  format, name derivation, NRPN mapping, etc.
+
+The C-backend path remains useful for offline batch transpiles
+(e.g. building a fixed instrument library to ship with a project).
+The ASC-backend path is what makes the live-coding workflow possible.
+
+<!--
+Speaker notes:
+  - This is the "what we got for free" slide. Keep it short — the
+    audience just needs to see the picture, not the details.
+-->
+
+---
+
+## Slide 11 — Cost: how we keep it cheap
+
+Faust DSPs are big — master_me alone has ~700 internal state fields,
+hundreds of per-sample reads. At AS's `-O0` (live-compile default),
+every `this.fRec5` is a function call to an accessor wasm function.
+That overhead can choke real-time playback for heavy DSPs.
+
+**Mitigation:** the in-browser worker takes `optimizeLevel: 1` (and
+makes it user-toggleable via a toolbar checkbox). At -O1, AS inlines
+the accessors and hoists invariant property reads out of hot loops.
+Compile time goes from ~80 ms to ~600 ms — still interactive.
+
+The user picks the trade-off per session: fast-compile for rapid
+iteration, optimized for heavy-DSP playback.
+
+<!--
+Speaker notes:
+  - Optional slide — drop if running long. Useful for the audience
+    that asks "OK but does it scale?".
+  - One sentence summary: bigger DSPs need -O1; the toggle is in the
+    toolbar.
+-->
+
+---
+
+## Slide 12 — Effects, not just instruments
+
+Faust files with stereo I/O and no notes (mastering chains, reverbs)
+go through `transpileEffect`:
+
+- Same `transpile-core.js` pipeline
+- Output is a class with `process(left: f32, right: f32): void`
+- Singleton instance wired into the synth's `postprocess()` automatically
+- UI params still exposed as typed fields → tweak from `synth.ts`
+
+Examples in the repo: **master_me** (full mastering chain) and a small
+custom **live_master** (compressor + brickwall limiter, ~80 lines).
+Per the trade-off mentioned earlier, the heavy chain goes in offline
+export; the light one runs in the live audio thread.
+
+<!--
+Speaker notes:
+  - Mention master_me explicitly — it's a well-known Faust example
+    and people will recognize it.
+-->
+
+---
+
+## Slide 13 — What this lets you do
+
+In one wasm module, simultaneously:
+
+- Hand-written AS instruments (sine voices, samples)
+- Faust DX7 (FM synthesis, NRPN-driven patches)
+- Faust physical-model instruments (clarinet, electric guitar)
+- Faust mastering effect on the output bus
+
+All controlled by one JS sequencer. All compile in ~1 s on save. The
+typical compiled synth wasm with several Faust instruments is under
+500 KB.
+
+Live-edit any of the above — the DSP source, the patches, the song —
+and hear it on the next save.
+
+<!--
+Speaker notes:
+  - This is the payoff slide. Pause here, let it sink in, then go to
+    the demo.
+-->
+
+---
+
+## Slide 14 — Demo
+
+→ Live coding session at the laptop.
+
+(See `ifc2026-plan.md` §1.5 for the demo sequence: empty editor →
+Faust sine + envelope → typed channel fields → DX7 algorithm with
+NRPN auto-mapping → master_me / live_master as a postprocess → hot-edit
+the .dsp mid-song.)
+
+Fallback: pre-recorded screencast of the same sequence, ready to play
+if audio routing misbehaves.
+
+<!--
+Speaker notes:
+  - ~10 min. If pressed for time, cut the master_me step.
+  - Always have headphones plugged into the laptop's headphone jack
+    as a fallback monitor.
+-->
+
+---
+
+## Slide 15 — What's next
+
+- Multi-window concert orchestration (BroadcastChannel handoff between
+  tabs, already wired)
+- More mature Faust DSP library curation (currently per-project)
+- Possible: shipping a "Faust transpiler" Cloudflare Pages function so
+  one-off transpiles can happen without the editor
+
+Out of scope for this talk: the AS optimization-level investigation
+that led to the in-toolbar `-O1` toggle. Happy to discuss in Q&A.
+
+<!--
+Speaker notes:
+  - Trim to whichever items feel actually likely in the next 6 months.
+  - Q&A handoff is the next slide.
+-->
+
+---
+
+## Slide 16 — Thanks
+
+**Thanks.** Q&A.
+
+- Code: [github.com/petersalomonsen/javascriptmusic](https://github.com/petersalomonsen/javascriptmusic)
+- Hosted app: [petersalomonsen.com/webassemblymusic/livecodev2/](https://petersalomonsen.com/webassemblymusic/livecodev2/)
+- Demo videos: [bit.ly/wasm-music-demos](https://www.youtube.com/watch?v=C8j_ieOm4vE&list=PLv5wm4YuO4IxRDu1k8fSBVuUlULA8CRa7)
+- Book: *Building and Deploying WebAssembly Apps* — BPB Publications, 2025
+- Previously presented at WebAssembly Summit 2020, NEARCON 2021, WAC 2025
+
+References (per the abstract): Letz/Orlarey/Fober WAC 2017;
+`grame-cncm/faustwasm`; `faustide.grame.fr`; WebAssembly Music
+[doi:10.5281/zenodo.6772287](https://doi.org/10.5281/zenodo.6772287).
+
+<!--
+Speaker notes:
+  - Keep this up while taking questions. The links are the most useful
+    audience-takeaway artifact of the whole talk.
+-->
+
+---
+
+## Open decisions before the deck is final
+
+- **Slide tool**: Reveal.js (live-codable from this repo), Marp (just
+  markdown), Keynote, Quarto? Plan §1.6 leans Reveal-in-this-repo.
+- **One concrete code side-by-side slide** (Faust source ↔ transpiled
+  AS) — would strengthen slide 7 or slide 8, but adds visual density.
+- **Slide 11 (the -O0/-O1 cost slide)** is optional. Drop it if the
+  talk runs over.
+- **What to cut if running short**: slide 15 (what's next) and the
+  optional cost slide are the natural trims.

--- a/wasmaudioworklet/README.md
+++ b/wasmaudioworklet/README.md
@@ -24,6 +24,7 @@ https://petersalomonsen.com/webassemblymusic/livecodev2/?gist=a74d2d036b3ecaa01a
 # Documentation
 
 - [JavaScript Sequence API Documentation](midisequencer/SEQUENCE_API.md) - Complete reference for writing JavaScript music sequences
+- [Hosting a song project in a NEAR-backed git repo](wasmgit/README.md) - Create your own `?gitrepo=` repo and push a project to it (on-chain git storage)
 
 # Build / Run / Export to WAW
 

--- a/wasmaudioworklet/devserver.js
+++ b/wasmaudioworklet/devserver.js
@@ -26,6 +26,7 @@ const MIME_TYPES = {
   '.dsp': 'text/plain',
   '.txt': 'text/plain',
   '.map': 'application/json',
+  '.md': 'text/markdown',
 };
 
 const CROSS_ORIGIN_HEADERS = {

--- a/wasmaudioworklet/presentations/ifc2026-slides.html
+++ b/wasmaudioworklet/presentations/ifc2026-slides.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IFC 2026 — Converting Faust to AssemblyScript for WebAssembly Music</title>
+
+  <!-- Reveal.js core + a dark theme. Pinned to a specific version so the
+       deck renders the same on every machine. Swap "black" for "white",
+       "league", "moon", "night" etc. to taste. -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reset.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/theme/black.css" id="theme">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/monokai.min.css">
+
+  <style>
+    /* Lefty-aligned bullet lists read better than centered ones for code-heavy
+       slides; the Reveal default tries to center everything. */
+    .reveal .slides section { text-align: left; }
+    .reveal h1, .reveal h2, .reveal h3 { text-transform: none; }
+    .reveal pre code { max-height: 70vh; }
+    /* Tighter base scale than the Reveal default (42px) so denser slides
+       (bullet-heavy / code) don't overflow. Auto-fit still scales to viewport. */
+    .reveal { font-size: 28px; }
+    .reveal h1 { font-size: 2.2em; }
+    .reveal h2 { font-size: 1.6em; }
+    .reveal h3 { font-size: 1.25em; }
+    .reveal pre { font-size: 0.7em; line-height: 1.3; }
+    .reveal ul, .reveal ol { margin-left: 1em; }
+    .reveal li + li { margin-top: 0.2em; }
+  </style>
+</head>
+<body>
+  <div class="reveal">
+    <div class="slides">
+      <!--
+        Markdown is fetched and pre-transformed in the script below so that
+        ```mermaid blocks become raw <div class="mermaid"> nodes instead of
+        going through Reveal's syntax-highlighter (which would otherwise
+        bake hljs spans into the mermaid parser's input and break it).
+        `data-separator` then splits the result on stand-alone `---` lines.
+      -->
+      <section data-markdown
+               data-separator="^\r?\n---\r?\n">
+        <script type="text/template" id="slides-markdown"></script>
+      </section>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/dist/reveal.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/markdown/markdown.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/highlight/highlight.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/notes/notes.js"></script>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: 'dark',
+      flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
+    });
+
+    // Fetch the .md ourselves so we can rewrite ```mermaid fences into raw
+    // <div class="mermaid"> nodes before Reveal's markdown plugin runs.
+    // Otherwise RevealHighlight syntax-highlights those code blocks and the
+    // resulting hljs spans contaminate mermaid's parser input.
+    const mdText = await fetch('ifc2026-slides.md').then(r => r.text());
+    const transformed = mdText.replace(
+      /```mermaid\r?\n([\s\S]*?)\r?\n```/g,
+      (_, src) => {
+        // CommonMark's raw-HTML block (the <div>) ends at the first blank
+        // line — after which marked parses the rest as markdown again and
+        // wraps lines in <p>, corrupting the mermaid source. Drop blank
+        // lines (mermaid is fine without them) so the whole block stays raw.
+        const compact = src.split(/\r?\n/).filter(l => l.trim() !== '').join('\n');
+        return `<div class="mermaid">\n${compact}\n</div>`;
+      }
+    );
+    document.getElementById('slides-markdown').textContent = transformed;
+
+    await Reveal.initialize({
+      hash: true,            // URL hash → /#/3 navigation, easier to deep-link
+      slideNumber: 'c/t',    // "3 / 16" indicator bottom-right
+      controls: true,
+      progress: true,
+      transition: 'fade',
+      plugins: [RevealMarkdown, RevealHighlight, RevealNotes],
+    });
+
+    await mermaid.run({ querySelector: '.mermaid' });
+  </script>
+</body>
+</html>

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -221,10 +221,9 @@ Transpiler responsibilities:
 - Wave tables, static array declarations
 - UI metadata harvested from `ui_interface->declare(...)` calls
 
-→ Output compiles through the same in-browser AS pipeline as
-hand-written instruments.
+→ Compiles through the same in-browser AS pipeline as hand-written code.
 
-**▶ Demo** — the C backend: `faust2as.js` on a `.dsp` at the CLI.
+**▶ Demo** — `faust2as.js` on a `.dsp` at the CLI.
 
 <!--
 Speaker notes:

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -380,7 +380,7 @@ the .dsp mid-song.)
 the minimal demo repo and open `faust/simplesynth.dsp` in the Faust
 editor next to its transpiled AssemblyScript.
 
-`webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet`
+[webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet](https://webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet)
 
 Fallback: pre-recorded screencast of the same sequence, ready to play
 if audio routing misbehaves.

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -322,8 +322,8 @@ Speaker notes:
 
 ## Slide 11 — Does it scale? The optimize toggle
 
-Heavy DSPs (e.g. master_me, hundreds of state fields) can choke at the
-fast `-O0` live-compile default.
+Heavy DSPs (e.g. master_me, ~700 state fields) can choke at the fast
+`-O0` live-compile default.
 
 → One **"Optimize AssemblyScript"** checkbox flips to `-O1`.
 

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -322,14 +322,14 @@ Speaker notes:
 
 ## Slide 11 — Does it scale? The optimize toggle
 
-Heavy DSPs (e.g. master_me, ~700 state fields) can choke at the fast
-`-O0` live-compile default.
+Heavy DSPs (e.g. master_me, hundreds of state fields) can choke at the
+fast `-O0` live-compile default.
 
 → One **"Optimize AssemblyScript"** checkbox flips to `-O1`.
 
 | | `-O0` | `-O1` |
 | --- | --- | --- |
-| Compile | ~80 ms | ~600 ms |
+| Compile (master_me) | ~150 ms | ~800 ms |
 | Use for | rapid iteration | heavy-DSP playback |
 
 <!--
@@ -342,6 +342,9 @@ Speaker notes:
   - I can demo this live: toggle the checkbox on master_me and show the
     compile-time / playback difference. The toggle persists in
     localStorage (asOptimizeLevel).
+  - Numbers are measured (asc 0.28.9, master_me mix): -O0 ~150 ms /
+    178 KB, -O1 ~800 ms / 138 KB. Heavier mixes scale up (the full DX7
+    demo: ~0.3 s / ~1.4 s). Machine-dependent; quote as "order of".
 -->
 
 ---

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -1,38 +1,4 @@
-<!--
-IFC 2026 talk — slide proposal.
-
-Slides are separated by `---` so the file is readable as plain markdown
-and also drops cleanly into Marp / Reveal.js if we pick one of those for
-the actual deck. Each slide is a markdown section; speaker notes live in
-an HTML comment block (`<!-- speaker notes: ... -->`) so they don't
-render but stay close to the slide they belong to.
-
-Source of truth for the content here:
-  - The submitted abstract (~/Downloads/PeterSalomonsen (2).pdf)
-  - Top-level README.md (origin chain, 4klang quote)
-  - wasmaudioworklet/README.md (architecture details)
-  - ifc2026-plan.md §1.1 (the "what / why" framing we agreed on)
-
-Nothing is invented — every concrete claim traces back to one of these.
-The talk targets ~30 min total: ~17 min framing/explanation + ~10 min
-live demo + ~3 min Q&A.
--->
-
-# IFC 2026 — Slide proposal
-
-Title: *Converting Faust to AssemblyScript for WebAssembly Music*
-
-Author: Peter Salomonsen
-
-Target length: ~30 min (27 content + 3 Q&A)
-
-Slide count: 16
-
----
-
-## Slide 1 — Title
-
-**Converting Faust to AssemblyScript for WebAssembly Music**
+# Converting Faust to AssemblyScript for WebAssembly Music
 
 Peter Salomonsen
 petersalomonsen.com · github.com/petersalomonsen/javascriptmusic
@@ -56,16 +22,53 @@ Speaker notes:
 - One wasm module → multi-timbral MIDI synth with voice allocation
 - Sample-by-sample processing
 - AudioWorklet for low-latency playback
-- Synth wasm modules typically <16 KB
-
-→ insert `wasmaudioworklet/overview.svg` here as the architecture
-diagram.
+- Synth wasm modules: kilobytes, not megabytes
 
 <!--
 Speaker notes:
-  - Spend most of this slide on the diagram. The single-wasm-module
-    point is the key one for the Faust integration story later.
+  - Set up the architecture diagram on the next slide. The single-wasm-
+    module point is the key one for the Faust integration story later.
   - Resist the urge to demo here — the demo block is at slide 15.
+-->
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph Editor[Browser editor]
+    SONG["Song.js"]
+    SYNTH["Synth.ts"]
+    FAUST["Faust .dsp"]
+  end
+
+  F2A[["faust2as<br/>transpiler"]]
+  ASC[["AssemblyScript<br/>compiler"]]
+
+  subgraph Runtime[AudioWorklet]
+    SEQ["Sequencer"]
+    WASM["Wasm synth<br/>(kilobytes)"]
+  end
+
+  AUDIO(["Audio output"])
+
+  FAUST --> F2A
+  F2A -.->|transpiled .ts| ASC
+  SYNTH --> ASC
+  SONG -.->|pattern data| SEQ
+  ASC -.->|compiled .wasm| WASM
+  SEQ --> WASM
+  WASM --> AUDIO
+```
+
+<!--
+Speaker notes:
+  - Walk through the diagram left-to-right, top-to-bottom: three editable
+    source files → two compile paths converging on the wasm synth →
+    AudioWorklet runtime → audio.
+  - The Faust → faust2as → AS-compiler arrow is the talk's thesis;
+    everything later expands on it.
 -->
 
 ---
@@ -76,10 +79,9 @@ The origin chain (from the project's own README):
 
 1. **NodeJS + MIDI** controlling ZynAddSubFX. Songs as JS files. Worked,
    but the synth was a black box.
-2. **4klang** — compact synth from the 64K demoscene tradition.
+2. **4klang** — compact synth from the 64K demoscene tradition, which
    > *"finally inspired me to attempt writing a synth in WebAssembly
    > running entirely in the browser."*
-   > — `README.md`
 3. **WebAssembly synth in the browser, written in AssemblyScript.**
    First commits July 2018. AudioWorklet integration Nov 2018.
 

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -376,6 +376,12 @@ Faust sine + envelope → typed channel fields → DX7 algorithm with
 NRPN auto-mapping → master_me / live_master as a postprocess → hot-edit
 the .dsp mid-song.)
 
+**Code side-by-side** — instead of a static slide, show it live: load
+the minimal demo repo and open `faust/simplesynth.dsp` in the Faust
+editor next to its transpiled AssemblyScript.
+
+`webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet`
+
 Fallback: pre-recorded screencast of the same sequence, ready to play
 if audio routing misbehaves.
 
@@ -384,6 +390,11 @@ Speaker notes:
   - ~10 min. If pressed for time, cut the master_me step.
   - Always have headphones plugged into the laptop's headphone jack
     as a fallback monitor.
+  - The simplesynth repo is 3 files (faust/simplesynth.dsp, synth.ts,
+    song.js). On a fresh load, transpile the .dsp ONCE in the Faust
+    editor to generate faust/simplesynth.ts before compiling — do this
+    before going on stage. Must be the pages.dev host (OPFS); the
+    petersalomonsen.com build can't load ?gitrepo=.
 -->
 
 ---
@@ -428,7 +439,7 @@ Speaker notes:
 **Thanks.** Q&A.
 
 - Code: [github.com/petersalomonsen/javascriptmusic](https://github.com/petersalomonsen/javascriptmusic)
-- Hosted app: [petersalomonsen.com/webassemblymusic/livecodev2/](https://petersalomonsen.com/webassemblymusic/livecodev2/)
+- Hosted app: [webassemblymusic.pages.dev](https://webassemblymusic.pages.dev/)
 - Demo videos: [bit.ly/wasm-music-demos](https://www.youtube.com/watch?v=C8j_ieOm4vE&list=PLv5wm4YuO4IxRDu1k8fSBVuUlULA8CRa7)
 - Book: *Building and Deploying WebAssembly Apps* — BPB Publications, 2025
 - Previously presented at WebAssembly Summit 2020, NEARCON 2021, WAC 2025
@@ -447,10 +458,15 @@ Speaker notes:
 
 ## Open decisions before the deck is final
 
-- **Slide tool**: Reveal.js (live-codable from this repo), Marp (just
-  markdown), Keynote, Quarto? Plan §1.6 leans Reveal-in-this-repo.
-- **One concrete code side-by-side slide** (Faust source ↔ transpiled
-  AS) — would strengthen slide 7 or slide 8, but adds visual density.
+- ~~**Slide tool**~~ → **resolved**: Reveal.js, live-codable from this
+  repo (`ifc2026-slides.html`).
+- ~~**One concrete code side-by-side slide**~~ → **resolved**: shown
+  live in the app instead of a static slide — slide 14 loads the
+  `ifc2026-faust2as.gitfactory.testnet` demo repo and opens
+  `faust/simplesynth.dsp` beside its transpiled AS.
+
+Delivery contingencies (cut if over time, not deck blockers):
+
 - **Slide 11 (the -O0/-O1 cost slide)** is optional. Drop it if the
   talk runs over.
 - **What to cut if running short**: slide 15 (what's next) and the

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -271,14 +271,26 @@ Both paths emit the same AS class shape. Same convergent format means:
 - One shared helper module (`transpile-core.js`) → consistent doc-comment
   format, name derivation, NRPN mapping, etc.
 
-The C-backend path remains useful for offline batch transpiles
-(e.g. building a fixed instrument library to ship with a project).
-The ASC-backend path is what makes the live-coding workflow possible.
+Only the C transpiler can handle DSPs that pull in C headers via
+`ffunction` (e.g. the STK **piano**). The ASC path is what makes the
+live-coding workflow possible.
 
 <!--
 Speaker notes:
   - This is the "what we got for free" slide. Keep it short — the
     audience just needs to see the picture, not the details.
+  - Chronology matters here: when the abstract was submitted there was
+    NO asc backend in Faust — the C transpiler was the whole approach.
+    The asc backend was added to Faust shortly after (right after my
+    LinkedIn post about the C transpiler). So frame the C path as the
+    original contribution that still has unique reach, NOT as legacy
+    superseded by asc.
+  - The piano line is worth landing for a Faust crowd: the STK piano's
+    tuning/decay/strike tables come from piano.h via ffunction. The C
+    backend reads that header and regenerates the tables as AS lookup
+    arrays; the asc backend would emit calls to C functions that don't
+    exist in the wasm target. Most instruments (piano1.dsp included)
+    now go through asc fine, but this is the case that keeps C alive.
 -->
 
 ---

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -378,18 +378,34 @@ Speaker notes:
 
 ## Slide 15 — What's next
 
-- Multi-window concert orchestration (BroadcastChannel handoff between
-  tabs, already wired)
-- More mature Faust DSP library curation (currently per-project)
-- Possible: shipping a "Faust transpiler" Cloudflare Pages function so
-  one-off transpiles can happen without the editor
+Faust ↔ WebAssembly Music as a two-way street:
+
+- **Maturing the Faust + AS coexistence.** Mixing hand-written AS
+  instruments and transpiled Faust DSPs in one module works today
+  (you just saw it) — next is hardening it: more of the Faust library
+  transpiling cleanly, more instruments and effects combined per song,
+  fewer rough edges on arbitrary `.dsp` input.
+- **What WebAssembly Music adds on top of Faust.** A multi-timbral
+  MIDI synth engine — voice allocation, `MidiVoice` / `MidiChannel`
+  routing, CC/NRPN auto-mapping. The ability to combine Faust DSPs
+  with synths written directly in AssemblyScript in one module. And
+  driving it all from JavaScript code or a MIDI sequencer — including
+  real MIDI hardware.
 
 Out of scope for this talk: the AS optimization-level investigation
 that led to the in-toolbar `-O1` toggle. Happy to discuss in Q&A.
 
 <!--
 Speaker notes:
-  - Trim to whichever items feel actually likely in the next 6 months.
+  - This is the room's audience — lead with the second bullet. Framing
+    it as "what this project adds on top of Faust" is the part that
+    resonates at a Faust conference.
+  - The three additions to call out: (1) the multi-timbral MIDI synth
+    engine, (2) mixing Faust DSPs with hand-written AS synths in one
+    module, (3) JS-code or MIDI-sequencer control, including MIDI
+    hardware.
+  - Don't oversell bullet 1 as new; slides 5 and 13 already showed the
+    Faust+AS mix working. It's "deepen," not "build."
   - Q&A handoff is the next slide.
 -->
 

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -24,11 +24,14 @@ Speaker notes:
 - AudioWorklet for low-latency playback
 - Synth wasm modules: kilobytes, not megabytes
 
+**▶ Demo** — the running app: play a song, tour the editors.
+
 <!--
 Speaker notes:
   - Set up the architecture diagram on the next slide. The single-wasm-
     module point is the key one for the Faust integration story later.
-  - Resist the urge to demo here — the demo block is at slide 15.
+  - Quick app tour here — keep it short; the deep live-coding demo is
+    slide 14.
 -->
 
 ---
@@ -135,6 +138,8 @@ Music — not as separate AudioWorklet nodes, but as voices in one
 > *Multi-timbral* = many instruments at once, one per MIDI channel
 > (piano + bass + drums together).
 
+**▶ Demo** — the app: a multi-timbral Faust song in one module.
+
 <!--
 Speaker notes:
   - Be respectful about Faust IDE / faustwasm — they're great tools
@@ -219,6 +224,8 @@ Transpiler responsibilities:
 → Output compiles through the same in-browser AS pipeline as
 hand-written instruments.
 
+**▶ Demo** — the C backend: `faust2as.js` on a `.dsp` at the CLI.
+
 <!--
 Speaker notes:
   - One concrete code-side-by-side here would help — pick a 5-line
@@ -246,6 +253,9 @@ What you get without writing any glue code:
 get feedback(): f32 { return _dx7_alg5_feedback; }
 set feedback(value: f32) { _dx7_alg5_feedback = value; }
 ```
+
+**▶ Demo** — IntelliSense on the typed fields in VS Code (Claude bridge);
+then export the wasm and play it in the standalone player.
 
 <!--
 Speaker notes:
@@ -363,6 +373,8 @@ Examples in the repo: **master_me** (full mastering chain) and a small
 custom **live_master** (compressor + brickwall limiter, ~80 lines).
 Per the trade-off mentioned earlier, the heavy chain goes in offline
 export; the light one runs in the live audio thread.
+
+**▶ Demo** — add an effect on the output bus, hear it change.
 
 <!--
 Speaker notes:

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -131,9 +131,24 @@ Faust = widely adopted DSP language; mature instrument libraries
 Music — not as separate AudioWorklet nodes, but as voices in one
 **multi-timbral** synth engine, compiled into a single wasm module.
 
-> **Polyphonic** = many notes of *one* instrument at once.
-> **Multi-timbral** = many *different* instruments at once, one per MIDI
-> channel — e.g. piano, bass and drums playing together.
+> *Polyphonic* = many notes, one instrument.
+> *Multi-timbral* = many instruments at once, one per MIDI channel
+> (piano + bass + drums together).
+
+<!--
+Speaker notes:
+  - Be respectful about Faust IDE / faustwasm — they're great tools
+    with different goals. Position as "a different choice for a
+    different use case," not "we do it better."
+  - Multi-timbral: define polyphony first (many notes, one sound), then
+    multi-timbral (many sounds at once, one per channel). The DX7 demo
+    has e-piano/bass/strings/drums on channels 0–4 simultaneously.
+  - The comparison table is on the next slide.
+-->
+
+---
+
+## Slide 5b — faustwasm runtime vs. WebAssembly Music
 
 |                  | Faust IDE / `faustwasm` runtime               | WebAssembly Music + transpiler                          |
 | ---------------- | --------------------------------------------- | ------------------------------------------------------- |
@@ -144,17 +159,11 @@ Music — not as separate AudioWorklet nodes, but as voices in one
 
 <!--
 Speaker notes:
-  - Be respectful about Faust IDE / faustwasm — they're great tools
-    with different goals. Position as "a different choice for a
-    different use case," not "we do it better."
   - faustwasm DOES manage voices — its poly node has a real voice pool
     with stealing. What it does NOT do: route MIDI channel to different
     instruments (keyOn's channel arg is "not used for now"), or put
     several instruments in one module. So the value WAW adds is
     multi-timbral routing + one shared module, not "voice management".
-  - Multi-timbral: define polyphony first (many notes, one sound), then
-    multi-timbral (many sounds at once, one per channel). The DX7 demo
-    has e-piano/bass/strings/drums on channels 0–4 simultaneously.
   - DAW plugin: the EXPORTED .wasm (the same midisynth binary) loads in
     a JUCE/WasmEdge plugin via the same exports the AudioWorklet uses
     (shortmessage / fillSampleBufferWithNumSamples / samplebuffer). One

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -400,23 +400,18 @@ Speaker notes:
 
 → Live coding session at the laptop.
 
-(See `ifc2026-plan.md` §1.5 for the demo sequence: empty editor →
-Faust sine + envelope → typed channel fields → DX7 algorithm with
-NRPN auto-mapping → master_me / live_master as a postprocess → hot-edit
-the .dsp mid-song.)
-
 **Code side-by-side** — instead of a static slide, show it live: load
 the minimal demo repo and open `faust/simplesynth.dsp` in the Faust
 editor next to its transpiled AssemblyScript.
 
 [webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet](https://webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet)
 
-Fallback: pre-recorded screencast of the same sequence, ready to play
-if audio routing misbehaves.
-
 <!--
 Speaker notes:
   - ~10 min. If pressed for time, cut the master_me step.
+  - Demo sequence: empty editor → Faust sine + envelope → typed channel
+    fields → DX7 algorithm with NRPN auto-mapping → master_me /
+    live_master as a postprocess → hot-edit the .dsp mid-song.
   - Always have headphones plugged into the laptop's headphone jack
     as a fallback monitor.
   - The simplesynth repo is 3 files (faust/simplesynth.dsp, synth.ts,

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -320,27 +320,28 @@ Speaker notes:
 
 ---
 
-## Slide 11 — Cost: how we keep it cheap
+## Slide 11 — Does it scale? The optimize toggle
 
-Faust DSPs are big — master_me alone has ~700 internal state fields,
-hundreds of per-sample reads. At AS's `-O0` (live-compile default),
-every `this.fRec5` is a function call to an accessor wasm function.
-That overhead can choke real-time playback for heavy DSPs.
+Heavy DSPs (e.g. master_me, ~700 state fields) can choke at the fast
+`-O0` live-compile default.
 
-**Mitigation:** the in-browser worker takes `optimizeLevel: 1` (and
-makes it user-toggleable via a toolbar checkbox). At -O1, AS inlines
-the accessors and hoists invariant property reads out of hot loops.
-Compile time goes from ~80 ms to ~600 ms — still interactive.
+→ One **"Optimize AssemblyScript"** checkbox flips to `-O1`.
 
-The user picks the trade-off per session: fast-compile for rapid
-iteration, optimized for heavy-DSP playback.
+| | `-O0` | `-O1` |
+| --- | --- | --- |
+| Compile | ~80 ms | ~600 ms |
+| Use for | rapid iteration | heavy-DSP playback |
 
 <!--
 Speaker notes:
-  - Optional slide — drop if running long. Useful for the audience
-    that asks "OK but does it scale?".
-  - One sentence summary: bigger DSPs need -O1; the toggle is in the
-    toolbar.
+  - Optional slide — drop if running long. The audience question this
+    answers is "OK but does it scale?".
+  - Why -O0 is slow for big DSPs: each `this.fRec5` is an accessor
+    wasm-function call; -O1 inlines those and hoists invariant reads
+    out of the hot loop. Both still interactive.
+  - I can demo this live: toggle the checkbox on master_me and show the
+    compile-time / playback difference. The toggle persists in
+    localStorage (asOptimizeLevel).
 -->
 
 ---

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -128,21 +128,37 @@ Faust = widely adopted DSP language; mature instrument libraries
 (physical models, FM synths, mastering chains).
 
 **This talk:** make Faust instruments available *inside* WebAssembly
-Music — not as separate AudioWorklet nodes, but as part of the
-existing multi-timbral synth engine.
+Music — not as separate AudioWorklet nodes, but as voices in one
+**multi-timbral** synth engine, compiled into a single wasm module.
 
-|                         | Faust IDE / `faustwasm` runtime         | WebAssembly Music + transpiler                        |
-| ----------------------- | ---------------------------------------- | ----------------------------------------------------- |
-| Where Faust runs        | Its own AudioWorklet node per DSP        | Same wasm module as the rest of the synth             |
-| Voice management        | Faust's own polyphonic runtime           | Existing `MidiVoice` / `MidiChannel` infrastructure   |
-| Binary size             | ~3 MB Faust compiler runtime per session | Faust DSP compiled into the <100 KB synth module      |
-| Integration             | Faust DSP is an isolated effect node     | Faust DSP is a `MidiVoice` subclass; shares routing   |
+> **Polyphonic** = many notes of *one* instrument at once.
+> **Multi-timbral** = many *different* instruments at once, one per MIDI
+> channel — e.g. piano, bass and drums playing together.
+
+|                  | Faust IDE / `faustwasm` runtime               | WebAssembly Music + transpiler                          |
+| ---------------- | --------------------------------------------- | ------------------------------------------------------- |
+| Per DSP          | One AudioWorklet node, polyphonic, one timbre | One `MidiVoice` subclass compiled into the shared module |
+| Many instruments | Wire up N separate nodes in the audio graph   | Many Faust instruments **+ effects** in **one** module  |
+| Routing          | MIDI channel ignored (`not used for now`)     | Channel → instrument: **multi-timbral** out of the box  |
+| Where it runs    | Browser Web Audio graph                       | Same wasm runs in the browser **and as a DAW plugin**   |
 
 <!--
 Speaker notes:
   - Be respectful about Faust IDE / faustwasm — they're great tools
     with different goals. Position as "a different choice for a
     different use case," not "we do it better."
+  - faustwasm DOES manage voices — its poly node has a real voice pool
+    with stealing. What it does NOT do: route MIDI channel to different
+    instruments (keyOn's channel arg is "not used for now"), or put
+    several instruments in one module. So the value WAW adds is
+    multi-timbral routing + one shared module, not "voice management".
+  - Multi-timbral: define polyphony first (many notes, one sound), then
+    multi-timbral (many sounds at once, one per channel). The DX7 demo
+    has e-piano/bass/strings/drums on channels 0–4 simultaneously.
+  - DAW plugin: the EXPORTED .wasm (the same midisynth binary) loads in
+    a JUCE/WasmEdge plugin via the same exports the AudioWorklet uses
+    (shortmessage / fillSampleBufferWithNumSamples / samplebuffer). One
+    binary, browser and DAW. See dawplugin/ in the repo.
   - Source-to-source is the architectural commitment that follows
     from the single-wasm-module design.
 -->

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -439,9 +439,6 @@ Faust ↔ WebAssembly Music as a two-way street:
   driving it all from JavaScript code or a MIDI sequencer — including
   real MIDI hardware.
 
-Out of scope for this talk: the AS optimization-level investigation
-that led to the in-toolbar `-O1` toggle. Happy to discuss in Q&A.
-
 <!--
 Speaker notes:
   - This is the room's audience — lead with the second bullet. Framing

--- a/wasmaudioworklet/wasmgit/README.md
+++ b/wasmaudioworklet/wasmgit/README.md
@@ -1,0 +1,154 @@
+# Hosting a song project in a NEAR-backed git repo (`?gitrepo=`)
+
+WebAssembly Music can load a whole song/synth project straight from a git
+repository that lives **on the NEAR blockchain**, by adding `?gitrepo=` to the
+app URL:
+
+```
+https://webassemblymusic.pages.dev/?gitrepo=<name>.gitfactory.testnet
+```
+
+This document explains how the feature works and how to create your own repo
+and push a project to it. The on-chain git storage is provided by the separate
+[`near-git-storage`](https://github.com/petersalomonsen/near-git-storage)
+project; the code in this folder (`wasmgit/`) is the browser client.
+
+> **Use the `pages.dev` deployment.** The git client clones into OPFS (Origin
+> Private File System). `webassemblymusic.pages.dev` supports it;
+> `petersalomonsen.com/webassemblymusic/...` does **not**, so `?gitrepo=` will
+> silently fail to load there.
+
+## How it works
+
+- `?gitrepo=<name>.gitfactory.testnet` is resolved to `<origin>/near-repo/<name>.git`
+  ([`wasmgitclient.js`](wasmgitclient.js)).
+- A service worker (from `near-git-storage`) intercepts those git HTTP requests
+  and translates them into NEAR RPC calls — there is no server. Transaction
+  signing happens in the browser; the private key never leaves the client.
+- wasm-git clones the repo into OPFS and the editor loads the song/synth/shader
+  from it. The in-app **commit / pull / push** UI ([`wasmgitui.html`](wasmgitui.html))
+  writes changes back to the chain.
+
+## 1. Create the repo contract
+
+Each repo is a NEAR sub-account of the `gitfactory.testnet` factory. Create one
+from the web UI (no CLI needed):
+
+- <https://near-git-storage.pages.dev/create-repo> (or <https://gitfactory.testnet.page/>)
+- Connect your NEAR wallet — **this account becomes the repo owner; only the
+  owner can push.**
+- Enter a **repository name**: lowercase letters, digits and hyphens only (no
+  dots, no uppercase). It becomes `<name>.gitfactory.testnet`.
+- The form attaches ~1 NEAR to cover account creation, a 0.1 NEAR service fee,
+  and initial storage.
+
+## 2. Repository layout
+
+Minimum the app needs is a song and a synth at the repo **root**:
+
+```
+song.js      # the sequence (JavaScript)
+synth.ts     # the synth (AssemblyScript)
+```
+
+With no config file these are auto-detected (first `*.js` → song, first `*.ts`
+→ synth, first `*.glsl` → shader, scanning the repo root). Add a
+`wasmmusic.config.json` to be explicit and to ship multiple songs:
+
+```json
+{
+  "songfilename": "mysong/song.js",
+  "synthfilename": "mysong/synth.ts",
+  "fragmentshader": "shaders/myshader.glsl",
+  "allsongs": [
+    { "name": "My song", "songfilename": "mysong/song.js",
+      "synthfilename": "mysong/synth.ts", "fragmentshader": "shaders/myshader.glsl" }
+  ],
+  "name": "My song"
+}
+```
+
+Optional folders:
+
+- `faust/**/*.dsp` (+ transpiled `*.ts`) — Faust instruments/effects. The Faust
+  editor lists `faust/**/*.dsp`; the compiler injects `faust/**/*.ts`.
+- `shaders/*.glsl` — visualizer shaders.
+
+**Import paths.** `synth.ts` is compiled in the engine's `mixes/` context (as
+`mixes/midi.mix.ts`), regardless of where it sits in the repo. So it imports:
+
+```ts
+import { midichannels, MidiChannel } from '../mixes/globalimports';
+import { SAMPLERATE } from '../environment';
+import { MyInstrument, MyInstrumentChannel } from '../faust/myinstrument';
+```
+
+## 3. Push with `git-remote-near` (CLI)
+
+You can push from the in-app UI, or from the command line with the
+`git-remote-near` helper:
+
+```sh
+# one-time: install the remote helper from the near-git-storage repo
+cargo install --path git-remote-near
+
+# in your project directory
+git init -b main
+git add -A && git commit -m "initial song"
+git remote add origin near://<name>.gitfactory.testnet
+git push -u origin main
+```
+
+`git-remote-near` signs as the **repo owner**, reading the key from
+`~/.near-credentials/testnet/<owner>.json` (or the `NEAR_SIGNER_ACCOUNT` /
+`NEAR_SIGNER_KEY` env vars). Pushes use thin packfiles with delta compression,
+so incremental edits are tiny.
+
+## 4. Funding (storage staking)
+
+On-chain storage is **staked** against the repo account's balance. If a push
+fails with `LackBalanceForState`, top the account up:
+
+```sh
+near tokens <your-account> send-near <name>.gitfactory.testnet '1 NEAR' \
+  network-config testnet sign-with-legacy-keychain send
+```
+
+Rough guide: roughly ~1 NEAR per ~100 KB of stored packfile.
+
+## 5. Resetting a repo
+
+NEAR git storage is **append-only** — `git push -f` does *not* reclaim old
+objects (the helper only diffs against the remote ref and appends a pack). To
+wipe everything and start clean, call the contract's owner-only
+`clear_storage()`, then push fresh:
+
+```sh
+near contract call-function as-transaction <name>.gitfactory.testnet \
+  clear_storage json-args '{}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
+  sign-as <owner> network-config testnet sign-with-legacy-keychain send
+```
+
+For a clean history afterwards, re-init the local repo (`rm -rf .git && git init`)
+so a single fresh commit is pushed rather than the whole prior history.
+
+## 6. Load it
+
+```
+https://webassemblymusic.pages.dev/?gitrepo=<name>.gitfactory.testnet
+```
+
+## Faust instruments — note
+
+A `.dsp` is **not** transpiled during the synth compile. Open `faust/<name>.dsp`
+in the Faust editor and save it; that transpiles it to a sibling
+`faust/<name>.ts` (which `synth.ts` imports) and commits both. On a fresh repo,
+do this once before the synth will compile. Class names derive from the
+filename: `simplesynth.dsp` → `Simplesynth` / `SimplesynthChannel`.
+
+---
+
+For a tiny end-to-end example, see the repo
+`ifc2026-faust2as.gitfactory.testnet` (3 files: `faust/simplesynth.dsp`,
+`synth.ts`, `song.js`) loaded via
+<https://webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet>.


### PR DESCRIPTION
Draft — prep for the IFC 2026 talk *"Converting Faust to AssemblyScript for WebAssembly Music."* Two themes: the talk materials, and a generally-useful doc that came out of building the demo.

## Talk materials
- **`docs/presentations/ifc2026-plan.md`** — talk plan / structure.
- **`wasmaudioworklet/presentations/ifc2026-slides.{md,html}`** — in-browser reveal.js deck (markdown source + HTML shell with inline mermaid). Serve over http and open `presentations/ifc2026-slides.html`.
- **`wasmaudioworklet/devserver.js`** — add `.md` MIME type so the dev server serves the deck's markdown.

Notable slide content decisions:
- **Slide 5 / 5b** — positioned against the Faust IDE / `faustwasm` runtime: faustwasm is one AudioWorklet node per DSP with per-node polyphony but no MIDI-channel routing; WebAssembly Music compiles many Faust instruments + effects into one **multi-timbral** module, and the same exported `.wasm` also runs as a DAW plugin (`dawplugin/`). Includes a polyphonic-vs-multi-timbral definition. Claims verified against the `@psalomo/faustwasm` source.
- **Slide 10** notes that **only the C-backend transpiler** (`faust2as.js`) handles `ffunction` C-header DSPs (e.g. the STK piano); the `asc` backend can't bind foreign C.
- **Slide 11** (optimize toggle) carries **measured** `-O0`/`-O1` compile numbers (benchmarked via the real in-browser compile path on the master_me mix).
- **"What's next"** reframed around Faust ↔ AS coexistence.
- **Live demo cues**: visible `▶ Demo` markers placed through the deck (slides 2, 5, 7, 8, 12) plus the dedicated demo slide 14 — the talk demos throughout, not only at the end.
- The code **side-by-side is shown live in-app** (slide 14) via `?gitrepo=`, not as a static slide — linking the demo repo on the pages.dev host.

## Docs (useful beyond the talk)
- **`wasmaudioworklet/wasmgit/README.md`** — how to host a song project in a NEAR-backed git repo and load it via `?gitrepo=`: creating the repo contract (gitfactory web UI), repo layout + import-path model, pushing with `git-remote-near`, storage-staking funding (`LackBalanceForState`), resetting via `clear_storage()`, and the Faust `.dsp`→`.ts` transpile step. Linked from the main README.

## Not in this PR
- The live demo repo `ifc2026-faust2as.gitfactory.testnet` lives on NEAR testnet (external to this git repo). Load: https://webassemblymusic.pages.dev/?gitrepo=ifc2026-faust2as.gitfactory.testnet

## Viewing the deck
From `wasmaudioworklet/`: `python3 -m http.server 8099`, then open `http://localhost:8099/presentations/ifc2026-slides.html`. Press **S** for speaker notes. (Mermaid + the demo link verified rendering via Playwright. `file://` won't work — the deck `fetch`es the markdown.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)