### PR TITLE
docs: Faust effects guide with a doc-as-source-of-truth audio test

### DIFF
--- a/wasmaudioworklet/docs/README.md
+++ b/wasmaudioworklet/docs/README.md
@@ -21,6 +21,9 @@ itself see the [app README](../README.md); for the monorepo overview see the
 - [Developing & testing visualizer shaders](shaders.md) — the fragment-shader
   uniform contract and a headless compile + render harness
   ([tools/shadertest](../../tools/shadertest/render.mjs)).
+- [Faust effects: channel & master](effects.md) — adding a per-instrument
+  effect (`effect =`) or a whole-mix master effect (`postprocess()`), with a
+  chorus and a Tapiir-echo worked example.
 
 ## Sharing & hosting
 

--- a/wasmaudioworklet/docs/effects.md
+++ b/wasmaudioworklet/docs/effects.md
@@ -1,0 +1,148 @@
+# Faust effects: channel & master
+
+Two ways to add a Faust effect in this app, with copy-paste steps. The key idea:
+
+> **`process = …` is the instrument (a *voice*, with NO audio input).
+> An effect HAS an audio input, so it never goes in `process`.**
+> That's why a chorus/echo put in `process` fails with `Cannot find name 'input0'`.
+
+Pick the pattern by *where* the effect should run:
+
+| Pattern | Runs | Use for | Wired in |
+| --- | --- | --- | --- |
+| **A. Channel effect** (`effect = …`) | once per channel, on that instrument's mixed voices | per-instrument colour (chorus, flanger, per-synth reverb) | the instrument's `.dsp` |
+| **B. Master effect** (standalone class) | once on the whole mix | global send (room reverb, master echo) | `synth.ts` `postprocess()` |
+
+---
+
+## A. Chorus on the SimpleSynth — channel effect (`effect =`)
+
+Faust's convention: `process` = the voice, `effect` = the post-voice channel
+processing. faust2as turns `effect` into `<Name>Channel.preprocess()` and feeds
+it the voice mix. We **reuse** the upstream chorus via `library(...)` instead of
+copy-pasting it.
+
+**1. Copy two files into the song's `faust/` folder** (from the Faust SAM chorus
+example):
+
+- `chorus.dsp` — https://github.com/grame-cncm/faust/blob/master-dev/examples/SAM/chorus/chorus.dsp
+- `layout2.dsp` — https://github.com/grame-cncm/faust/blob/master-dev/examples/SAM/chorus/layout2.dsp
+  (the chorus's UI grouping helpers `ckg`/`csg` — `chorus.dsp` imports it)
+
+Leave both files **as-is** — no editing. `chorus.dsp` has its own
+`process = …` and a generic `voices`, but that's fine: we pull it in with
+`library()`, which **namespaces** everything behind a prefix so nothing leaks
+into or collides with the synth (a plain `import("chorus.dsp")` would dump its
+`process`/`voices` into global scope instead).
+
+**2. In `simplesynth.dsp`, add two lines** after the `process = …` line:
+
+```faust
+ch = library("chorus.dsp");
+effect = ch.chorus_mono(ch.dmax, ch.curdel, ch.rate, ch.sigma, ch.do2, ch.voices);
+```
+
+Full file:
+
+```faust
+import("stdfaust.lib");
+
+// A minimal subtractive-synth voice: a sawtooth oscillator through a
+// resonant low-pass filter, shaped by an ADSR envelope.
+// freq / gain / gate are the MIDI note interface; cutoff / resonance
+// become tweakable channel parameters (mapped to MIDI CC).
+
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+gate = button("gate");
+
+cutoff    = hslider("cutoff", 2000, 50, 8000, 1);
+resonance = hslider("resonance", 2, 0.7, 25, 0.01);
+
+env = en.adsr(0.01, 0.2, 0.7, 0.3, gate);
+
+process = os.sawtooth(freq) : fi.resonlp(cutoff, resonance, 1) : *(env * gain);
+ch = library("chorus.dsp");
+effect = ch.chorus_mono(ch.dmax, ch.curdel, ch.rate, ch.sigma, ch.do2, ch.voices);
+```
+
+**3. Transpile** `simplesynth.dsp` in the app's Faust editor. It reports
+`Detected effect declaration — will generate SimplesynthChannel`. The instrument
+class `Simplesynth` has **no `input0`**; the chorus lands in
+`SimplesynthChannel.preprocess()`.
+
+**4. Hear it / tweak it** — the chorus params carry `[midi:ctrl N]` tags, so
+they're channel CCs. On the SimpleSynth's channel in `synth.ts`:
+
+```ts
+midichannels[0].controlchange(3, 70);   // chorus depth     (CC 3)
+midichannels[0].controlchange(2, 10);   // chorus rate      (CC 2, slow)
+midichannels[0].controlchange(4, 64);   // chorus delay     (CC 4)
+midichannels[0].controlchange(58, 45);  // chorus deviation (CC 58)
+```
+
+**Gotchas**
+- `effect` must live in a `.dsp` that **also** has a `process` voice — an effect
+  attaches to a channel that has voices. You can't transpile a lone chorus.
+- Don't add a standalone `ChorusChannel` instrument in `synth.ts` — that's the
+  `input0` error. The chorus lives *inside* `SimplesynthChannel`.
+
+---
+
+## B. Tapiir echo — master effect (whole mix)
+
+Tapiir is its own class, applied to the final mix in `postprocess()`. This is
+already wired in `demo/synth.ts`:
+
+```ts
+import { Tapiir } from '../faust/tapiir';
+const tapiir = new Tapiir();
+
+export function postprocess(): void {
+  tapiir.process(outputline.left, outputline.right);
+  outputline.left  = tapiir.signal.left;
+  outputline.right = tapiir.signal.right;
+}
+```
+
+By default every delay-tap output gain is **0**, so only the dry signal passes —
+no echo. Set fields on the `tapiir` instance (e.g. in `initializeMidiSynth()`):
+
+```ts
+// --- 300 ms echo with feedback, via Tapiir delay-line 0 ---
+tapiir.delaySec = 0.3;   // time between repeats, seconds (0..5)
+tapiir.tap07    = 0.5;   // delayed line 0 -> LEFT output
+tapiir.tap08    = 0.5;   // delayed line 0 -> RIGHT output
+tapiir.tap0     = 0.4;   // feedback: line 0 into itself (repeats). 0 = single slap-back. keep < 0.9
+```
+
+**Tapiir field map** (6 delay lines × 2 outputs)
+- **Delay times**: `delaySec`, `delaySec2` … `delaySec6` — the 6 lines (seconds).
+- **To outputs**: `tap07…tap57` → LEFT out; `tap08…tap58` → RIGHT out (lines 0…5).
+- **Feedback**: `tap0…tap5` feed lines back into line 0; `tap02…tap52` into
+  line 1; etc. So `tap0` = line-0 self-feedback (more = more repeats).
+- **Dry passthrough**: `input07/input17` (L) and `input08/input18` (R) are 1.0 —
+  the dry signal. For a stereo dry path set `input17 = 0` and `input08 = 0`.
+
+**Why "no echo" at first**: `delaySec` defaults to 0 and all `tapXX` output gains
+are 0 → the delayed signal never reaches the output. Set a delay time **and** a
+tap output gain.
+
+---
+
+## One-line rule of thumb
+- Colour one instrument → **`effect =` in its `.dsp`** (Pattern A).
+- Process the whole mix → **standalone class in `postprocess()`** (Pattern B).
+- Anything with an audio input is an effect → **never** put it in `process`.
+
+---
+
+## Regression test
+
+The Pattern B wiring above is verified end-to-end by
+[e2e/effects-doc.spec.js](../e2e/effects-doc.spec.js): it extracts the
+`postprocess()` and field-setting code blocks **from this document**, transpiles
+a Tapiir effect in the browser, renders a note to WAV through the app's export
+pipeline, and asserts an audible echo tail appears with the settings (and not
+with the defaults). If the wiring or field names here drift from what the
+transpiler produces, that test fails — so these snippets stay correct.

--- a/wasmaudioworklet/docs/effects.md
+++ b/wasmaudioworklet/docs/effects.md
@@ -91,8 +91,14 @@ midichannels[0].controlchange(58, 45);  // chorus deviation (CC 58)
 
 ## B. Tapiir echo — master effect (whole mix)
 
-Tapiir is its own class, applied to the final mix in `postprocess()`. This is
-already wired in `demo/synth.ts`:
+Tapiir is its own class, applied to the final mix in `postprocess()`.
+
+Transpiling a stereo-in/stereo-out `.dsp` (like `tapiir.dsp`) puts the transpiler
+in **mastering mode**: the generated `faust/tapiir.ts` exports the `Tapiir` class
+*and* a ready-made `postprocess()` that runs a default singleton over
+`outputline`. That hook only fires if the effect file itself is the mix entry —
+normally your `synth.ts` is (it's the file that wires `midichannels`), so wire the
+effect there yourself:
 
 ```ts
 import { Tapiir } from '../faust/tapiir';

--- a/wasmaudioworklet/e2e/effects-doc.spec.js
+++ b/wasmaudioworklet/e2e/effects-doc.spec.js
@@ -66,7 +66,7 @@ function assembleSynthTs(withEcho) {
         // (wires itself onto channel 0); we re-export it and add the doc's
         // master-effect postprocess on top.
         `// midi mix: route voices via midichannels, then apply the master effect`,
-        `import { initializeMidiSynth } from '../faust/simplesynth';`,
+        `import { initializeMidiSynth } from '../faust/echovoice';`,
         `import { outputline } from '../mixes/globalimports';`,
         ...docImports, // import { Tapiir } from '../faust/tapiir';  (from the doc)
         `export { initializeMidiSynth };`,
@@ -260,7 +260,11 @@ test.describe('docs/effects.md — Pattern B (Tapiir master effect)', () => {
             return app && app.shadowRoot && app.shadowRoot.getElementById('startaudiobutton');
         }, { timeout: 30000 });
 
-        const voiceTs = await transpile(page, VOICE_DSP, 'simplesynth.dsp');
+        // A unique voice name (not "simplesynth") so this spec's pushes to the
+        // shared NEAR repo don't collide with faust-save-then-play, which needs
+        // faust/simplesynth.ts to be ABSENT at clone time. We write only .ts
+        // (no .dsp), so faust-editor's ".dsp file list" assertions are unaffected.
+        const voiceTs = await transpile(page, VOICE_DSP, 'echovoice.dsp');
         const tapiirTs = await transpile(page, TAPIIR_DSP, 'tapiir.dsp');
 
         // 2. Push a project: song, both transpiled faust .ts, and the echo
@@ -268,7 +272,7 @@ test.describe('docs/effects.md — Pattern B (Tapiir master effect)', () => {
         await setupRepo(page, {
             'song.js': SONG_SOURCE,
             'synth.ts': assembleSynthTs(true),
-            'faust/simplesynth.ts': voiceTs,
+            'faust/echovoice.ts': voiceTs,
             'faust/tapiir.ts': tapiirTs,
         });
 

--- a/wasmaudioworklet/e2e/effects-doc.spec.js
+++ b/wasmaudioworklet/e2e/effects-doc.spec.js
@@ -1,0 +1,304 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+    NEAR_REPO_CONTRACT,
+    setupServiceWorker,
+    clearOPFS,
+    waitForAppReady,
+    fetchCredentials,
+} from './near-git-helpers.js';
+
+// Documentation-as-regression-test for docs/effects.md "Pattern B" (master
+// effect in postprocess()). The doc is the SINGLE SOURCE OF TRUTH: this test
+// extracts the postprocess() wiring and the echo field-settings straight out of
+// the markdown, transpiles a Tapiir effect in the browser, renders a note to
+// WAV through the app's export pipeline, and asserts the doc's two claims:
+//
+//   1. With the field settings, an audible echo tail appears.
+//   2. With the defaults, the tail is essentially gone (dry passthrough only).
+//
+// If the wiring or the Tapiir field names in the doc drift from what the
+// transpiler actually produces, the assembled synth.ts fails to compile or the
+// echo never appears, and this test fails — keeping the doc honest.
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoName = NEAR_REPO_CONTRACT + '.git';
+const DOC_PATH = path.join(__dirname, '..', 'docs', 'effects.md');
+
+// --- Extract Pattern B code blocks from the documentation -------------------
+function extractTsBlocks(md) {
+    return [...md.matchAll(/```ts\n([\s\S]*?)```/g)].map((m) => m[1]);
+}
+const DOC = fs.readFileSync(DOC_PATH, 'utf8');
+const TS_BLOCKS = extractTsBlocks(DOC);
+const POSTPROCESS_BLOCK = TS_BLOCKS.find(
+    (b) => b.includes('export function postprocess') && b.includes('tapiir.process'));
+const FIELD_BLOCK = TS_BLOCKS.find((b) => b.includes('tapiir.delaySec'));
+
+if (!POSTPROCESS_BLOCK || !FIELD_BLOCK) {
+    throw new Error('docs/effects.md: could not extract the Pattern B `ts` code blocks '
+        + '(postprocess wiring and/or tapiir field settings). Did the doc structure change?');
+}
+
+// Assemble a synth.ts mix file from the doc blocks. `withEcho` toggles the
+// field-settings block — that toggle IS the doc's claim under test.
+//
+// The doc's Pattern B snippet is just the postprocess() wiring; it assumes the
+// rest of synth.ts is a normal midi mix. So we drop the snippet into a realistic
+// mix that wires the voice onto channel 0 (exactly like the demo's synth.ts).
+// The literal "midichannels" is also how the compiler detects a midi synth
+// (browsercompilerwebworker.js) and places this at mixes/midi.mix.ts.
+function assembleSynthTs(withEcho) {
+    const lines = POSTPROCESS_BLOCK.split('\n');
+    const docImports = lines.filter((l) => l.trim().startsWith('import '));
+    const docBody = lines.filter((l) => !l.trim().startsWith('import ')).join('\n').trim();
+    // Drop the echo field settings right after the tapiir instance is created.
+    const body = docBody.replace(/const tapiir = new Tapiir\(\);/,
+        (m) => (withEcho ? `${m}\n${FIELD_BLOCK.trim()}` : m));
+    return [
+        // The emitted comment below must contain "midichannels": that literal
+        // is how the compiler detects a midi synth (browsercompilerwebworker.js)
+        // and places this file at mixes/midi.mix.ts — same trick as
+        // faust-save-then-play. The voice transpiles its own initializeMidiSynth
+        // (wires itself onto channel 0); we re-export it and add the doc's
+        // master-effect postprocess on top.
+        `// midi mix: route voices via midichannels, then apply the master effect`,
+        `import { initializeMidiSynth } from '../faust/simplesynth';`,
+        `import { outputline } from '../mixes/globalimports';`,
+        ...docImports, // import { Tapiir } from '../faust/tapiir';  (from the doc)
+        `export { initializeMidiSynth };`,
+        '',
+        body, // const tapiir = ...; (echo fields); export function postprocess()
+        '',
+    ].join('\n');
+}
+
+// --- Fixtures ---------------------------------------------------------------
+// A minimal subtractive voice — short release so the dry note is silent well
+// before the echo-tail measurement window.
+const VOICE_DSP = `import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+gate = button("gate");
+env = en.adsr(0.01, 0.1, 0.7, 0.15, gate);
+process = os.sawtooth(freq) * gain * env;
+`;
+
+// Upstream Tapiir (Grame, BSD) — the file the doc tells you to copy into faust/.
+const TAPIIR_DSP = `declare name 		"tapiir";
+declare version 	"1.0";
+declare author 		"Grame";
+declare license 	"BSD";
+declare copyright 	"(c)GRAME 2006";
+
+import("stdfaust.lib");
+
+dsize = 524288;
+
+tap(n) = vslider("tap %n", 0,0,1,0.1);
+in(n) = vslider("input %n", 1,0,1,0.1);
+gain = vslider("gain", 1,0,1,0.1);
+del = vslider("delay (sec)", 0, 0, 5, 0.01) * ma.SR;
+
+mixer(taps,lines) = par(i,taps,*(tap(i))), par(i,lines,*(in(i))) :> *(gain);
+
+matrix(taps,lines) = (si.bus(lines+taps)
+                        <: tgroup("",
+                        par(i, taps, hgroup("Tap %i", mixer(taps,lines) : de.delay(dsize,del))))
+                    ) ~ si.bus(taps);
+
+tapiir(taps,lines) = vgroup("Tapiir",
+                            si.bus(lines)
+                            <: (matrix(taps,lines), si.bus(lines))
+                            <: vgroup("outputs", par(i, lines, hgroup("output %i", mixer(taps,lines))))
+                            );
+
+process = tapiir(6,2);
+`;
+
+// Play c4 near t=0, then idle to ~2s so the WAV render (length = last event
+// time) is long enough to capture the echo repeats.
+const SONG_SOURCE = `setBPM(120);
+await createTrack(0).steps(4, [c4,,,,]);
+await waitForBeat(4);
+loopHere();
+`;
+
+// --- Helpers (mirrors faust-rs-dx7-audio.spec.js audio harness) -------------
+async function transpile(page, src, filename) {
+    return await page.evaluate(async ({ src, filename }) => {
+        const origDefine = customElements.define.bind(customElements);
+        customElements.define = (name, ctor, opts) => {
+            try { origDefine(name, ctor, opts); } catch (e) { /* already defined */ }
+        };
+        const m = await import('/faust/browser-transpile.js');
+        const { ts } = await m.transpileDspSource(src, filename, {});
+        return ts;
+    }, { src, filename });
+}
+
+async function setupRepo(page, files) {
+    const creds = await fetchCredentials();
+    const accessToken = JSON.stringify({
+        accountId: creds.accountId,
+        publicKey: creds.publicKey.replace('ed25519:', ''),
+        privateKey: creds.secretKey.replace('ed25519:', ''),
+    });
+    const repoUrl = `http://localhost:8080/near-repo/${repoName}`;
+    await page.evaluate(async ({ repoUrl, accessToken, username, files }) => {
+        const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
+        let resolveNext;
+        const pending = [];
+        worker.onmessage = (msg) => {
+            if (resolveNext) { const r = resolveNext; resolveNext = null; r(msg.data); }
+            else pending.push(msg.data);
+        };
+        const next = () => pending.length > 0 ? Promise.resolve(pending.shift()) : new Promise((r) => { resolveNext = r; });
+
+        worker.postMessage({ accessToken, username, useremail: username });
+        await next();
+        worker.postMessage({ command: 'clone', url: repoUrl });
+        await next();
+        let id = 100;
+        worker.postMessage({ command: 'init', args: ['.'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'remote', args: ['add', 'origin', repoUrl], id: id++ });
+        await next();
+        for (const [filename, contents] of Object.entries(files)) {
+            worker.postMessage({ command: 'writefileandstage', filename, contents });
+            await next();
+        }
+        worker.postMessage({ command: 'config', args: ['user.name', 'Test'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'config', args: ['user.email', 'test@test.com'], id: id++ });
+        await next();
+        worker.postMessage({ command: 'commitpullpush', commitmessage: 'effects-doc test fixture', id: id++ });
+        await next();
+        worker.terminate();
+    }, { repoUrl, accessToken, username: creds.accountId, files });
+}
+
+async function setEditorContent(page, editorSelector, content) {
+    await page.evaluate(({ selector, text }) => {
+        const shadowRoot = document.querySelector('app-javascriptmusic').shadowRoot;
+        shadowRoot.querySelector(`${selector} .CodeMirror`).CodeMirror.setValue(text);
+    }, { selector: editorSelector, text: content });
+}
+
+async function exportToWavFile(page) {
+    // Auto-answer the export-type modal with "wav", and any follow-up modal
+    // (e.g. a clipping warning) with true. Restore document.createElement
+    // afterwards so repeated exports don't stack wrappers.
+    await page.evaluate(() => {
+        const origCreate = document.createElement.bind(document);
+        window.__origCreateElement = origCreate;
+        const modalResponses = ['wav', true, true];
+        document.createElement = function (tagName, opts) {
+            const el = origCreate(tagName, opts);
+            if (tagName === 'common-modal') {
+                const response = modalResponses.shift() ?? true;
+                setTimeout(() => el.shadowRoot.result(response), 0);
+            }
+            return el;
+        };
+    });
+    try {
+        const downloadPromise = page.waitForEvent('download', { timeout: 240000 });
+        page.evaluate(() => window.compileSong(true));
+        const download = await downloadPromise;
+        const filePath = path.join('/tmp', `effects-doc-${repoName}-${process.hrtime.bigint()}.wav`);
+        await download.saveAs(filePath);
+        return filePath;
+    } finally {
+        await page.evaluate(() => {
+            if (window.__origCreateElement) document.createElement = window.__origCreateElement;
+        });
+    }
+}
+
+async function getWavSamples(page, wavFilePath, seconds) {
+    const wavBase64 = fs.readFileSync(wavFilePath).toString('base64');
+    return await page.evaluate(async ({ b64, seconds }) => {
+        const binary = atob(b64);
+        const buf = new ArrayBuffer(binary.length);
+        const view = new Uint8Array(buf);
+        for (let i = 0; i < binary.length; i++) view[i] = binary.charCodeAt(i);
+        const offlineCtx = new OfflineAudioContext(1, 44100 * seconds, 44100);
+        const decoded = await offlineCtx.decodeAudioData(buf);
+        const ch0 = decoded.getChannelData(0);
+        return {
+            samples: Array.from(ch0.slice(0, Math.min(ch0.length, 44100 * seconds))),
+            sampleRate: decoded.sampleRate,
+        };
+    }, { b64: wavBase64, seconds });
+}
+
+function rms(samples) {
+    return Math.sqrt(samples.reduce((acc, v) => acc + v * v, 0) / samples.length);
+}
+
+test.describe('docs/effects.md — Pattern B (Tapiir master effect)', () => {
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, repoName);
+    });
+
+    test('echo wiring from the doc produces an audible echo tail; defaults do not', async ({ page }) => {
+        // Two full asc compiles (optimizeLevel 3) + two offline renders.
+        test.setTimeout(600000);
+        page.on('console', (m) => { if (m.type() === 'error') console.log('[browser]', m.text()); });
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+
+        // 1. Load the app shell and transpile the voice + Tapiir effect in-browser.
+        await page.goto('http://localhost:8080');
+        await clearOPFS(page, repoName);
+        await setupServiceWorker(page);
+        await page.waitForFunction(() => {
+            const app = document.querySelector('app-javascriptmusic');
+            return app && app.shadowRoot && app.shadowRoot.getElementById('startaudiobutton');
+        }, { timeout: 30000 });
+
+        const voiceTs = await transpile(page, VOICE_DSP, 'simplesynth.dsp');
+        const tapiirTs = await transpile(page, TAPIIR_DSP, 'tapiir.dsp');
+
+        // 2. Push a project: song, both transpiled faust .ts, and the echo
+        //    synth.ts assembled from the doc blocks.
+        await setupRepo(page, {
+            'song.js': SONG_SOURCE,
+            'synth.ts': assembleSynthTs(true),
+            'faust/simplesynth.ts': voiceTs,
+            'faust/tapiir.ts': tapiirTs,
+        });
+
+        // 3. Open the project.
+        await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+        await waitForAppReady(page);
+
+        async function render(synthTs) {
+            await setEditorContent(page, '#assemblyscripteditor', synthTs);
+            await setEditorContent(page, '#editor', SONG_SOURCE);
+            const wavPath = await exportToWavFile(page);
+            const { samples, sampleRate } = await getWavSamples(page, wavPath, 2);
+            fs.unlinkSync(wavPath);
+            const win = (t0, t1) => samples.slice(Math.floor(t0 * sampleRate), Math.floor(t1 * sampleRate));
+            // note window: the dry note; tail window: well after the voice's
+            // release, so any energy there can only be the echo.
+            return { note: rms(win(0.0, 0.3)), tail: rms(win(0.7, 1.9)) };
+        }
+
+        const echo = await render(assembleSynthTs(true));
+        const dry = await render(assembleSynthTs(false));
+        console.log(`echo: note=${echo.note.toFixed(5)} tail=${echo.tail.toFixed(5)} | `
+            + `dry: note=${dry.note.toFixed(5)} tail=${dry.tail.toFixed(5)}`);
+
+        // The voice is audible in both renders (sanity: dry passthrough works).
+        expect(echo.note).toBeGreaterThan(0.005);
+        expect(dry.note).toBeGreaterThan(0.005);
+        // Doc claim 1: the field settings produce an audible echo tail.
+        expect(echo.tail).toBeGreaterThan(0.003);
+        // Doc claim 2: with defaults the tail is essentially gone.
+        expect(echo.tail).toBeGreaterThan(dry.tail * 5);
+    });
+});

--- a/wasmaudioworklet/e2e/effects-doc.spec.js
+++ b/wasmaudioworklet/e2e/effects-doc.spec.js
@@ -134,7 +134,7 @@ async function transpile(page, src, filename) {
         customElements.define = (name, ctor, opts) => {
             try { origDefine(name, ctor, opts); } catch (e) { /* already defined */ }
         };
-        const m = await import('/faust/browser-transpile.js');
+        const m = await import('/faust/faust-rs-transpile.js');
         const { ts } = await m.transpileDspSource(src, filename, {});
         return ts;
     }, { src, filename });


### PR DESCRIPTION
Turns the Faust effects cheat sheet into proper, **verified** documentation.

## What's here
- **`wasmaudioworklet/docs/effects.md`** — the effects guide, relocated from the
  untracked `presentations/` copy and linked from the docs index. Covers
  Pattern A (channel effect via `effect =`) and Pattern B (master effect in
  `postprocess()`).
- **`wasmaudioworklet/e2e/effects-doc.spec.js`** — a documentation-as-regression
  test for Pattern B. It **extracts the `postprocess()` wiring and the Tapiir
  field-settings code blocks straight out of `docs/effects.md`**, transpiles a
  Tapiir effect in the browser, renders a note to WAV through the app's export
  pipeline, and asserts the doc's two claims:
  1. with the field settings, an audible echo tail appears, and
  2. with the defaults, it does not.

  Because the test reads the snippets from the markdown, the doc and the test
  cannot drift apart — if the wiring or Tapiir field names in the doc stop
  matching what the transpiler produces, the test fails.

## Verified both ways
- Passes with the current doc: `echo tail RMS = 0.015` vs `dry = 0.0002` (~75x),
  note level identical in both renders.
- Setting `delaySec = 0.0` in the doc collapses the tail to `0.0004` and the
  echo-tail assertion fails — confirming the test is genuinely wired to the doc.

## Refreshed 2026-07-27
Rebased onto master and brought up to date with what has landed since June:

- **`browser-transpile.js` is gone** (removed in #175, the native
  `control()`/`frame()` delegation). The spec now imports
  `/faust/faust-rs-transpile.js` — same `transpileDspSource(src, file, {})`
  signature, matching `faust-rs-dx7-audio.spec.js`.
- **Dropped the doc's `demo/synth.ts` reference** — that path does not exist in
  this repo. Replaced with what the transpiler actually emits for a
  stereo-in/stereo-out `.dsp`: a mastering class plus a default-singleton
  `postprocess()` that only fires when the effect file itself is the mix entry,
  which is why the manual `synth.ts` wiring below it is the normal case.
- Re-verified after the rebase: the spec still passes with the same numbers
  (`echo tail = 0.01503` vs `dry tail = 0.00020`), so the Tapiir field names
  (`delaySec`, `tap07`, `tap08`, `tap0`) survived #175's accessor rework
  unchanged. Full local suite: **58 passed, 0 failed** (3.4m).

## CI / notes for reviewers
- **Serialization is already handled** — `playwright.config.js` sets
  `workers: 1`, and CI also passes `--workers=1`. Required because the sandbox
  specs share a single `NEAR_REPO_CONTRACT`. This spec is picked up
  automatically (no file filter).
- **Runtime: negligible.** The earlier "~6-7 min" note in this description was
  wrong. The spec ran in this PR's June CI job and the whole Playwright job took
  **5m07s**, against **4m52s** on master the day before — roughly **15 seconds**
  of incremental cost. Locally the spec alone runs in ~5s.
- **Still not covered:** Pattern A (the `effect =` chorus) has no test. Its
  structure holds — `[midi:ctrl N]` is honored in `transpile-core.js` and the
  editor passes sibling `.dsp` files via `collectSiblingLibs`, so
  `library("chorus.dsp")` resolves — but the CC numbers quoted in the doc
  (3/2/4/58) come from upstream `chorus.dsp` metadata and nothing pins them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
