### PR TITLE
Shader dev harness + visualizer shader guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Notes for AI agents
+
+Orientation for agents working in this repo (a WebAssembly music + visuals app).
+Humans: see [README.md](README.md) and [wasmaudioworklet/docs](wasmaudioworklet/docs/README.md).
+
+## Where things are
+- `wasmaudioworklet/` — the app (synth engine, sequencer, visualizer, web UI).
+- `wasmaudioworklet/docs/` — authoring & dev guides (start at its README).
+- `tools/` — dev tooling: `faust2as` (Faust→AssemblyScript), `claude-bridge`
+  (connect an agent to the app's editors), `shadertest` (shader harness).
+- Songs/visuals are usually authored in separate NEAR-backed git repos loaded
+  via `?gitrepo=` (see [git-hosting](wasmaudioworklet/docs/git-hosting.md)); a
+  song project holds `song.js`, `synth.ts`, `shaders/`, `images/` and
+  `wasmmusic.config.json`.
+
+## Use the feedback loops (don't guess — verify)
+You can't see the canvas or hear the audio, so lean on the headless checks:
+- **Visualizer shaders**: compile + render frames headlessly with
+  `tools/shadertest/render.mjs` — see
+  [docs/shaders.md](wasmaudioworklet/docs/shaders.md). Always compile-check after
+  an edit; render frames at a few times/energies and read the PNGs before
+  claiming a shader works.
+- **Songs (`song.js`)**: it's ESM with top-level `await`; a quick
+  `node --check` catches syntax errors before loading in the app.
+- **Faust / AssemblyScript / near-git**: Playwright suites under
+  `wasmaudioworklet/e2e` (`npm run test-faust`, `test-near-git`, etc.).
+
+## Key guides
+- [Song API](wasmaudioworklet/docs/song-api.md), [Animations](wasmaudioworklet/docs/animations.md),
+  [Shaders](wasmaudioworklet/docs/shaders.md)
+- [faust2as](tools/faust2as/README.md), [claude-bridge](tools/claude-bridge/README.md)
+
+## Conventions
+- AssemblyScript synth code: `--runtime stub` (no GC), `StaticArray`, `f32` audio,
+  `Mathf.*`, sample-by-sample `nextframe()`.
+- Don't commit or push unless asked. If on the default branch, branch first.

--- a/tools/shadertest/render.mjs
+++ b/tools/shadertest/render.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/*
+ * Visualizer shader test harness.
+ *
+ * Compiles a WebAssembly-Music fragment shader in a headless WebGL context and
+ * renders still frames to PNG, with the same uniforms the app provides. This is
+ * the feedback loop for developing shaders without a human (or a GPU) in the
+ * loop: catch GLSL compile errors instantly, then eyeball / measure rendered
+ * frames at chosen times and "music energy".
+ *
+ * Requires Playwright, which is a dev-dependency of wasmaudioworklet — so run it
+ * from there (that is where node_modules/playwright resolves):
+ *
+ *   cd wasmaudioworklet
+ *   node ../tools/shadertest/render.mjs <shader.glsl> [options]
+ *
+ * Options:
+ *   --time <s>            time uniform, seconds (default 4)
+ *   --frames <t1,t2,...>  render several frames at these times (overrides --time)
+ *   --energy <0..1>       fake "music energy": fills a band of note states so
+ *                         note-reactive shaders light up (default 0.5)
+ *   --size <WxH>          framebuffer size (default 900x506)
+ *   --out <file.png>      output path (single frame). Default: /tmp/<name>_t<time>.png
+ *   --outdir <dir>        output dir for --frames (default /tmp)
+ *   --compile-only        just compile-check; print OK/FAIL and exit
+ *
+ * Exit code is non-zero if the shader fails to compile, so it doubles as a
+ * pre-commit / CI smoke check.
+ *
+ * Uniform contract (what the app binds — keep shaders compatible with these):
+ *   uniform vec2  resolution;              // framebuffer pixels
+ *   uniform float time;                    // seconds since the shader started
+ *   uniform float targetNoteStates[128];   // per MIDI note, -1..1, where -1 = "no note"
+ *                                          //   (a sounding note ~ velocity/127*2-1)
+ *   uniform float smoothedNoteStates[128]; // JS-smoothed view: fast attack, slow release
+ *   uniform sampler2D uSampler;            // active image/video frame (image shaders)
+ *   uniform sampler2D uSamplerPrev;        // previous frame (crossfade pair)
+ *   uniform float uMix;                    // 0..1 crossfade; pinned to 1 outside transitions
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+// Playwright is a dev-dependency of wasmaudioworklet; resolve it from there no
+// matter where this script is run from.
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const waw = path.resolve(scriptDir, '../../wasmaudioworklet');
+let chromium;
+try {
+  chromium = createRequire(path.join(waw, 'package.json'))('playwright').chromium;
+} catch (e) {
+  try { ({ chromium } = await import('playwright')); }
+  catch (e2) {
+    console.error('Could not load playwright. Install deps once:  (cd wasmaudioworklet && npm install)');
+    process.exit(2);
+  }
+}
+
+function parseArgs(argv) {
+  const a = { time: 4, energy: 0.5, size: '900x506', frames: null, out: null, outdir: '/tmp', compileOnly: false };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--time') a.time = parseFloat(argv[++i]);
+    else if (k === '--energy') a.energy = parseFloat(argv[++i]);
+    else if (k === '--size') a.size = argv[++i];
+    else if (k === '--frames') a.frames = argv[++i].split(',').map(Number);
+    else if (k === '--out') a.out = argv[++i];
+    else if (k === '--outdir') a.outdir = argv[++i];
+    else if (k === '--compile-only') a.compileOnly = true;
+    else rest.push(k);
+  }
+  a.shader = rest[0];
+  return a;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.shader) {
+  console.error('usage: node ../tools/shadertest/render.mjs <shader.glsl> [--time s] [--frames t1,t2] [--energy 0..1] [--size WxH] [--out f.png] [--compile-only]');
+  process.exit(2);
+}
+const src = fs.readFileSync(args.shader, 'utf8');
+const [W, H] = args.size.split('x').map(Number);
+const name = path.basename(args.shader).replace(/\.[^.]+$/, '');
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+// Headless compile check first — clear, fast failure with the GLSL info log.
+const compile = await page.evaluate((src) => {
+  const gl = document.createElement('canvas').getContext('webgl');
+  const sh = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(sh, src);
+  gl.compileShader(sh);
+  return gl.getShaderParameter(sh, gl.COMPILE_STATUS) ? 'OK' : gl.getShaderInfoLog(sh);
+}, src);
+if (compile !== 'OK') {
+  console.error(`COMPILE FAIL (${args.shader}):\n${compile}`);
+  await browser.close();
+  process.exit(1);
+}
+console.log(`COMPILE OK  ${args.shader}`);
+if (args.compileOnly) { await browser.close(); process.exit(0); }
+
+async function render(time) {
+  const r = await page.evaluate(({ src, W, H, time, energy }) => {
+    const cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+    const gl = cv.getContext('webgl', { preserveDrawingBuffer: true });
+    const mk = (type, s) => { const o = gl.createShader(type); gl.shaderSource(o, s); gl.compileShader(o); return o; };
+    const vs = mk(gl.VERTEX_SHADER, 'attribute vec2 a_position;void main(){gl_Position=vec4(a_position,0.0,1.0);}');
+    const fs = mk(gl.FRAGMENT_SHADER, src);
+    const p = gl.createProgram(); gl.attachShader(p, vs); gl.attachShader(p, fs); gl.linkProgram(p); gl.useProgram(p);
+    const buf = gl.createBuffer(); gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]), gl.STATIC_DRAW);
+    const loc = gl.getAttribLocation(p, 'a_position');
+    gl.enableVertexAttribArray(loc); gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
+    const set2 = (n, x, y) => { const l = gl.getUniformLocation(p, n); if (l) gl.uniform2f(l, x, y); };
+    const set1 = (n, x) => { const l = gl.getUniformLocation(p, n); if (l) gl.uniform1f(l, x); };
+    const setv = (n, arr) => { const l = gl.getUniformLocation(p, n); if (l) gl.uniform1fv(l, arr); };
+    set2('resolution', W, H);
+    set1('time', time);
+    set1('uMix', 1.0);
+    // note states: -1 = silent; fill a band to 'energy' to simulate sounding notes.
+    const z = new Float32Array(128).fill(-1);
+    for (let i = 20; i < 20 + Math.floor(energy * 60); i++) z[i] = 0.9;
+    setv('targetNoteStates', z);
+    setv('smoothedNoteStates', z);
+    // bind a 1x1 texture for image shaders so uSampler/uSamplerPrev don't error.
+    for (let u = 0; u < 2; u++) {
+      const name = u === 0 ? 'uSampler' : 'uSamplerPrev';
+      const l = gl.getUniformLocation(p, name); if (!l) continue;
+      const tex = gl.createTexture(); gl.activeTexture(gl.TEXTURE0 + u); gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([90, 90, 90, 255]));
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.uniform1i(l, u);
+    }
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+    // simple "did it draw anything" metric: fraction of non-near-black pixels.
+    const px = new Uint8Array(W * H * 4); gl.readPixels(0, 0, W, H, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    let lit = 0; for (let i = 0; i < px.length; i += 4) if (px[i] + px[i + 1] + px[i + 2] > 24) lit++;
+    return { url: cv.toDataURL('image/png'), litPct: Math.round((100 * lit) / (W * H)) };
+  }, { src, W, H, time, energy: args.energy });
+  return r;
+}
+
+const times = args.frames ?? [args.time];
+for (const tm of times) {
+  const r = await render(tm);
+  const out = args.frames
+    ? path.join(args.outdir, `${name}_t${tm}.png`)
+    : (args.out ?? path.join(args.outdir, `${name}_t${tm}.png`));
+  fs.writeFileSync(out, Buffer.from(r.url.split(',')[1], 'base64'));
+  console.log(`  t=${tm}s  energy=${args.energy}  lit=${r.litPct}%  -> ${out}`);
+}
+
+await browser.close();

--- a/wasmaudioworklet/docs/README.md
+++ b/wasmaudioworklet/docs/README.md
@@ -10,6 +10,9 @@ itself see the [app README](../README.md); for the monorepo overview see the
   JavaScript: tracks, patterns, notes, timing, instruments, audio & video.
 - [Animating images & text](animations.md) — frame-by-frame animation, text
   overlays, letterboxing and fades in the visualizer.
+- [Developing & testing visualizer shaders](shaders.md) — the fragment-shader
+  uniform contract and a headless compile + render harness
+  ([tools/shadertest](../../tools/shadertest/render.mjs)).
 
 ## Sharing & hosting
 

--- a/wasmaudioworklet/docs/shaders.md
+++ b/wasmaudioworklet/docs/shaders.md
@@ -1,0 +1,95 @@
+# Developing & testing visualizer shaders
+
+The visualizer renders a full-screen **fragment shader** (WebGL1 / GLSL ES 1.00)
+behind the music. Shaders live in a song project's `shaders/` folder and are
+selected per song in `wasmmusic.config.json` (`fragmentshader`, plus the
+`availableShaders` picker list). This guide is the contract every shader must
+follow and the headless feedback loop for building one without a GPU in front of
+you — useful for humans and essential for agents (which can't see the canvas).
+
+For images/video, text overlays and frame-by-frame animation that a shader
+samples, see [animations.md](animations.md). This doc is about the shader itself.
+
+## Uniform contract
+
+The renderer binds these uniforms. Declare the ones you use; unused ones can be
+omitted (but keep `uSampler`/`uSamplerPrev`/`uMix` referenced if you sample
+images — see animations.md):
+
+```glsl
+precision highp float;
+uniform vec2  resolution;              // framebuffer size in pixels
+uniform float time;                    // seconds since the shader started (~song time)
+uniform float targetNoteStates[128];   // per MIDI note 0..127, value in -1..1
+                                       //   -1 == "no note". A sounding note maps from
+                                       //   velocity: value ≈ velocity/127*2 - 1.
+uniform float smoothedNoteStates[128]; // JS-smoothed view of the above: FAST attack
+                                       //   (snaps up on note-on), SLOW release.
+uniform sampler2D uSampler;            // active image/video frame (image shaders)
+uniform sampler2D uSamplerPrev;        // previous frame (crossfade pair)
+uniform float uMix;                    // 0..1 crossfade; pinned to 1 outside transitions
+```
+
+Common idioms:
+
+```glsl
+// aspect-correct, centered coords, y up:
+vec2 uv = (gl_FragCoord.xy - 0.5 * resolution.xy) / resolution.y;
+
+// aggregate note energy 0..1 (only sounding notes contribute, since -1 -> 0):
+float e = 0.0;
+for (int i = 0; i < 128; i++) e += max(0.0, smoothedNoteStates[i] * 0.5 + 0.5);
+e = clamp(e / 24.0, 0.0, 1.0);
+```
+
+- Use `smoothedNoteStates` for eased/visual reactions; use the raw
+  `targetNoteStates` for sharp note-on gates (it falls back to -1 quickly).
+- Split the 0..127 range into bass/mid/treble bands if you want frequency-ish
+  reactions (low indices ≈ bass).
+- Note: the smoothing **attack is instant** (it snaps on note-on). There is no
+  per-clip / tempo clock uniform — if you need tempo-locked motion, derive it
+  from `time` (e.g. `beat = time * BPM/60`).
+
+## The test harness
+
+[`tools/shadertest/render.mjs`](../../tools/shadertest/render.mjs) compiles a
+shader in headless WebGL and renders PNG frames with the uniforms above. It uses
+Playwright (a dev-dependency of this package), so run it from `wasmaudioworklet`:
+
+```sh
+cd wasmaudioworklet
+npm install                                   # once, to get Playwright
+
+# compile-check only (fast; non-zero exit on failure → good for pre-commit/CI):
+node ../tools/shadertest/render.mjs path/to/shader.glsl --compile-only
+
+# render a frame at a given time and fake "music energy":
+node ../tools/shadertest/render.mjs path/to/shader.glsl --time 6 --energy 0.7
+
+# render several frames (e.g. across a beat or a camera move):
+node ../tools/shadertest/render.mjs path/to/shader.glsl --frames 3,18,30 --energy 0.8
+```
+
+Options: `--time <s>`, `--frames <t1,t2,..>`, `--energy <0..1>` (fills a band of
+note states so reactive shaders light up), `--size <WxH>`, `--out <file.png>`,
+`--outdir <dir>`, `--compile-only`. On a compile error it prints the GLSL info
+log and exits non-zero. Each rendered frame prints a `lit=NN%` metric (fraction
+of non-black pixels) — a quick "did anything draw" sanity check.
+
+The loop that works well:
+
+1. **Compile-check** after every edit — catches the dumb GLSL errors instantly.
+2. **Render** a few frames at representative times / energies and look at the
+   PNGs (open them, or an agent reads them back).
+3. For objective checks, extend the harness to `readPixels` and **measure** —
+   e.g. count bright pixels in a region to confirm a reaction scales with
+   `--energy`, or compare a calm vs loud frame — rather than only eyeballing.
+
+## Adding a shader to a song
+
+1. Put `shader_<name>.glsl` in the song project's `shaders/` folder.
+2. Implement the uniform contract above.
+3. In `wasmmusic.config.json`: set the song's `fragmentshader` to
+   `shaders/shader_<name>.glsl`, and add an entry to `availableShaders` so it
+   shows in the picker.
+4. Verify with the harness before loading it in the app.


### PR DESCRIPTION
Adds reusable tooling and documentation for the visualizer fragment-shader workflow — useful for humans extending shaders, and essential for agents that can't see the canvas.

## What's included
- **`tools/shadertest/render.mjs`** — a headless shader test harness. Compiles a shader in WebGL (non-zero exit + GLSL info log on failure, so it works as a pre-commit/CI check) and renders PNG frames with the app's uniforms. Handles procedural and image (`uSampler`) shaders, prints a `lit=%` "did it draw" metric, and resolves Playwright from `wasmaudioworklet/` so it runs from any cwd.
  ```sh
  cd wasmaudioworklet
  node ../tools/shadertest/render.mjs path/to/shader.glsl --compile-only
  node ../tools/shadertest/render.mjs path/to/shader.glsl --frames 3,18,30 --energy 0.8
  ```
- **`wasmaudioworklet/docs/shaders.md`** — the fragment-shader uniform contract (with correct note-state semantics: `targetNoteStates` is −1..1 where −1 = "no note"; `smoothedNoteStates` is fast-attack/slow-release; no tempo uniform → derive beats from `time`), common idioms, the compile → render → measure loop, and how to wire a shader into a song. Linked from the docs index.
- **`AGENTS.md`** — repo orientation for agents and the dev feedback loops to use (shader harness, `node --check` for songs, the Playwright e2e suites).

## Notes
- Verified the harness on existing shaders (procedural + image) and on a deliberately broken shader (fails with the GLSL log, exit 1).
- No app/runtime code changes; docs + a dev tool only.
- The per-song-repo `shaders/README.md` (in song projects) is now superseded by `docs/shaders.md` as the canonical reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)