### PR TITLE
Fix: reset playing flag after compilation failure

### DIFF
--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -43,13 +43,13 @@ export function initAudioWorkletNode(componentRoot) {
             return;
         }
         playing = true;
+        try {
+            // For Safari iOS, MUST happen before using "await"
+            context.resume();
 
-        // For Safari iOS, MUST happen before using "await"
-        context.resume();
+            const song = await window.compileSong();
 
-        const song = await window.compileSong();
-
-        let bytes;
+            let bytes;
 
         if (song.eventlist) {
             await context.audioWorklet.addModule(getAudioWorkletModuleUrl(AudioWorkletProcessorSequencerModule));
@@ -157,6 +157,10 @@ export function initAudioWorkletNode(componentRoot) {
         recordAudioNode(audioworkletnode);
         componentRoot.getElementById('startaudiobutton').style.display = 'none';
         componentRoot.getElementById('stopaudiobutton').style.display = 'block';
+        } catch (e) {
+            playing = false;
+            throw e;
+        }
     };
 
     window.stopaudio = async () => {

--- a/wasmaudioworklet/e2e/faust-save-then-play-bug.spec.js
+++ b/wasmaudioworklet/e2e/faust-save-then-play-bug.spec.js
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test';
+import {
+    NEAR_REPO_CONTRACT,
+    setupServiceWorker,
+    clearOPFS,
+    waitForAppReady,
+    pushBaseline,
+    readRepoFile,
+} from './near-git-helpers.js';
+import { fetchCredentials } from './near-git-helpers.js';
+
+const repoName = NEAR_REPO_CONTRACT + '.git';
+
+const SIMPLESYNTH_DSP = `import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
+`;
+
+const SYNTH_MIX_SOURCE = `// uses midichannels (route via midi.mix)
+import { initializeMidiSynth, postprocess } from '../faust/simplesynth';
+export { initializeMidiSynth, postprocess };
+`;
+
+const SONG_SOURCE = `setBPM(120);
+
+await createTrack(0).steps(4, [
+    c4,, e4,,
+]);
+
+loopHere();
+`;
+
+// Helper to set up repo with song.js, synth.ts, and faust/simplesynth.dsp but NO faust/simplesynth.ts
+async function setupInitialRepo(page) {
+    await pushBaseline(page, repoName, SONG_SOURCE);
+    
+    const creds = await fetchCredentials();
+    const accessToken = JSON.stringify({
+        accountId: creds.accountId,
+        publicKey: creds.publicKey.replace('ed25519:', ''),
+        privateKey: creds.secretKey.replace('ed25519:', ''),
+    });
+
+    await page.evaluate(async ({ repoUrl, accessToken, username, synthMixSource, simplesynthDsp }) => {
+        const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
+        let resolveNext;
+        const pending = [];
+        worker.onmessage = (msg) => {
+            if (resolveNext) { const r = resolveNext; resolveNext = null; r(msg.data); }
+            else pending.push(msg.data);
+        };
+        const next = () => pending.length > 0 ? Promise.resolve(pending.shift()) : new Promise(r => { resolveNext = r; });
+
+        worker.postMessage({ accessToken, username, useremail: username });
+        await next();
+        worker.postMessage({ command: 'clone', url: repoUrl });
+        await next();
+
+        let id = 100;
+        worker.postMessage({ command: 'init', args: ['.'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'remote', args: ['add', 'origin', repoUrl], id: id++ });
+        await next();
+
+        // Write synth.ts
+        worker.postMessage({ command: 'writefileandstage', filename: 'synth.ts', contents: synthMixSource });
+        await next();
+        
+        // Create faust directory and write simplesynth.dsp
+        worker.postMessage({ command: 'mkdir', args: ['faust'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'writefileandstage', filename: 'faust/simplesynth.dsp', contents: simplesynthDsp });
+        await next();
+
+        worker.postMessage({ command: 'config', args: ['user.name', 'Test'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'config', args: ['user.email', 'test@test.com'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'commitpullpush', commitmessage: 'initial: dsp without ts', id: id++ });
+        await next();
+        worker.terminate();
+    }, {
+        repoUrl: `http://localhost:8080/near-repo/${repoName}`,
+        accessToken,
+        username: creds.accountId,
+        synthMixSource: SYNTH_MIX_SOURCE,
+        simplesynthDsp: SIMPLESYNTH_DSP,
+    });
+}
+
+test.describe('Faust: save DSP then play bug - playing flag fix', () => {
+    test.beforeEach(async ({ page }) => {
+        await clearOPFS(page, repoName);
+    });
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, repoName);
+    });
+
+    test('After Faust DSP is saved, play works without page reload', async ({ page }) => {
+        page.on('console', (m) => { if (m.type() === 'error') console.log('[browser]', m.text()); });
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+
+        await page.goto('http://localhost:8080');
+        await setupServiceWorker(page);
+        await setupInitialRepo(page);
+        await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+        await waitForAppReady(page);
+
+        // Step 1: Click play (start button) - should fail because faust/simplesynth.ts doesn't exist yet
+        await page.locator('#startaudiobutton').click();
+        await page.waitForTimeout(5000); // Wait for compilation to complete (and fail)
+        
+        // Verify compilation failed (WASM_SYNTH_BYTES should be null/undefined)
+        const wasmBefore = await page.evaluate(() => window.WASM_SYNTH_BYTES);
+        expect(wasmBefore).toBeFalsy();
+
+        // Step 2: Open Faust editor
+        await page.locator('#fausteditortogglecheckbox').check();
+        
+        // Wait for Faust file list to populate
+        await page.waitForFunction(() => {
+            const sel = document.querySelector('app-javascriptmusic').shadowRoot
+                .getElementById('faustfileselect');
+            return sel && Array.from(sel.options).some(opt => opt.value === 'faust/simplesynth.dsp');
+        }, { timeout: 10000 });
+
+        // Select simplesynth.dsp
+        await page.evaluate(() => {
+            const root = document.querySelector('app-javascriptmusic').shadowRoot;
+            const sel = root.getElementById('faustfileselect');
+            sel.value = 'faust/simplesynth.dsp';
+            sel.dispatchEvent(new Event('change'));
+        });
+        
+        // Wait for file to load
+        await page.waitForFunction(() => {
+            const cm = document.querySelector('app-javascriptmusic').shadowRoot
+                .querySelector('#faustcodemirror .CodeMirror');
+            return cm && cm.CodeMirror.getValue().includes('hslider');
+        }, { timeout: 10000 });
+
+        // Make a small change to trigger transpilation
+        await page.evaluate(() => {
+            const cm = document.querySelector('app-javascriptmusic').shadowRoot
+                .querySelector('#faustcodemirror .CodeMirror');
+            const current = cm.CodeMirror.getValue();
+            cm.CodeMirror.setValue(current + '\n// test');
+        });
+
+        // Save the Faust file - this creates faust/simplesynth.ts
+        await page.evaluate(async () => {
+            await window.__saveFaustIfChanged();
+        });
+        
+        // Verify the .ts file was created by checking the save status
+        const saveStatus = await page.evaluate(() => {
+            return document.querySelector('app-javascriptmusic').shadowRoot
+                .getElementById('faustsavestatus').textContent;
+        });
+        // The save status shows the basename without the faust/ prefix
+        expect(saveStatus).toContain('Saved simplesynth.dsp');
+        expect(saveStatus).toContain("import { Simplesynth } from '../faust/simplesynth'");
+        
+        // Wait a moment for the file to be committed
+        await page.waitForTimeout(2000);
+        
+        // Verify the .ts file exists in the repo
+        const tsExists = await readRepoFile(page, repoName, 'faust/simplesynth.ts');
+        expect(tsExists).toBeTruthy();
+
+        // Step 3: Click play again - this SHOULD work without page reload
+        // The fix: reset window.WASM_SYNTH_BYTES to ensure fresh compilation
+        await page.evaluate(() => { window.WASM_SYNTH_BYTES = null; });
+        await page.locator('#startaudiobutton').click();
+        
+        // Wait for compilation to complete
+        await page.waitForTimeout(15000);
+        
+        // Check if WASM_SYNTH_BYTES was set (compilation succeeded)
+        const wasmAfter = await page.evaluate(() => window.WASM_SYNTH_BYTES);
+        
+        // With the fix (try-catch resetting playing flag), this should succeed
+        expect(wasmAfter).toBeTruthy();
+        const wasmBytes = await page.evaluate(() => window.WASM_SYNTH_BYTES ? window.WASM_SYNTH_BYTES.byteLength : 0);
+        expect(wasmBytes).toBeGreaterThan(1000);
+    });
+});

--- a/wasmaudioworklet/e2e/faust-save-then-play-bug.spec.js
+++ b/wasmaudioworklet/e2e/faust-save-then-play-bug.spec.js
@@ -32,18 +32,19 @@ await createTrack(0).steps(4, [
 loopHere();
 `;
 
-// Helper to set up repo with song.js, synth.ts, and faust/simplesynth.dsp but NO faust/simplesynth.ts
+// Helper to set up repo with everything pushed in a single worker session.
+// Uses a single clone + writes to avoid the "directory already exists" hang
+// that occurs when cloning the same repo in separate workers.
 async function setupInitialRepo(page) {
-    await pushBaseline(page, repoName, SONG_SOURCE);
-    
     const creds = await fetchCredentials();
     const accessToken = JSON.stringify({
         accountId: creds.accountId,
         publicKey: creds.publicKey.replace('ed25519:', ''),
         privateKey: creds.secretKey.replace('ed25519:', ''),
     });
+    const repoUrl = `http://localhost:8080/near-repo/${repoName}`;
 
-    await page.evaluate(async ({ repoUrl, accessToken, username, synthMixSource, simplesynthDsp }) => {
+    await page.evaluate(async ({ repoUrl, accessToken, username, songSource, synthMixSource, simplesynthDsp }) => {
         const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
         let resolveNext;
         const pending = [];
@@ -55,6 +56,8 @@ async function setupInitialRepo(page) {
 
         worker.postMessage({ accessToken, username, useremail: username });
         await next();
+
+        // Clone the repo (first clone — succeeds because directory is clean)
         worker.postMessage({ command: 'clone', url: repoUrl });
         await next();
 
@@ -64,13 +67,15 @@ async function setupInitialRepo(page) {
         worker.postMessage({ command: 'remote', args: ['add', 'origin', repoUrl], id: id++ });
         await next();
 
+        // Write song.js
+        worker.postMessage({ command: 'writefileandstage', filename: 'song.js', contents: songSource });
+        await next();
+
         // Write synth.ts
         worker.postMessage({ command: 'writefileandstage', filename: 'synth.ts', contents: synthMixSource });
         await next();
-        
-        // Create faust directory and write simplesynth.dsp
-        worker.postMessage({ command: 'mkdir', args: ['faust'], id: id++ });
-        await next();
+
+        // Create faust/ directory and write simplesynth.dsp
         worker.postMessage({ command: 'writefileandstage', filename: 'faust/simplesynth.dsp', contents: simplesynthDsp });
         await next();
 
@@ -82,9 +87,10 @@ async function setupInitialRepo(page) {
         await next();
         worker.terminate();
     }, {
-        repoUrl: `http://localhost:8080/near-repo/${repoName}`,
+        repoUrl,
         accessToken,
         username: creds.accountId,
+        songSource: SONG_SOURCE,
         synthMixSource: SYNTH_MIX_SOURCE,
         simplesynthDsp: SIMPLESYNTH_DSP,
     });
@@ -111,14 +117,14 @@ test.describe('Faust: save DSP then play bug - playing flag fix', () => {
         // Step 1: Click play (start button) - should fail because faust/simplesynth.ts doesn't exist yet
         await page.locator('#startaudiobutton').click();
         await page.waitForTimeout(5000); // Wait for compilation to complete (and fail)
-        
+
         // Verify compilation failed (WASM_SYNTH_BYTES should be null/undefined)
         const wasmBefore = await page.evaluate(() => window.WASM_SYNTH_BYTES);
         expect(wasmBefore).toBeFalsy();
 
         // Step 2: Open Faust editor
         await page.locator('#fausteditortogglecheckbox').check();
-        
+
         // Wait for Faust file list to populate
         await page.waitForFunction(() => {
             const sel = document.querySelector('app-javascriptmusic').shadowRoot
@@ -133,7 +139,7 @@ test.describe('Faust: save DSP then play bug - playing flag fix', () => {
             sel.value = 'faust/simplesynth.dsp';
             sel.dispatchEvent(new Event('change'));
         });
-        
+
         // Wait for file to load
         await page.waitForFunction(() => {
             const cm = document.querySelector('app-javascriptmusic').shadowRoot
@@ -153,7 +159,7 @@ test.describe('Faust: save DSP then play bug - playing flag fix', () => {
         await page.evaluate(async () => {
             await window.__saveFaustIfChanged();
         });
-        
+
         // Verify the .ts file was created by checking the save status
         const saveStatus = await page.evaluate(() => {
             return document.querySelector('app-javascriptmusic').shadowRoot
@@ -162,25 +168,30 @@ test.describe('Faust: save DSP then play bug - playing flag fix', () => {
         // The save status shows the basename without the faust/ prefix
         expect(saveStatus).toContain('Saved simplesynth.dsp');
         expect(saveStatus).toContain("import { Simplesynth } from '../faust/simplesynth'");
-        
+
         // Wait a moment for the file to be committed
         await page.waitForTimeout(2000);
-        
+
         // Verify the .ts file exists in the repo
         const tsExists = await readRepoFile(page, repoName, 'faust/simplesynth.ts');
         expect(tsExists).toBeTruthy();
 
-        // Step 3: Click play again - this SHOULD work without page reload
-        // The fix: reset window.WASM_SYNTH_BYTES to ensure fresh compilation
+        // Step 3: Click play again - this SHOULD work without page reload.
+        // The actual fix under test is the `playing` flag reset in
+        // audioworkletnode.js (without it, this click returns early at the
+        // `if (playing) return` guard and never recompiles). We null
+        // WASM_SYNTH_BYTES first purely as a test precaution, so the final
+        // assertion can only pass if THIS click triggered a fresh successful
+        // compile - not because of bytes left over from an earlier step.
         await page.evaluate(() => { window.WASM_SYNTH_BYTES = null; });
         await page.locator('#startaudiobutton').click();
-        
+
         // Wait for compilation to complete
         await page.waitForTimeout(15000);
-        
+
         // Check if WASM_SYNTH_BYTES was set (compilation succeeded)
         const wasmAfter = await page.evaluate(() => window.WASM_SYNTH_BYTES);
-        
+
         // With the fix (try-catch resetting playing flag), this should succeed
         expect(wasmAfter).toBeTruthy();
         const wasmBytes = await page.evaluate(() => window.WASM_SYNTH_BYTES ? window.WASM_SYNTH_BYTES.byteLength : 0);

--- a/wasmaudioworklet/e2e/near-git-helpers.js
+++ b/wasmaudioworklet/e2e/near-git-helpers.js
@@ -127,15 +127,24 @@ export async function readRepoFile(page, repoName, filename) {
         const next = () => pending.length > 0 ? Promise.resolve(pending.shift()) : new Promise(r => { resolveNext = r; });
         try {
             // The repo is already in OPFS from the page's editor session.
-            // Replay just enough to get the worker into the right cwd.
-            worker.postMessage({ accessToken: '', username: '', useremail: '' });
-            await next();
-            worker.postMessage({ command: 'clone', url: repoUrl });
-            await next();
-            let id = 200;
-            worker.postMessage({ command: 'readfile', filename, id: id++ });
+            // Use synclocal to attach this fresh worker to the existing OPFS
+            // repo (clone would fail because the directory already exists).
+            // No auth handshake here: reading from local OPFS needs no token,
+            // and an empty-string accessToken is falsy in the worker, so it
+            // would never reply and this await would hang.
+            worker.postMessage({ command: 'synclocal', url: repoUrl });
+            const sync = await next();
+            if (!sync || !sync.dircontents) {
+                return null; // repo not present in OPFS
+            }
+            worker.postMessage({ command: 'readfile', filename });
             const reply = await next();
-            return reply && reply.contents;
+            if (!reply || reply.error) {
+                return null; // file not found
+            }
+            return typeof reply.filecontents === 'string'
+                ? reply.filecontents
+                : new TextDecoder().decode(reply.filecontents);
         } finally {
             worker.terminate();
         }


### PR DESCRIPTION
When a play attempt fails due to a missing Faust .ts file, the 'playing' flag in audioworkletnode.js was left as true, preventing subsequent play attempts from starting the compilation process. After saving the Faust file to create the .ts, clicking play would do nothing.

Fix: Wrap the startaudio() function body in a try-catch block to reset the playing flag to false when compileSong() throws an error.

Includes a Playwright test (`e2e/faust-save-then-play-bug.spec.js`) that reproduces the bug:
1. Load page with repo containing `faust/simplesynth.dsp` but no `.ts`
2. Click play → compilation fails, `playing` flag is stuck at true
3. Save Faust file → creates `faust/simplesynth.ts`
4. Click play → works with the fix; without it the click returns early at the `if (playing) return` guard and never recompiles

Verified: the test passes with the fix and fails against the pre-fix code.