### PR TITLE
docs: link the DX7 FM synth example from the docs index

### DIFF
--- a/wasmaudioworklet/docs/README.md
+++ b/wasmaudioworklet/docs/README.md
@@ -19,6 +19,7 @@ itself see the [app README](../README.md); for the monorepo overview see the
 ## Other docs in the repo
 
 - [faust2as transpiler](../../tools/faust2as/README.md) — Faust → AssemblyScript.
+- [DX7 FM synth example](../../examples/dx7/README.md) — Yamaha DX7 algorithms as transpiled instruments, and porting real ROM (`.syx`) patches into a channel.
 - [claude-bridge](../../tools/claude-bridge/README.md) — connect Claude Code to
   the app's editors.
 - [DAW plugin](../../dawplugin/README.md) — load exported wasm instruments in a DAW.


### PR DESCRIPTION
One-line docs pointer: link `examples/dx7/README.md` from the `wasmaudioworklet/docs/` index (under "Other docs in the repo"), so the DX7 algorithms + ROM-patch porting workflow (added in #143) is discoverable from the top-level docs. Verified the relative link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)