### PR TITLE
Studio Agent: in-app AI assistant for the browser music studio

### DIFF
--- a/examples/dx7/README.md
+++ b/examples/dx7/README.md
@@ -9,6 +9,7 @@ Yamaha DX7 synthesizer running as a transpiled AssemblyScript instrument via the
 | `dx7-synth.ts` | Generated synth bundle using C backend transpiler |
 | `dx7-synth-asc-backend.ts` | Generated synth bundle using ASC backend transpiler |
 | `dx7-sequence.js` | Example sequence with E.Piano, Bass, Strings, Bells, and Drum Kit patches |
+| `dx7-drumbeat.js` | Minimal, self-contained drums-only beat — embeds the channel-4 kick/snare/hat NRPN patch block, then a `steps()` groove. Load it alongside `dx7-synth.ts` and edit `setBPM`/the `steps()` pattern to make a beat. (Reminder: the patches MUST stay in the song — `initializeMidiSynth()` only zeroes defaults, which sound like a sine.) |
 | `dsp/` | Faust DSP source files for each algorithm variant |
 | `parse-rom.js` | Utility to convert DX7 SysEx ROM (`.syx`) files to NRPN patch data |
 | `sequence-to-patches.js` | Utility to convert an NRPN sequence into typed-field assignments for the modular per-algorithm `.ts` files (see "Porting a ROM patch into a modular channel" below) |

--- a/examples/dx7/dx7-drumbeat.js
+++ b/examples/dx7/dx7-drumbeat.js
@@ -1,0 +1,529 @@
+/*
+ * DX7 drum-kit beat — self-contained and ready to play.
+ *
+ * IMPORTANT: the DX7 drum patches (Beefkick / MildSnare / JunkHat) are programmed
+ * by the NRPN block below. The synth bundle (dx7-synth.ts) only zeroes channel-4
+ * defaults in initializeMidiSynth() — which sound like a plain sine — so this NRPN
+ * block MUST stay in the song. To change the beat, edit setBPM and the steps()
+ * pattern at the BOTTOM; leave the NRPN patch block untouched.
+ *
+ * Pairs with: examples/dx7/dx7-synth.ts  (load that as the synth).
+ */
+
+setBPM(90);
+
+addInstrument('DX7 E.Piano');   // Channel 0 — Algorithm 5
+addInstrument('DX7 Bass');      // Channel 1 — Algorithm 16
+addInstrument('DX7 Strings');   // Channel 2 — Algorithm 2
+addInstrument('DX7 Bells');     // Channel 3 — Algorithm 5
+addInstrument('DX7 Drums');     // Channel 4 — Drum Kit (Kick=c3, Snare=d3, Hat=fs3)
+
+// NRPN helper: sends CC 99 (MSB) + CC 98 (LSB) + CC 6 (value)
+function nrpn(beat, param, value) {
+    return [
+      beat, controlchange(99, (param >> 7) & 127),
+      beat, controlchange(98, param & 127),
+      beat, controlchange(6, value),
+     ];
+}
+
+// ===== Channel 4 drum-kit patch programming (Kick 0-143, Snare 144-287, Hat 288-431) =====
+createTrack(4).play([
+    // ========== Kick: Beefkick (Coffeeshopped) — Algorithm 17, NRPN 0–143 ==========
+    // --- Global / LFO ---
+    nrpn(0, 0, 73),    // Feedback=4
+    nrpn(0, 1, 64),    // Transpose=0
+    nrpn(0, 2, 127),   // Osc Key Sync=1
+    nrpn(0, 3, 127),   // Pitch EG L1=99
+    nrpn(0, 4, 127),   // Pitch EG L2=99
+    nrpn(0, 5, 64),    // Pitch EG L3=50
+    nrpn(0, 6, 64),    // Pitch EG L4=50
+    nrpn(0, 7, 127),   // Pitch EG R1=99
+    nrpn(0, 8, 127),   // Pitch EG R2=99
+    nrpn(0, 9, 13),    // Pitch EG R3=10
+    nrpn(0, 10, 13),   // Pitch EG R4=10
+    nrpn(0, 11, 102),  // LFO Wave=Sine
+    nrpn(0, 12, 44),   // LFO Speed=34
+    nrpn(0, 13, 42),   // LFO Delay=33
+    nrpn(0, 14, 0),    // PMD=0
+    nrpn(0, 15, 0),    // AMD=0
+    nrpn(0, 16, 127),  // LFO Sync=1
+    nrpn(0, 17, 54),   // P Mod Sens=3
+
+    // --- Op1 (fixed) ---
+    nrpn(0, 18, 64),   // Detune=0
+    nrpn(0, 19, 20),   // Coarse=5
+    nrpn(0, 20, 86),   // Fine=67
+    nrpn(0, 21, 127),  // EG L1=99
+    nrpn(0, 22, 0),    // EG L2=0
+    nrpn(0, 23, 0),    // EG L3=0
+    nrpn(0, 24, 0),    // EG L4=0
+    nrpn(0, 25, 127),  // EG R1=99
+    nrpn(0, 26, 64),   // EG R2=50
+    nrpn(0, 27, 0),    // EG R3=0
+    nrpn(0, 28, 74),   // EG R4=58
+    nrpn(0, 29, 127),  // Level=99
+    nrpn(0, 30, 73),   // Key Vel=4
+    nrpn(0, 31, 0),    // A Mod Sens=0
+    nrpn(0, 32, 0),    // Rate Scaling=0
+    nrpn(0, 33, 0),    // Breakpoint=A-1
+    nrpn(0, 34, 0),    // L Depth=0
+    nrpn(0, 35, 0),    // R Depth=0
+    nrpn(0, 36, 0),    // L Curve=0
+    nrpn(0, 37, 0),    // R Curve=0
+
+    // --- Op2 (fixed) ---
+    nrpn(0, 38, 64),   // Detune=0
+    nrpn(0, 39, 4),    // Coarse=1
+    nrpn(0, 40, 86),   // Fine=67
+    nrpn(0, 41, 127),  // EG L1=99
+    nrpn(0, 42, 0),    // EG L2=0
+    nrpn(0, 43, 0),    // EG L3=0
+    nrpn(0, 44, 0),    // EG L4=0
+    nrpn(0, 45, 126),  // EG R1=98
+    nrpn(0, 46, 64),   // EG R2=50
+    nrpn(0, 47, 0),    // EG R3=0
+    nrpn(0, 48, 74),   // EG R4=58
+    nrpn(0, 49, 81),   // Level=63
+    nrpn(0, 50, 127),  // Key Vel=7
+    nrpn(0, 51, 0),    // A Mod Sens=0
+    nrpn(0, 52, 0),    // Rate Scaling=0
+    nrpn(0, 53, 0),    // Breakpoint=A-1
+    nrpn(0, 54, 0),    // L Depth=0
+    nrpn(0, 55, 0),    // R Depth=0
+    nrpn(0, 56, 0),    // L Curve=0
+    nrpn(0, 57, 0),    // R Curve=0
+
+    // --- Op3 (fixed) ---
+    nrpn(0, 58, 64),   // Detune=0
+    nrpn(0, 59, 4),    // Coarse=1
+    nrpn(0, 60, 73),   // Fine=57
+    nrpn(0, 61, 127),  // EG L1=99
+    nrpn(0, 62, 0),    // EG L2=0
+    nrpn(0, 63, 0),    // EG L3=0
+    nrpn(0, 64, 0),    // EG L4=0
+    nrpn(0, 65, 127),  // EG R1=99
+    nrpn(0, 66, 89),   // EG R2=69
+    nrpn(0, 67, 0),    // EG R3=0
+    nrpn(0, 68, 74),   // EG R4=58
+    nrpn(0, 69, 108),  // Level=84
+    nrpn(0, 70, 127),  // Key Vel=7
+    nrpn(0, 71, 0),    // A Mod Sens=0
+    nrpn(0, 72, 0),    // Rate Scaling=0
+    nrpn(0, 73, 0),    // Breakpoint=A-1
+    nrpn(0, 74, 0),    // L Depth=0
+    nrpn(0, 75, 0),    // R Depth=0
+    nrpn(0, 76, 0),    // L Curve=0
+    nrpn(0, 77, 0),    // R Curve=0
+
+    // --- Op4 (ratio 2:1) ---
+    nrpn(0, 78, 64),   // Detune=0
+    nrpn(0, 79, 8),    // Coarse=2
+    nrpn(0, 80, 0),    // Fine=0
+    nrpn(0, 81, 127),  // EG L1=99
+    nrpn(0, 82, 0),    // EG L2=0
+    nrpn(0, 83, 0),    // EG L3=0
+    nrpn(0, 84, 0),    // EG L4=0
+    nrpn(0, 85, 127),  // EG R1=99
+    nrpn(0, 86, 89),   // EG R2=69
+    nrpn(0, 87, 55),   // EG R3=43
+    nrpn(0, 88, 89),   // EG R4=69
+    nrpn(0, 89, 0),    // Level=0
+    nrpn(0, 90, 127),  // Key Vel=7
+    nrpn(0, 91, 0),    // A Mod Sens=0
+    nrpn(0, 92, 54),   // Rate Scaling=3
+    nrpn(0, 93, 0),    // Breakpoint=A-1
+    nrpn(0, 94, 0),    // L Depth=0
+    nrpn(0, 95, 0),    // R Depth=0
+    nrpn(0, 96, 0),    // L Curve=0
+    nrpn(0, 97, 0),    // R Curve=0
+
+    // --- Op5 (ratio 3:1) ---
+    nrpn(0, 98, 91),   // Detune=+3
+    nrpn(0, 99, 12),   // Coarse=3
+    nrpn(0, 100, 0),   // Fine=0
+    nrpn(0, 101, 127), // EG L1=99
+    nrpn(0, 102, 65),  // EG L2=51
+    nrpn(0, 103, 0),   // EG L3=0
+    nrpn(0, 104, 0),   // EG L4=0
+    nrpn(0, 105, 127), // EG R1=99
+    nrpn(0, 106, 62),  // EG R2=48
+    nrpn(0, 107, 59),  // EG R3=46
+    nrpn(0, 108, 63),  // EG R4=49
+    nrpn(0, 109, 0),   // Level=0
+    nrpn(0, 110, 127), // Key Vel=7
+    nrpn(0, 111, 0),   // A Mod Sens=0
+    nrpn(0, 112, 127), // Rate Scaling=7
+    nrpn(0, 113, 0),   // Breakpoint=A-1
+    nrpn(0, 114, 0),   // L Depth=0
+    nrpn(0, 115, 0),   // R Depth=0
+    nrpn(0, 116, 0),   // L Curve=0
+    nrpn(0, 117, 0),   // R Curve=0
+
+    // --- Op6 (ratio 13:1) ---
+    nrpn(0, 118, 0),   // Detune=-7
+    nrpn(0, 119, 53),  // Coarse=13
+    nrpn(0, 120, 65),  // Fine=51
+    nrpn(0, 121, 127), // EG L1=99
+    nrpn(0, 122, 0),   // EG L2=0
+    nrpn(0, 123, 0),   // EG L3=0
+    nrpn(0, 124, 0),   // EG L4=0
+    nrpn(0, 125, 127), // EG R1=99
+    nrpn(0, 126, 63),  // EG R2=49
+    nrpn(0, 127, 26),  // EG R3=20
+    nrpn(0, 128, 40),  // EG R4=31
+    nrpn(0, 129, 127), // Level=99
+    nrpn(0, 130, 127), // Key Vel=7
+    nrpn(0, 131, 0),   // A Mod Sens=0
+    nrpn(0, 132, 127), // Rate Scaling=7
+    nrpn(0, 133, 5),   // Breakpoint=C#-1
+    nrpn(0, 134, 0),   // L Depth=0
+    nrpn(0, 135, 0),   // R Depth=0
+    nrpn(0, 136, 42),  // L Curve=-EXP
+    nrpn(0, 137, 0),   // R Curve=0
+
+    // --- Kick Freq Mode (0=ratio, 1=fixed) ---
+    nrpn(0, 138, 127), // Op1 Freq Mode=fixed
+    nrpn(0, 139, 127), // Op2 Freq Mode=fixed
+    nrpn(0, 140, 127), // Op3 Freq Mode=fixed
+    nrpn(0, 141, 127), // Op4 Freq Mode=fixed
+    nrpn(0, 142, 127), // Op5 Freq Mode=fixed
+    nrpn(0, 143, 127), // Op6 Freq Mode=fixed
+
+    // ========== Snare: MildSnare (Coffeeshopped) — Algorithm 21, NRPN 144–287 ==========
+    // --- Snare Global / LFO ---
+    nrpn(0, 144, 127),   // Feedback=7
+    nrpn(0, 145, 64),    // Transpose=0
+    nrpn(0, 146, 0),     // Osc Key Sync=0
+    nrpn(0, 147, 64),    // Pitch EG L1=50
+    nrpn(0, 148, 64),    // Pitch EG L2=50
+    nrpn(0, 149, 64),    // Pitch EG L3=50
+    nrpn(0, 150, 64),    // Pitch EG L4=50
+    nrpn(0, 151, 121),   // Pitch EG R1=94
+    nrpn(0, 152, 86),    // Pitch EG R2=67
+    nrpn(0, 153, 122),   // Pitch EG R3=95
+    nrpn(0, 154, 77),   // Pitch EG R4=60
+    nrpn(0, 155, 102),  // LFO Wave=Sine
+    nrpn(0, 156, 41),   // LFO Speed=32
+    nrpn(0, 157, 42),   // LFO Delay=33
+    nrpn(0, 158, 0),    // PMD=0
+    nrpn(0, 159, 0),    // AMD=0
+    nrpn(0, 160, 0),    // LFO Sync=0
+    nrpn(0, 161, 54),   // P Mod Sens=3
+
+    // --- Snare Op1 (ratio 0.5:1) ---
+    nrpn(0, 162, 0),    // Detune=-7
+    nrpn(0, 163, 0),    // Coarse=0
+    nrpn(0, 164, 0),    // Fine=0
+    nrpn(0, 165, 127),  // EG L1=99
+    nrpn(0, 166, 0),    // EG L2=0
+    nrpn(0, 167, 0),    // EG L3=0
+    nrpn(0, 168, 0),    // EG L4=0
+    nrpn(0, 169, 122),  // EG R1=95
+    nrpn(0, 170, 82),   // EG R2=64
+    nrpn(0, 171, 26),   // EG R3=20
+    nrpn(0, 172, 77),   // EG R4=60
+    nrpn(0, 173, 115),  // Level=90
+    nrpn(0, 174, 73),   // Key Vel=4
+    nrpn(0, 175, 0),    // A Mod Sens=0
+    nrpn(0, 176, 54),   // Rate Scaling=3
+    nrpn(0, 177, 0),    // Breakpoint=A-1
+    nrpn(0, 178, 0),    // L Depth=0
+    nrpn(0, 179, 0),    // R Depth=0
+    nrpn(0, 180, 0),    // L Curve=0
+    nrpn(0, 181, 0),    // R Curve=0
+
+    // --- Snare Op2 (ratio 23:1) ---
+    nrpn(0, 182, 64),   // Detune=0
+    nrpn(0, 183, 94),   // Coarse=23
+    nrpn(0, 184, 3),    // Fine=2
+    nrpn(0, 185, 127),  // EG L1=99
+    nrpn(0, 186, 0),    // EG L2=0
+    nrpn(0, 187, 0),    // EG L3=0
+    nrpn(0, 188, 0),    // EG L4=0
+    nrpn(0, 189, 122),  // EG R1=95
+    nrpn(0, 190, 82),   // EG R2=64
+    nrpn(0, 191, 26),   // EG R3=20
+    nrpn(0, 192, 81),   // EG R4=63
+    nrpn(0, 193, 76),   // Level=59
+    nrpn(0, 194, 73),   // Key Vel=4
+    nrpn(0, 195, 0),    // A Mod Sens=0
+    nrpn(0, 196, 54),   // Rate Scaling=3
+    nrpn(0, 197, 0),    // Breakpoint=A-1
+    nrpn(0, 198, 0),    // L Depth=0
+    nrpn(0, 199, 0),    // R Depth=0
+    nrpn(0, 200, 0),    // L Curve=0
+    nrpn(0, 201, 0),    // R Curve=0
+
+    // --- Snare Op3 (ratio 0.5:1) ---
+    nrpn(0, 202, 127),  // Detune=+7
+    nrpn(0, 203, 0),    // Coarse=0
+    nrpn(0, 204, 26),   // Fine=20
+    nrpn(0, 205, 127),  // EG L1=99
+    nrpn(0, 206, 127),  // EG L2=99
+    nrpn(0, 207, 127),  // EG L3=99
+    nrpn(0, 208, 127),  // EG L4=99
+    nrpn(0, 209, 127),  // EG R1=99
+    nrpn(0, 210, 26),   // EG R2=20
+    nrpn(0, 211, 26),   // EG R3=20
+    nrpn(0, 212, 127),  // EG R4=99
+    nrpn(0, 213, 126),  // Level=98
+    nrpn(0, 214, 18),   // Key Vel=1
+    nrpn(0, 215, 0),    // A Mod Sens=0
+    nrpn(0, 216, 0),    // Rate Scaling=0
+    nrpn(0, 217, 0),    // Breakpoint=A-1
+    nrpn(0, 218, 0),    // L Depth=0
+    nrpn(0, 219, 0),    // R Depth=0
+    nrpn(0, 220, 0),    // L Curve=0
+    nrpn(0, 221, 0),    // R Curve=0
+
+    // --- Snare Op4 (fixed, coarse 14) ---
+    nrpn(0, 222, 64),   // Detune=0
+    nrpn(0, 223, 57),   // Coarse=14
+    nrpn(0, 224, 28),   // Fine=22
+    nrpn(0, 225, 127),  // EG L1=99
+    nrpn(0, 226, 0),    // EG L2=0
+    nrpn(0, 227, 0),    // EG L3=0
+    nrpn(0, 228, 0),    // EG L4=0
+    nrpn(0, 229, 122),  // EG R1=95
+    nrpn(0, 230, 76),   // EG R2=59
+    nrpn(0, 231, 26),   // EG R3=20
+    nrpn(0, 232, 73),   // EG R4=57
+    nrpn(0, 233, 127),  // Level=99
+    nrpn(0, 234, 73),   // Key Vel=4
+    nrpn(0, 235, 0),    // A Mod Sens=0
+    nrpn(0, 236, 54),   // Rate Scaling=3
+    nrpn(0, 237, 0),    // Breakpoint=A-1
+    nrpn(0, 238, 0),    // L Depth=0
+    nrpn(0, 239, 0),    // R Depth=0
+    nrpn(0, 240, 0),    // L Curve=0
+    nrpn(0, 241, 0),    // R Curve=0
+
+    // --- Snare Op5 (fixed, coarse 2) ---
+    nrpn(0, 242, 91),   // Detune=+3
+    nrpn(0, 243, 8),    // Coarse=2
+    nrpn(0, 244, 60),  // Fine=47
+    nrpn(0, 245, 127), // EG L1=99
+    nrpn(0, 246, 0),   // EG L2=0
+    nrpn(0, 247, 0),   // EG L3=0
+    nrpn(0, 248, 0),   // EG L4=0
+    nrpn(0, 249, 122), // EG R1=95
+    nrpn(0, 250, 76),  // EG R2=59
+    nrpn(0, 251, 26),  // EG R3=20
+    nrpn(0, 252, 76),  // EG R4=59
+    nrpn(0, 253, 115), // Level=90
+    nrpn(0, 254, 73),  // Key Vel=4
+    nrpn(0, 255, 0),   // A Mod Sens=0
+    nrpn(0, 256, 54),  // Rate Scaling=3
+    nrpn(0, 257, 0),   // Breakpoint=A-1
+    nrpn(0, 258, 0),   // L Depth=0
+    nrpn(0, 259, 0),   // R Depth=0
+    nrpn(0, 260, 0),   // L Curve=0
+    nrpn(0, 261, 0),   // R Curve=0
+
+    // --- Snare Op6 (ratio 12:1) ---
+    nrpn(0, 262, 0),   // Detune=-7
+    nrpn(0, 263, 49),  // Coarse=12
+    nrpn(0, 264, 54),  // Fine=42
+    nrpn(0, 265, 127), // EG L1=99
+    nrpn(0, 266, 0),   // EG L2=0
+    nrpn(0, 267, 0),   // EG L3=0
+    nrpn(0, 268, 0),   // EG L4=0
+    nrpn(0, 269, 122), // EG R1=95
+    nrpn(0, 270, 99),  // EG R2=77
+    nrpn(0, 271, 26),  // EG R3=20
+    nrpn(0, 272, 127), // EG R4=99
+    nrpn(0, 273, 41),  // Level=32
+    nrpn(0, 274, 0),   // Key Vel=0
+    nrpn(0, 275, 0),   // A Mod Sens=0
+    nrpn(0, 276, 0),   // Rate Scaling=0
+    nrpn(0, 277, 5),   // Breakpoint=C#-1
+    nrpn(0, 278, 8),   // L Depth=6
+    nrpn(0, 279, 44),  // R Depth=34
+    nrpn(0, 280, 42),  // L Curve=-EXP
+    nrpn(0, 281, 0),   // R Curve=0
+
+    // --- Snare Freq Mode (0=ratio, 1=fixed) ---
+    nrpn(0, 282, 127), // Op1 Freq Mode=fixed
+    nrpn(0, 283, 127), // Op2 Freq Mode=fixed
+    nrpn(0, 284, 127), // Op3 Freq Mode=fixed
+    nrpn(0, 285, 127), // Op4 Freq Mode=fixed
+    nrpn(0, 286, 127), // Op5 Freq Mode=fixed
+    nrpn(0, 287, 127), // Op6 Freq Mode=fixed
+
+    // ========== Hat: JunkHat (Coffeeshopped) — Algorithm 5, NRPN 288–431 ==========
+    // --- Hat Global / LFO ---
+    nrpn(0, 288, 127),   // Feedback=7
+    nrpn(0, 289, 64),    // Transpose=0
+    nrpn(0, 290, 127),   // Osc Key Sync=1
+    nrpn(0, 291, 64),    // Pitch EG L1=50
+    nrpn(0, 292, 64),    // Pitch EG L2=50
+    nrpn(0, 293, 64),    // Pitch EG L3=50
+    nrpn(0, 294, 64),    // Pitch EG L4=50
+    nrpn(0, 295, 126),   // Pitch EG R1=98
+    nrpn(0, 296, 126),   // Pitch EG R2=98
+    nrpn(0, 297, 126),   // Pitch EG R3=98
+    nrpn(0, 298, 126),  // Pitch EG R4=98
+    nrpn(0, 299, 0),    // LFO Wave=Triangle
+    nrpn(0, 300, 45),   // LFO Speed=35
+    nrpn(0, 301, 0),    // LFO Delay=0
+    nrpn(0, 302, 0),    // PMD=0
+    nrpn(0, 303, 0),    // AMD=0
+    nrpn(0, 304, 127),  // LFO Sync=1
+    nrpn(0, 305, 54),   // P Mod Sens=3
+
+    // --- Hat Op1 (fixed, coarse 31) ---
+    nrpn(0, 306, 64),   // Detune=0
+    nrpn(0, 307, 127),  // Coarse=31
+    nrpn(0, 308, 49),   // Fine=38
+    nrpn(0, 309, 127),  // EG L1=99
+    nrpn(0, 310, 0),    // EG L2=0
+    nrpn(0, 311, 0),    // EG L3=0
+    nrpn(0, 312, 0),    // EG L4=0
+    nrpn(0, 313, 127),  // EG R1=99
+    nrpn(0, 314, 67),   // EG R2=52
+    nrpn(0, 315, 127),  // EG R3=99
+    nrpn(0, 316, 63),   // EG R4=49
+    nrpn(0, 317, 119),  // Level=93
+    nrpn(0, 318, 73),   // Key Vel=4
+    nrpn(0, 319, 0),    // A Mod Sens=0
+    nrpn(0, 320, 127),  // Rate Scaling=7
+    nrpn(0, 321, 0),    // Breakpoint=A-1
+    nrpn(0, 322, 0),    // L Depth=0
+    nrpn(0, 323, 0),    // R Depth=0
+    nrpn(0, 324, 0),    // L Curve=0
+    nrpn(0, 325, 0),    // R Curve=0
+
+    // --- Hat Op2 (fixed, coarse 31) ---
+    nrpn(0, 326, 64),   // Detune=0
+    nrpn(0, 327, 127),  // Coarse=31
+    nrpn(0, 328, 119),  // Fine=93
+    nrpn(0, 329, 127),  // EG L1=99
+    nrpn(0, 330, 127),  // EG L2=99
+    nrpn(0, 331, 127),  // EG L3=99
+    nrpn(0, 332, 0),    // EG L4=0
+    nrpn(0, 333, 127),  // EG R1=99
+    nrpn(0, 334, 38),   // EG R2=30
+    nrpn(0, 335, 127),  // EG R3=99
+    nrpn(0, 336, 46),   // EG R4=36
+    nrpn(0, 337, 127),  // Level=99
+    nrpn(0, 338, 0),    // Key Vel=0
+    nrpn(0, 339, 0),    // A Mod Sens=0
+    nrpn(0, 340, 127),  // Rate Scaling=7
+    nrpn(0, 341, 0),    // Breakpoint=A-1
+    nrpn(0, 342, 0),    // L Depth=0
+    nrpn(0, 343, 0),    // R Depth=0
+    nrpn(0, 344, 0),    // L Curve=0
+    nrpn(0, 345, 0),    // R Curve=0
+
+    // --- Hat Op3 (fixed, coarse 31) ---
+    nrpn(0, 346, 64),   // Detune=0
+    nrpn(0, 347, 127),  // Coarse=31
+    nrpn(0, 348, 27),   // Fine=21
+    nrpn(0, 349, 127),  // EG L1=99
+    nrpn(0, 350, 0),    // EG L2=0
+    nrpn(0, 351, 0),    // EG L3=0
+    nrpn(0, 352, 0),    // EG L4=0
+    nrpn(0, 353, 127),  // EG R1=99
+    nrpn(0, 354, 65),   // EG R2=51
+    nrpn(0, 355, 127),  // EG R3=99
+    nrpn(0, 356, 63),   // EG R4=49
+    nrpn(0, 357, 117),  // Level=91
+    nrpn(0, 358, 73),   // Key Vel=4
+    nrpn(0, 359, 0),    // A Mod Sens=0
+    nrpn(0, 360, 127),  // Rate Scaling=7
+    nrpn(0, 361, 0),    // Breakpoint=A-1
+    nrpn(0, 362, 0),    // L Depth=0
+    nrpn(0, 363, 0),    // R Depth=0
+    nrpn(0, 364, 0),    // L Curve=0
+    nrpn(0, 365, 0),    // R Curve=0
+
+    // --- Hat Op4 (fixed, coarse 31) ---
+    nrpn(0, 366, 64),   // Detune=0
+    nrpn(0, 367, 127),  // Coarse=31
+    nrpn(0, 368, 127),  // Fine=99
+    nrpn(0, 369, 127),  // EG L1=99
+    nrpn(0, 370, 127),  // EG L2=99
+    nrpn(0, 371, 127),  // EG L3=99
+    nrpn(0, 372, 0),    // EG L4=0
+    nrpn(0, 373, 127),  // EG R1=99
+    nrpn(0, 374, 38),   // EG R2=30
+    nrpn(0, 375, 127),  // EG R3=99
+    nrpn(0, 376, 46),   // EG R4=36
+    nrpn(0, 377, 127),  // Level=99
+    nrpn(0, 378, 0),    // Key Vel=0
+    nrpn(0, 379, 0),    // A Mod Sens=0
+    nrpn(0, 380, 127),  // Rate Scaling=7
+    nrpn(0, 381, 0),    // Breakpoint=A-1
+    nrpn(0, 382, 0),    // L Depth=0
+    nrpn(0, 383, 0),    // R Depth=0
+    nrpn(0, 384, 0),    // L Curve=0
+    nrpn(0, 385, 0),    // R Curve=0
+
+    // --- Hat Op5 (fixed, coarse 31) ---
+    nrpn(0, 386, 64),   // Detune=0
+    nrpn(0, 387, 127),  // Coarse=31
+    nrpn(0, 388, 122), // Fine=95
+    nrpn(0, 389, 127), // EG L1=99
+    nrpn(0, 390, 0),   // EG L2=0
+    nrpn(0, 391, 0),   // EG L3=0
+    nrpn(0, 392, 0),   // EG L4=0
+    nrpn(0, 393, 127), // EG R1=99
+    nrpn(0, 394, 69),  // EG R2=54
+    nrpn(0, 395, 127), // EG R3=99
+    nrpn(0, 396, 76),  // EG R4=59
+    nrpn(0, 397, 127), // Level=99
+    nrpn(0, 398, 73),  // Key Vel=4
+    nrpn(0, 399, 0),   // A Mod Sens=0
+    nrpn(0, 400, 127), // Rate Scaling=7
+    nrpn(0, 401, 0),   // Breakpoint=A-1
+    nrpn(0, 402, 0),   // L Depth=0
+    nrpn(0, 403, 0),   // R Depth=0
+    nrpn(0, 404, 0),   // L Curve=0
+    nrpn(0, 405, 0),   // R Curve=0
+
+    // --- Hat Op6 (fixed, coarse 31) ---
+    nrpn(0, 406, 64),  // Detune=0
+    nrpn(0, 407, 127), // Coarse=31
+    nrpn(0, 408, 123), // Fine=96
+    nrpn(0, 409, 127), // EG L1=99
+    nrpn(0, 410, 127), // EG L2=99
+    nrpn(0, 411, 127), // EG L3=99
+    nrpn(0, 412, 0),   // EG L4=0
+    nrpn(0, 413, 127), // EG R1=99
+    nrpn(0, 414, 26),  // EG R2=20
+    nrpn(0, 415, 26),  // EG R3=20
+    nrpn(0, 416, 23),  // EG R4=18
+    nrpn(0, 417, 127), // Level=99
+    nrpn(0, 418, 0),   // Key Vel=0
+    nrpn(0, 419, 0),   // A Mod Sens=0
+    nrpn(0, 420, 127), // Rate Scaling=7
+    nrpn(0, 421, 0),   // Breakpoint=A-1
+    nrpn(0, 422, 0),   // L Depth=0
+    nrpn(0, 423, 0),   // R Depth=0
+    nrpn(0, 424, 0),   // L Curve=0
+    nrpn(0, 425, 0),   // R Curve=0
+
+    // --- Hat Freq Mode (0=ratio, 1=fixed) ---
+    nrpn(0, 426, 127), // Op1 Freq Mode=fixed
+    nrpn(0, 427, 127), // Op2 Freq Mode=fixed
+    nrpn(0, 428, 127), // Op3 Freq Mode=fixed
+    nrpn(0, 429, 127), // Op4 Freq Mode=fixed
+    nrpn(0, 430, 127), // Op5 Freq Mode=fixed
+    nrpn(0, 431, 127), // Op6 Freq Mode=fixed
+]);
+
+// ===== The beat — EDIT THIS PART =====
+// channel 4 drum notes: c3 = kick, d3 = snare, fs3 = hi-hat
+createTrack(4).steps(4, [
+  c3, , , ,   d3, , , ,   , , c3, ,   d3, , , ,
+  c3, , , ,   d3, , , ,   c3, , c3, , d3, , , ,
+]);
+await createTrack(4).steps(2, [
+  fs3, fs3(0.1, 20), fs3, fs3(0.1, 20),
+  fs3, fs3(0.1, 20), fs3, fs3(0.1, 20),
+  fs3, fs3(0.1, 20), fs3, fs3(0.1, 20),
+  fs3, fs3(0.1, 20), fs3, fs3(0.1, 20),
+]);
+
+loopHere();

--- a/tools/studio-agent/.gitignore
+++ b/tools/studio-agent/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+logs/

--- a/tools/studio-agent/README.md
+++ b/tools/studio-agent/README.md
@@ -67,6 +67,9 @@ It also has read-only `Read`/`Glob`/`Grep` over this repo so it can learn from
 
 - `STUDIO_AGENT_PORT` — WebSocket port (default `17891`). The browser side reads
   `window.STUDIO_AGENT_PORT` if you need to override it there too.
+- `STUDIO_AGENT_MODEL` — model override for the speed/depth tradeoff, e.g.
+  `STUDIO_AGENT_MODEL=sonnet npm start` for faster replies, or `opus` for deeper
+  reasoning. Unset uses the Claude Code default. Shown at startup.
 
 ## Session logs
 

--- a/tools/studio-agent/README.md
+++ b/tools/studio-agent/README.md
@@ -1,0 +1,86 @@
+# studio-agent
+
+A local agent process that drives the in-browser **WebAssembly Music** app
+through a chat panel. Unlike [claude-bridge](../claude-bridge/) (which mirrors
+files to disk so you drive Claude *locally*), studio-agent is the **full in-app**
+path: the agent's tool calls execute **inside the browser** — on the editors,
+the wasm compiler, and the audio worklet — so nothing is synced to the
+filesystem.
+
+```
+browser chat panel ──ws──► studio-agent (Agent SDK)
+        ▲                          │  reads examples/docs from the repo (Read/Glob/Grep)
+        │  tool_call               │
+        └──────────────────────────┘
+   set_song / set_synth / compile / play  ← executed in the browser
+```
+
+Iteration 1 backs the chat with **Claude via the Agent SDK**, authenticated with
+your **Claude Code subscription** (Max/Pro) — no API key, no per-token billing.
+Future iterations can add other agent backends behind the same WebSocket
+protocol.
+
+## Auth
+
+Uses your existing `claude` login. **Do not** set `ANTHROPIC_API_KEY` — it takes
+precedence and switches you to per-token API billing. (`unset ANTHROPIC_API_KEY`
+if it's in your environment; the server warns you on start if it is.)
+
+## Run
+
+```sh
+cd tools/studio-agent
+npm install
+npm start            # listens on ws://localhost:17891
+```
+
+Then start the web app dev server and open it:
+
+```sh
+cd ../../wasmaudioworklet
+npm run serve        # http://localhost:8080/
+```
+
+Open <http://localhost:8080/>, tick the **agent** checkbox in the second toolbar
+to reveal the chat panel, and ask for something, e.g.
+*"make a song with a four-on-the-floor beat and a simple bassline, then play it"*.
+
+The agent writes the synth + song into the editors, compiles, fixes any compile
+errors, and starts playback — all in your browser.
+
+## Tools the agent can call (executed in the browser)
+
+| Tool | Effect in the app |
+| --- | --- |
+| `get_song` / `set_song` | read / replace the song editor |
+| `get_synth` / `set_synth` | read / replace the synth editor |
+| `edit_synth` / `edit_song` | surgical find-and-replace in place (like Edit) — change a large doc (e.g. the 14k-line DX7 bundle) without rewriting it |
+| `grep_synth` / `grep_song` | regex-search the current in-browser doc for anchors, without dumping the whole file into context |
+| `write_faust` / `read_faust` / `list_faust` | author instruments in **Faust** (`.dsp`) in OPFS `faust/` — `write_faust` also transpiles to AssemblyScript and reports the generated classes (needs `?gitrepo=` mode) |
+| `compile` | `window.compileSong()`, returns "compiled OK" or the compiler error |
+| `play` / `stop` | `window.startaudio()` / `window.stopaudio()` |
+
+It also has read-only `Read`/`Glob`/`Grep` over this repo so it can learn from
+`examples/` (incl. the DX7 FM synth), `songs/`, and `wasmaudioworklet/docs/`.
+
+## Config
+
+- `STUDIO_AGENT_PORT` — WebSocket port (default `17891`). The browser side reads
+  `window.STUDIO_AGENT_PORT` if you need to override it there too.
+
+## Session logs
+
+Every server run writes a JSONL transcript to `logs/session-<timestamp>.jsonl`
+(gitignored) — one line per event: the user's `chat` prompts, the agent's `text`,
+each `tool_use` (with truncated input), `tool_result`s, and the final `result`
+(turns + cost). These exist so the agent's behaviour can be reviewed and improved
+after a session — e.g. "look at my last session" reads the newest file. Delete
+the `logs/` folder anytime to clear them.
+
+## Status / limits (iteration 1)
+
+- One browser connection at a time.
+- Conversation continuity via the SDK `resume` session id.
+- No locking yet: if you hand-edit while the agent is mid-edit, last write wins.
+- Claude-only backend so far; the WS protocol (`chat` / `text` / `tool_call` /
+  `tool_result` / `done`) is provider-neutral by design.

--- a/tools/studio-agent/package.json
+++ b/tools/studio-agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "studio-agent",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Local agent process that drives the in-browser music studio (compile/play/edit) over WebSocket. Iteration 1: Claude via Agent SDK (Max subscription).",
+  "scripts": { "start": "node server.mjs" },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "ws": "^8.18.0",
+    "zod": "^4.0.0"
+  }
+}

--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -19,6 +19,7 @@ The user's work is precious and much of it (recorded MIDI takes especially) exis
 - **Never call set_song to demo an instrument.** If asked to "make a drum kit", stop after the instruments are built and compiled; tell the user it's ready and ask if they want a beat — do not invent one over their song.
 - **If doing what's asked seems to require changing something the user didn't mention, STOP and ask** in a one-line chat reply instead of guessing.
 - To play/preview without a song, you may compile; do not fabricate a song to hear it.
+- **Adding or changing a PART for an existing instrument is a SONG edit only.** Do NOT re-run write_faust for instruments that already exist (use list_faust if unsure) — write_faust is only for creating a NEW sound. Reserve heavy tools (write_faust) for what's actually new; issue them one at a time, not in a batch.
 
 ## SONG format & the COMPLETE sequence command set
 The song is JavaScript run by the sequencer. The full DSL is below — if a capability exists, it's one of these. The authoritative reference with exact signatures is \`wasmaudioworklet/docs/song-api.md\`; READ it whenever you're unsure of a command or its arguments. NEVER invent commands or guess what a request maps to — if the user names a sequencing behaviour you don't recognise, check the doc.

--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -1,0 +1,130 @@
+// System prompt for the studio agent. Describes the in-browser music app, the
+// song/synth formats, the tools the agent drives, and where to find examples.
+export const SYSTEM_PROMPT = `You are the Studio Agent for "WebAssembly Music" — a browser-based DAW where music is made by editing two source documents and compiling them to WebAssembly that runs live in the user's browser. You do NOT edit files on disk. You drive the running app through tools, and you READ example/reference files from the repository to learn how things are done.
+
+## The pieces you work with (all in the browser, via tools)
+1. FAUST INSTRUMENTS — each instrument's DSP is authored as a Faust \`.dsp\` file in the OPFS \`faust/\` folder. This is where you DESIGN sounds. (Faust is a concise functional DSP language.)
+2. SYNTH (synth.ts, AssemblyScript) — the multitimbral COMBINER only. It imports the Faust-generated voice classes and assigns them to MIDI channels. It should contain almost no DSP of its own.
+3. SONG — a JavaScript sequencer DSL that triggers notes on MIDI channels.
+
+Flow: author instrument DSP in Faust → it transpiles to an AssemblyScript voice+channel class pair → synth.ts wires each to a channel → song plays notes on those channels. SONG↔SYNTH are linked BY CHANNEL INDEX.
+
+**Authoring policy (important):** design instruments in FAUST (\`write_faust\`), NOT by hand-writing MidiVoice DSP in AssemblyScript. synth.ts is only for combining. The exception is trivial glue or reusing an existing AS voice from the repo.
+
+## SONG format & the COMPLETE sequence command set
+The song is JavaScript run by the sequencer. The full DSL is below — if a capability exists, it's one of these. The authoritative reference with exact signatures is \`wasmaudioworklet/docs/song-api.md\`; READ it whenever you're unsure of a command or its arguments. NEVER invent commands or guess what a request maps to — if the user names a sequencing behaviour you don't recognise, check the doc.
+
+- **Tempo / flow:** \`setBPM(bpm)\`; \`await waitForBeat(beat)\`; \`playFromHere()\`; \`loopHere()\` (marks the loop point — usually the last line).
+- **Instruments / structure:** \`addInstrument('name')\` — the Nth call is channel N (0-based); order MUST match the synth's midichannels[]. \`definePartStart('name')\` / \`definePartEnd('name')\`.
+- **Tracks:** \`const t = createTrack(channel, stepsPerBeat?, defaultVelocity?)\`. Then:
+  - \`await t.steps(stepsPerBeat, [ ...notes ])\` — step grid; empty slot = rest; \`[...].repeat(n)\`.
+  - \`await t.play([ [beat, note(...), ...], ... ])\` — absolute-beat placement; append \`.quantize(stepsPerBeat, pct?)\` to snap timing.
+  - \`t.setChannel(ch)\`, \`t.waitForBeat(b)\`, \`t.waitForStep(s)\`, \`t.waitDuration(d)\`, \`t.note(midiNo, dur)\`, \`t.playNote('c4', dur)\`.
+- **Notes:** \`<name><octave>(duration?, velocity?, offset?)\` e.g. \`c4(0.5, 100)\`; names \`c cs d ds e f fs g gs a as b\`, octaves 0-10; bare \`c4\` uses track defaults. Also \`note(midiNo, dur, vel, offset)\`, \`c4.transpose(semitones)\`, \`c4.fixVelocity(v)\`. GM-style drums: kick \`c3\`, snare \`d3\`, hi-hat \`fs3\`.
+- **Automation:** \`pitchbend(start, target, dur, steps)\`; \`controlchange(cc, start, target?, dur, steps)\`. A bare \`controlchange(cc, value)\` sends one CC immediately — that's how DX7 NRPN is sent (CC 99/98/6).
+- **Channel control:** \`mute(ch)\`, \`solo(ch)\`.
+- **Recording (capture live MIDI input INTO the song):** \`startRecording()\` … \`stopRecording()\` wrap the section during which the player's live MIDI input is recorded into the song. To "record the piano while the beat plays", put \`startRecording()\` right before the played/looped section and \`stopRecording()\` right after it (see examples/dx7/dx7-sequence.js lines 1134 & 1193). These do NOT start/stop audio — they bracket what gets captured.
+- **Media:** \`addAudio(url)\`, \`addImage(name,url)\`, \`addVideo(name,url)\`, \`startVideo(name, t?)\`, \`stopVideo(name)\`.
+- **Multi-window sync (midi path):** \`broadcastSend('name')\`, \`await broadcastWait('name')\`.
+- **Array helpers:** \`.repeat(n)\`, \`.quantize(stepsPerBeat, pct?)\`, \`.fixVelocity(v)\`.
+
+## Adding a voice/channel to a LARGE existing synth (e.g. mixing a non-DX7 voice into the DX7 bundle)
+A song plays through ONE synth document. To add a different instrument (say a waveguide string from examples/beachdrive/synth.ts) alongside the DX7 voices, you must put its voice class + a midichannels[N] registration INTO the current synth — but if that synth is the 14k-line DX7 bundle you CANNOT rewrite it with set_synth. Use surgical edits instead:
+1. Read the small source voice (e.g. the String/waveguide class in examples/beachdrive/synth.ts) and note its class + any imports/helpers it needs (e.g. ../synth/waveguide).
+2. Find anchors in the CURRENT synth with grep_synth (the in-browser doc is what compiles; don't assume it equals the on-disk file): grep for \`export function initializeMidiSynth\`, for the \`midichannels[<n>] = \` line you want to add/replace, and for the import block at the top.
+3. edit_synth to (a) add any needed import line, (b) insert the new voice class (anchor on a unique line just before initializeMidiSynth), and (c) add or replace the \`midichannels[N] = new MidiChannel(maxVoices, (ch) => new YourVoice(ch));\` registration. Keep all existing DX7 channels intact.
+4. Make sure the song's addInstrument() count covers channel N, then write that channel's part. A non-FM voice (waveguide/subtractive) does NOT need NRPN patch data — only DX7/FM channels do.
+5. compile; if an import or symbol doesn't resolve, grep_synth/Read to find the right path and fix with edit_synth. Repeat until "compiled OK", then play.
+
+## Authoring an instrument in FAUST (the primary way to make a sound)
+Use \`write_faust(path, source)\` — it writes \`faust/<path>.dsp\` AND transpiles it to \`faust/<path>.ts\`, returning the generated class names (or the exact transpile error to fix). Requires the app opened with \`?gitrepo=…\` (OPFS). Then synth.ts imports those classes.
+
+A Faust MIDI instrument must expose the standard voice controls \`freq\`, \`gate\`, \`gain\` and have 0 audio inputs / 1 output (the transpiler then makes a polyphonic voice; a 2-in/2-out DSP is treated as a stereo effect instead). Minimal template:
+\`\`\`
+import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
+\`\`\`
+- Always drive the amplitude with an envelope gated by \`gate\` (e.g. \`en.adsr(a,d,s,r, gate)\`) so notes start and RELEASE. Without it a note never stops.
+- Extra \`hslider\`/\`nentry\` controls (cutoff, detune, etc.) become channel parameters, settable from the song via NRPN or as channel fields.
+- A file \`faust/bass.dsp\` transpiles to classes \`Bass\` (voice) + \`BassChannel\` (channel). \`write_faust\` tells you the exact names — use them.
+- Keep instruments as separate files (faust/bass.dsp, faust/lead.dsp, …), one instrument per channel.
+
+## synth.ts is ONLY the multitimbral combiner
+It should look essentially like this — imports + channel wiring, no DSP:
+\`\`\`
+import { midichannels, MidiChannel } from '../mixes/globalimports';
+import { Bass, BassChannel } from '../faust/bass';
+import { Lead, LeadChannel } from '../faust/lead';
+
+export function initializeMidiSynth(): void {
+    midichannels[0] = new BassChannel(6, (channel: MidiChannel) => new Bass(channel));
+    midichannels[1] = new LeadChannel(8, (channel: MidiChannel) => new Lead(channel));
+}
+export function postprocess(): void {}
+\`\`\`
+- The channel index MUST match the song's addInstrument() order.
+- Import the Faust-generated classes from \`'../faust/<stem>'\` (that path is how the compiler injects transpiled Faust). Use the class names \`write_faust\` reported.
+- Do NOT paste DSP or reimplement the instrument here. If you're writing oscillators/filters in synth.ts, stop — put them in a \`.dsp\` via write_faust instead.
+
+## Typical "make an instrument" workflow
+1. write_faust('bass', '<faust source>') → note the reported classes + fix any transpile error by editing the .dsp and calling write_faust again.
+2. Wire it into synth.ts: if the synth is small, set_synth the whole combiner; if it's a large existing bundle, edit_synth to add the import + the midichannels[N] line (see the large-synth section above).
+3. addInstrument in the song at the matching index and write the part.
+4. compile → fix → play.
+
+## Your tools
+You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try to use anything else.
+- Read / Glob / Grep — read reference files in this repo (examples, songs, docs) to learn syntax.
+- get_song / set_song(source) — read / replace the entire song document (in the browser).
+- get_synth / set_synth(source) — read / replace the entire synth document (in the browser).
+- edit_synth(old_string, new_string, replace_all?) / edit_song(...) — SURGICAL find-and-replace in place (like the Edit tool). old_string must match exactly and be unique (or set replace_all). Use this to change a LARGE document without rewriting it.
+- grep_synth(pattern, context?) / grep_song(pattern, context?) — regex-search the CURRENT in-browser document; returns matching line numbers + text. Use to find exact anchors for edit_synth in a big synth without dumping the whole file into context.
+- write_faust(path, source) — author an INSTRUMENT: write faust/<path>.dsp and transpile it to AssemblyScript in one step; returns the generated class names or the transpile error. THE primary way to create instrument DSP.
+- read_faust(path) / list_faust() — read a .dsp / list the .dsp instruments in faust/.
+- load_synth_from_file(path) / load_song_from_file(path) — load a repo file DIRECTLY into the synth/song editor. The file content never enters your context — you only pass a repo-relative path. **Use this for any large file** (e.g. the DX7 bundle).
+- compile — compile song+synth in the browser; returns "compiled OK" or the exact compiler error. ALWAYS compile after editing and FIX errors before continuing.
+- play / stop — start/stop live audio (play compiles first).
+
+## CRITICAL: never shuttle large files through your context
+Some references (notably examples/dx7/dx7-synth.ts, ~14k lines) are far too large to Read in full or to paste into set_synth. NEVER try to read a big bundle chunk-by-chunk to reproduce it. To put a large file into an editor, call load_synth_from_file / load_song_from_file with its path. Use Read/Grep only to inspect SMALL files or specific ranges so you understand structure (channel layout, note mapping) — not to copy big files.
+
+## How to work
+1. Understand the request. It's usually about the SONG (map it to the sequence commands above — if unsure, Read wasmaudioworklet/docs/song-api.md) or about an INSTRUMENT SOUND (author it in Faust).
+2. For a NEW instrument sound: author it with write_faust (design the DSP in Faust), then wire the returned classes into synth.ts. Do NOT hand-write the DSP in AssemblyScript. For DX7 specifically, the ready bundle path still applies (see below).
+3. Put things in place: write small synth.ts combiners with set_synth, or edit large ones with edit_synth; write/edit the song. When ADDING to an existing song/synth, get_song/grep_synth first and edit it — don't discard what's there. Keep channel order consistent between synth and song.
+4. compile. If it errors, read the error, fix, compile again. Repeat until "compiled OK". (A Faust transpile error comes back from write_faust — fix the .dsp; an AS error comes back from compile — fix synth.ts.)
+5. If the user asked to hear it, call play. Reply briefly; don't paste source unless asked.
+
+**Asking the user:** you have NO interactive dialog tool — do not attempt one. If a request is genuinely ambiguous and the interpretations lead to very different results, ask ONE short clarifying question in your text reply and stop; the user answers in their next message. But prefer the most likely interpretation and proceed when the choice is minor.
+
+## DX7 / FM (CRITICAL — every channel's patch comes from the SONG as NRPN)
+A DX7 voice is a stack of FM operators; with NO patch data it outputs a bare carrier SINE (and drum voices effectively go silent). The synth bundle (dx7-synth.ts) does NOT hold the patches: its initializeMidiSynth() only sends value-0 NRPN that ZEROES each channel's parameters — that zeroed state is exactly what sounds like a sine. The real patch VALUES are sent from the SONG: ~144 NRPN messages per channel (CC 99/98/6) at beat 0, before the notes (see examples/dx7/dx7-sequence.js). This is true for EVERY channel you sound — bass, e.piano, strings, bells AND drums. Never assume a channel is "pre-programmed". A DX7 song with only addInstrument()+notes and no nrpn() block is THE "I only hear a sine wave" bug. This rule is fixed — do not re-derive it.
+
+Always load the synth first: \`load_synth_from_file('examples/dx7/dx7-synth.ts')\` (don't read it; it's huge).
+
+Then pick the cheapest correct SONG path:
+- **Drum beat (most common):** \`load_song_from_file('examples/dx7/dx7-drumbeat.js')\` — a self-contained drums-only song that ALREADY embeds the kick/snare/hat NRPN patch block. To customize: get_song, edit ONLY setBPM and the steps() pattern near the bottom (leave the NRPN block intact), then set_song. Drum notes: c3=kick, d3=snare, fs3=hi-hat.
+- **Full demo / verify sound:** \`load_song_from_file('examples/dx7/dx7-sequence.js')\`.
+- **Custom melodic part:** copy that channel's nrpn() patch block from dx7-sequence.js into your song before its notes — line ranges: E.Piano 26-178, Bass 181-333, Strings 336-488, Bells 492-644, Drums 648-1131. Read only the range you need; never paste a whole channel from memory.
+
+Then compile, fix any error, play.
+
+## Editing recorded performances (the user plays live; you clean it up)
+When the user records live MIDI, the captured notes appear as \`createTrack(N).play([...])\` arrays inside the \`startRecording()\`/\`stopRecording()\` markers. You cannot press the app's record button — the user does that; your job is to set up channels and edit the takes. Common requests:
+- **"the <instrument> is silent / missing"** → that channel has notes but no patch, so it renders as a sine. Add its NRPN patch block (same rule as everywhere: any sounding channel needs its patch). After a recording, EVERY channel that has notes needs its patch.
+- **"fix my timing / quantize"** → append \`.quantize(stepsPerBeat, pct?)\` to the take's array. CAUTION: quantizing snaps every note to the grid, which COLLAPSES fast ornaments — grace notes and trills (Norwegian "triller") land on the same step as their target note and sound simultaneous. So quantize the structural melody, but pull ornament / lead-in notes into a SEPARATE, UN-quantized \`createTrack(N).play([...])\` layer and place each a fraction of a beat before its target (e.g. a 32nd ahead). Offer percentage quantize (\`.quantize(4, 0.7)\`) to keep some human feel.
+- **"up / down an octave"** → either change the patch Transpose (NRPN param 1: value 64 = 0 semitones, 32 = −12, 76 ≈ +12) to keep note data as-is, or transpose the notes (\`.transpose(12)\`). Pick based on whether the patch character should be preserved; mention the alternative.
+- **Preserve everything else** → get_song and change ONLY what was asked. Keep the drums, other takes, all patches, and the record markers intact.
+
+## Reference material in the repo (read these to learn syntax)
+- wasmaudioworklet/docs/song-api.md — the AUTHORITATIVE full sequence/song DSL reference (every command + exact signatures). Consult it for anything sequencing-related you're unsure about.
+- examples/beachdrive/song.js + examples/beachdrive/synth.ts — a clean, minimal song↔synth pairing (good starting template).
+- songs/ — more example songs.
+- DX7 FM synth: examples/dx7/README.md, examples/dx7/dx7-synth.ts (the full FM synth source to use as the synth), examples/dx7/dx7-sequence.js (how a song selects DX7 patches via NRPN). If the user asks for a DX7 sound, read these and reproduce the approach (the dx7-synth.ts is large — set it as the synth source, then write a song that targets its channels).
+- examples/master_me/ — Faust mastering chain (a stereo EFFECT, not an instrument).
+- Faust instrument DSP examples: examples/dx7/dsp/*.dsp (FM algorithms) and the standard Faust libraries (stdfaust.lib: os.* oscillators, en.* envelopes, fi.* filters, ef.* effects). Keep instrument DSPs small and self-contained; use write_faust and let the transpile error guide fixes.
+
+Be practical and concise. The goal is music the user can immediately hear in their browser.`;

--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -11,6 +11,15 @@ Flow: author instrument DSP in Faust → it transpiles to an AssemblyScript voic
 
 **Authoring policy (important):** design instruments in FAUST (\`write_faust\`), NOT by hand-writing MidiVoice DSP in AssemblyScript. synth.ts is only for combining. The exception is trivial glue or reusing an existing AS voice from the repo.
 
+## SCOPE DISCIPLINE — do ONLY what is asked (READ FIRST)
+The user's work is precious and much of it (recorded MIDI takes especially) exists ONLY in the browser and NOT in your context — if you overwrite it, it may be gone forever. Therefore:
+- **Do exactly what's requested — nothing extra.** Don't add a demo song, don't "also" play it, don't create a bassline, don't retarget channels, unless the user asked. Finishing the requested change is the whole job.
+- **NEVER replace the SONG (set_song) unless the user explicitly asked to create or rewrite the song.** "Make/add an instrument" does NOT include touching the song. If you build a kick/snare/hihat, you write the .dsp files and wire them into synth.ts — you do NOT write or change song.js at all.
+- **Before replacing ANY existing document, get_song / get_synth (or grep) FIRST to preserve it, and prefer edit_song / edit_synth (additive) over a full set_*.** Only use set_song/set_synth to create a document from scratch (it's currently empty/default) or when the user explicitly said "rewrite/replace it".
+- **Never call set_song to demo an instrument.** If asked to "make a drum kit", stop after the instruments are built and compiled; tell the user it's ready and ask if they want a beat — do not invent one over their song.
+- **If doing what's asked seems to require changing something the user didn't mention, STOP and ask** in a one-line chat reply instead of guessing.
+- To play/preview without a song, you may compile; do not fabricate a song to hear it.
+
 ## SONG format & the COMPLETE sequence command set
 The song is JavaScript run by the sequencer. The full DSL is below — if a capability exists, it's one of these. The authoritative reference with exact signatures is \`wasmaudioworklet/docs/song-api.md\`; READ it whenever you're unsure of a command or its arguments. NEVER invent commands or guess what a request maps to — if the user names a sequencing behaviour you don't recognise, check the doc.
 
@@ -84,6 +93,7 @@ You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try
 - grep_synth(pattern, context?) / grep_song(pattern, context?) — regex-search the CURRENT in-browser document; returns matching line numbers + text. Use to find exact anchors for edit_synth in a big synth without dumping the whole file into context.
 - write_faust(path, source) — author an INSTRUMENT: write faust/<path>.dsp and transpile it to AssemblyScript in one step; returns the generated class names or the transpile error. THE primary way to create instrument DSP.
 - read_faust(path) / list_faust() — read a .dsp / list the .dsp instruments in faust/.
+- git_log() / read_committed(path, ref?) — inspect the OPFS repo history / read a file's COMMITTED content (default HEAD). The user commits their work to OPFS git. To RESTORE something that was overwritten in the editor, read_committed the repo-relative path (e.g. 'song.js') and set_song/set_synth it back. This is how you recover a lost song — check git before saying it's gone.
 - load_synth_from_file(path) / load_song_from_file(path) — load a repo file DIRECTLY into the synth/song editor. The file content never enters your context — you only pass a repo-relative path. **Use this for any large file** (e.g. the DX7 bundle).
 - compile — compile song+synth in the browser; returns "compiled OK" or the exact compiler error. ALWAYS compile after editing and FIX errors before continuing.
 - play / stop — start/stop live audio (play compiles first).

--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -66,18 +66,20 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
 It should look essentially like this — imports + channel wiring, no DSP:
 \`\`\`
 import { midichannels, MidiChannel } from '../mixes/globalimports';
-import { Bass, BassChannel } from '../faust/bass';
-import { Lead, LeadChannel } from '../faust/lead';
+import { Bass } from '../faust/bass';
+import { Lead } from '../faust/lead';
 
 export function initializeMidiSynth(): void {
-    midichannels[0] = new BassChannel(6, (channel: MidiChannel) => new Bass(channel));
-    midichannels[1] = new LeadChannel(8, (channel: MidiChannel) => new Lead(channel));
+    midichannels[0] = new MidiChannel(6, (channel: MidiChannel) => new Bass(channel));
+    midichannels[1] = new MidiChannel(8, (channel: MidiChannel) => new Lead(channel));
 }
 export function postprocess(): void {}
 \`\`\`
 - The channel index MUST match the song's addInstrument() order.
-- Import the Faust-generated classes from \`'../faust/<stem>'\` (that path is how the compiler injects transpiled Faust). Use the class names \`write_faust\` reported.
+- **Import EXACTLY the classes write_faust reported, and no others.** Most instruments export only the voice class \`<Name>\` — register it with the base \`MidiChannel\` (as above). A \`<Name>Channel\` class is generated ONLY when the instrument exposes extra hslider/nentry params (beyond freq/gate/gain); import and use it in place of MidiChannel ONLY when write_faust actually listed it. Importing a \`<Name>Channel\` that wasn't generated is the recurring "has no exported member" compile error — don't guess.
+- Import from \`'../faust/<stem>'\` (that path is how the compiler injects transpiled Faust).
 - Do NOT paste DSP or reimplement the instrument here. If you're writing oscillators/filters in synth.ts, stop — put them in a \`.dsp\` via write_faust instead.
+- AssemblyScript **warnings** (AS235 "only variables/functions/enums become exports", AS233 typedChannel, etc.) are NON-fatal — if compile still says "compiled OK", ignore them; only fix ERRORs.
 
 ## Typical "make an instrument" workflow
 1. write_faust('bass', '<faust source>') → note the reported classes + fix any transpile error by editing the .dsp and calling write_faust again.

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -1,0 +1,233 @@
+// studio-agent — local process that drives the in-browser WebAssembly Music app.
+//
+// The browser (chat panel) connects over WebSocket. When the user sends a chat
+// message we run the Claude Agent SDK; the agent's custom tools (set_song,
+// compile, play, …) are proxied back over the SAME socket to execute INSIDE the
+// browser (on the editors / compiler / audio worklet). The agent reads example
+// files from this repo via its built-in Read/Glob/Grep tools.
+//
+// AUTH: uses your Claude Code login (Max/Pro subscription). Do NOT set
+// ANTHROPIC_API_KEY (it would switch you to per-token API billing).
+//
+// Run:  npm install && npm start    (listens on ws://localhost:17891)
+
+import { WebSocketServer } from 'ws';
+import { readFile } from 'node:fs/promises';
+import { mkdirSync, createWriteStream } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { z } from 'zod';
+import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { SYSTEM_PROMPT } from './prompt.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..'); // tools/studio-agent -> repo root
+const PORT = process.env.STUDIO_AGENT_PORT || 17891;
+const TOOL_TIMEOUT_MS = 120000;
+
+// ---- session logging: one JSONL file per server boot, for later review ------
+const LOG_DIR = resolve(__dirname, 'logs');
+mkdirSync(LOG_DIR, { recursive: true });
+const LOG_PATH = resolve(LOG_DIR, `session-${new Date().toISOString().replace(/[:.]/g, '-')}.jsonl`);
+const logStream = createWriteStream(LOG_PATH, { flags: 'a' });
+const trunc = (s, n = 2000) => (typeof s === 'string' && s.length > n ? `${s.slice(0, n)}…[+${s.length - n} chars]` : s);
+const truncInput = (input) => {
+  if (!input || typeof input !== 'object') return input;
+  const o = {};
+  for (const k of Object.keys(input)) o[k] = trunc(input[k]);
+  return o;
+};
+function logEvent(obj) {
+  try { logStream.write(JSON.stringify({ ts: new Date().toISOString(), ...obj }) + '\n'); } catch { /* never let logging break a turn */ }
+}
+
+if (process.env.ANTHROPIC_API_KEY) {
+  console.warn(
+    '\n⚠️  ANTHROPIC_API_KEY is set — the SDK will bill per-token, NOT your\n' +
+    '   Max subscription. Run `unset ANTHROPIC_API_KEY` to use the subscription.\n'
+  );
+}
+
+// Tools the agent may use: our browser-proxied studio tools + read-only repo access.
+const STUDIO_TOOLS = [
+  'get_song', 'set_song', 'get_synth', 'set_synth',
+  'edit_synth', 'edit_song', 'grep_synth', 'grep_song',
+  'write_faust', 'read_faust', 'list_faust',
+  'load_synth_from_file', 'load_song_from_file',
+  'compile', 'play', 'stop',
+];
+const ALLOWED = new Set([
+  ...STUDIO_TOOLS.map((n) => `mcp__studio__${n}`),
+  'Read', 'Glob', 'Grep',
+]);
+// Built-in tools that cause the agent to thrash on this task — keep it focused.
+const DISALLOWED = ['Bash', 'BashOutput', 'KillShell', 'Agent', 'Task', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'WebSearch', 'WebFetch', 'AskUserQuestion'];
+
+function safeResolve(p) {
+  const full = resolve(REPO_ROOT, p);
+  if (full !== REPO_ROOT && !full.startsWith(REPO_ROOT + '/')) throw new Error(`path "${p}" escapes the repo`);
+  return full;
+}
+
+// ---- WebSocket plumbing: one browser at a time -----------------------------
+let pending = new Map();   // id -> { resolve }
+let nextId = 1;
+
+function callBrowser(ws, name, args) {
+  return new Promise((resolveCall, rejectCall) => {
+    const id = nextId++;
+    pending.set(id, { resolve: resolveCall });
+    ws.send(JSON.stringify({ t: 'tool_call', id, name, args: args || {} }));
+    setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        rejectCall(new Error(`browser tool "${name}" timed out`));
+      }
+    }, TOOL_TIMEOUT_MS);
+  });
+}
+
+// ---- Build the in-process MCP tools, bound to one browser socket -----------
+function makeStudioServer(ws) {
+  const proxy = (name, description, shape) =>
+    tool(name, description, shape, async (args) => {
+      try {
+        const res = await callBrowser(ws, name, args);
+        if (!res.ok) {
+          return { content: [{ type: 'text', text: `ERROR: ${res.result ?? 'tool failed'}` }], isError: true };
+        }
+        const text = typeof res.result === 'string' ? res.result : JSON.stringify(res.result);
+        return { content: [{ type: 'text', text: text || 'ok' }] };
+      } catch (e) {
+        return { content: [{ type: 'text', text: `ERROR: ${e?.message || e}` }], isError: true };
+      }
+    });
+
+  // Load a repo file straight into an editor: the bytes are read server-side and
+  // pushed to the browser, so a huge bundle never has to pass through the model.
+  const loadInto = (toolName, browserOp, label) =>
+    tool(toolName,
+      `Load a repository file DIRECTLY into the ${label} editor without reading it into context. Use this for large bundles (e.g. examples/dx7/dx7-synth.ts) — pass a repo-relative path; the file content is sent to the browser for you.`,
+      { path: z.string() },
+      async ({ path }) => {
+        try {
+          const content = await readFile(safeResolve(path), 'utf8');
+          const res = await callBrowser(ws, browserOp, { source: content });
+          if (!res.ok) return { content: [{ type: 'text', text: `ERROR: ${res.result ?? 'load failed'}` }], isError: true };
+          return { content: [{ type: 'text', text: `loaded ${path} (${content.split('\n').length} lines) into the ${label} editor` }] };
+        } catch (e) {
+          return { content: [{ type: 'text', text: `ERROR: ${e?.message || e}` }], isError: true };
+        }
+      });
+
+  return createSdkMcpServer({
+    name: 'studio',
+    version: '1.0.0',
+    tools: [
+      proxy('get_song', 'Return the current song document (JavaScript sequencer DSL).', {}),
+      proxy('set_song', 'Replace the entire song document. Provide the full new source.', { source: z.string() }),
+      proxy('get_synth', 'Return the current synth document (AssemblyScript).', {}),
+      proxy('set_synth', 'Replace the entire synth document. Provide the full new source.', { source: z.string() }),
+      proxy('edit_synth', 'Surgically find-and-replace in the synth document IN PLACE (like the Edit tool). Use this to add a voice/channel to a large synth (e.g. the DX7 bundle) WITHOUT rewriting it. old_string must match exactly and be unique unless replace_all is true.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
+      proxy('edit_song', 'Surgically find-and-replace in the song document IN PLACE. old_string must match exactly and be unique unless replace_all is true.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
+      proxy('grep_synth', 'Search the CURRENT in-browser synth document for a regex; returns matching line numbers + text (optionally with surrounding context lines). Use to find exact anchors for edit_synth in a large synth without dumping the whole file.', { pattern: z.string(), context: z.number().optional() }),
+      proxy('grep_song', 'Search the CURRENT in-browser song document for a regex; returns matching line numbers + text.', { pattern: z.string(), context: z.number().optional() }),
+      proxy('write_faust', 'Author an INSTRUMENT in Faust: write faust/<path>.dsp AND transpile it to AssemblyScript in one step (persists faust/<name>.dsp + faust/<name>.ts in the browser OPFS). Returns the generated class names to import into synth.ts, or the exact transpile error. This is the primary way to create instrument DSP — do NOT hand-write DSP in AssemblyScript.', { path: z.string(), source: z.string() }),
+      proxy('read_faust', 'Read a Faust .dsp instrument source from the browser OPFS faust/ folder.', { path: z.string() }),
+      proxy('list_faust', 'List the .dsp Faust instruments in the browser OPFS faust/ folder.', {}),
+      loadInto('load_synth_from_file', 'set_synth', 'synth'),
+      loadInto('load_song_from_file', 'set_song', 'song'),
+      proxy('compile', 'Compile the current song+synth in the browser. Returns "compiled OK" or the exact compiler error. Call after every edit.', {}),
+      proxy('play', 'Start live audio playback in the browser (compiles first).', {}),
+      proxy('stop', 'Stop live audio playback.', {}),
+    ],
+  });
+}
+
+// ---- Run one chat turn through the agent -----------------------------------
+const t0 = () => new Date().toISOString().slice(11, 23);
+const dlog = (...a) => console.log(`  [${t0()}]`, ...a);
+
+async function handleChat(ws, { text, sessionId }) {
+  const send = (obj) => { if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(obj)); };
+  const studio = makeStudioServer(ws);
+  let sid = sessionId || null;
+  dlog('chat:', JSON.stringify(text).slice(0, 100), sessionId ? `(resume ${sessionId.slice(0, 8)})` : '(new)');
+  logEvent({ kind: 'chat', sessionId: sid, resumed: !!sessionId, text });
+
+  try {
+    for await (const m of query({
+      prompt: text,
+      options: {
+        resume: sessionId || undefined,
+        cwd: REPO_ROOT,
+        systemPrompt: SYSTEM_PROMPT,
+        mcpServers: { studio },
+        allowedTools: [...ALLOWED],
+        disallowedTools: DISALLOWED,
+        canUseTool: async (name, input) => {
+          const ok = ALLOWED.has(name);
+          dlog(ok ? 'ALLOW' : 'DENY ', name, ok ? '' : '(not in allowlist)');
+          return ok
+            ? { behavior: 'allow', updatedInput: input }
+            : { behavior: 'deny', message: `${name} is not available to the studio agent; use only Read/Glob/Grep and the studio tools (set_synth/set_song/compile/play/stop).` };
+        },
+        maxTurns: 60,
+      },
+    })) {
+      if (m.type === 'system' && m.subtype === 'init') {
+        sid = m.session_id || sid;
+        dlog('session init', m.session_id?.slice(0, 8), 'tools:', (m.tools || []).length);
+        logEvent({ kind: 'session', sessionId: sid, toolCount: (m.tools || []).length });
+        send({ t: 'session', sessionId: m.session_id });
+      } else if (m.type === 'assistant') {
+        for (const block of m.message?.content ?? []) {
+          if (block.type === 'text' && block.text) { dlog('text:', block.text.slice(0, 80).replace(/\n/g, ' ')); logEvent({ kind: 'text', sessionId: sid, text: block.text }); send({ t: 'text', text: block.text }); }
+          else if (block.type === 'tool_use') { dlog('tool_use →', block.name, JSON.stringify(block.input).slice(0, 80)); logEvent({ kind: 'tool_use', sessionId: sid, name: block.name, input: truncInput(block.input) }); send({ t: 'tool', name: block.name, input: block.input }); }
+        }
+      } else if (m.type === 'user') {
+        for (const block of m.message?.content ?? []) {
+          if (block.type === 'tool_result') {
+            const txt = Array.isArray(block.content) ? block.content.map(c => c.text || '').join('') : String(block.content || '');
+            dlog('tool_result', block.is_error ? '(ERROR)' : '', txt.slice(0, 80).replace(/\n/g, ' '));
+            logEvent({ kind: 'tool_result', sessionId: sid, isError: !!block.is_error, text: trunc(txt, 1000) });
+          }
+        }
+      } else if (m.type === 'result') {
+        dlog('RESULT', m.subtype, 'turns:', m.num_turns, 'cost:', m.total_cost_usd);
+        logEvent({ kind: 'result', sessionId: sid, subtype: m.subtype, turns: m.num_turns, costUsd: m.total_cost_usd });
+        send({ t: 'done', subtype: m.subtype });
+      }
+    }
+    dlog('query loop ended');
+  } catch (e) {
+    dlog('EXCEPTION', e?.message || e);
+    logEvent({ kind: 'error', sessionId: sid, error: String(e?.message || e) });
+    send({ t: 'error', error: String(e?.message || e) });
+  }
+}
+
+// ---- Server ----------------------------------------------------------------
+const wss = new WebSocketServer({ port: PORT });
+
+wss.on('connection', (ws) => {
+  console.log('  browser connected');
+  // Keep idle connections alive so a tool call after a long pause isn't stranded
+  // on a half-dead socket (browsers/proxies drop silent TCP after a few minutes).
+  const keepalive = setInterval(() => { if (ws.readyState === ws.OPEN) ws.ping(); }, 25000);
+  ws.on('message', (data) => {
+    let msg;
+    try { msg = JSON.parse(data.toString()); } catch { return; }
+    if (msg.t === 'tool_result') {
+      const p = pending.get(msg.id);
+      if (p) { pending.delete(msg.id); p.resolve(msg); }
+    } else if (msg.t === 'chat') {
+      handleChat(ws, msg);
+    }
+  });
+  ws.on('close', () => { clearInterval(keepalive); console.log('  browser disconnected'); });
+});
+
+console.log(`\n  studio-agent → ws://localhost:${PORT}`);
+console.log(`  repo root:     ${REPO_ROOT}`);
+console.log('  auth:          Claude Code subscription login (no API key)\n');

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -24,6 +24,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..'); // tools/studio-agent -> repo root
 const PORT = process.env.STUDIO_AGENT_PORT || 17891;
 const TOOL_TIMEOUT_MS = 120000;
+// Optional model override for speed/depth tradeoff, e.g. STUDIO_AGENT_MODEL=sonnet
+// (faster) vs opus (deeper). Unset = the SDK/Claude Code default.
+const MODEL = process.env.STUDIO_AGENT_MODEL || undefined;
 
 // ---- session logging: one JSONL file per server boot, for later review ------
 const LOG_DIR = resolve(__dirname, 'logs');
@@ -163,6 +166,7 @@ async function handleChat(ws, { text, sessionId }) {
       prompt: text,
       options: {
         resume: sessionId || undefined,
+        model: MODEL,
         cwd: REPO_ROOT,
         systemPrompt: SYSTEM_PROMPT,
         mcpServers: { studio },
@@ -233,4 +237,5 @@ wss.on('connection', (ws) => {
 
 console.log(`\n  studio-agent → ws://localhost:${PORT}`);
 console.log(`  repo root:     ${REPO_ROOT}`);
+console.log(`  model:         ${MODEL || '(default)'}`);
 console.log('  auth:          Claude Code subscription login (no API key)\n');

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -53,6 +53,7 @@ const STUDIO_TOOLS = [
   'get_song', 'set_song', 'get_synth', 'set_synth',
   'edit_synth', 'edit_song', 'grep_synth', 'grep_song',
   'write_faust', 'read_faust', 'list_faust',
+  'git_log', 'read_committed',
   'load_synth_from_file', 'load_song_from_file',
   'compile', 'play', 'stop',
 ];
@@ -135,6 +136,8 @@ function makeStudioServer(ws) {
       proxy('write_faust', 'Author an INSTRUMENT in Faust: write faust/<path>.dsp AND transpile it to AssemblyScript in one step (persists faust/<name>.dsp + faust/<name>.ts in the browser OPFS). Returns the generated class names to import into synth.ts, or the exact transpile error. This is the primary way to create instrument DSP — do NOT hand-write DSP in AssemblyScript.', { path: z.string(), source: z.string() }),
       proxy('read_faust', 'Read a Faust .dsp instrument source from the browser OPFS faust/ folder.', { path: z.string() }),
       proxy('list_faust', 'List the .dsp Faust instruments in the browser OPFS faust/ folder.', {}),
+      proxy('git_log', 'Show the commit history of the in-browser OPFS repo (the user commits their work here). Use it to find a commit to restore a file from.', {}),
+      proxy('read_committed', 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use to restore something overwritten in the editor: read_committed then set_song/set_synth it back.', { path: z.string(), ref: z.string().optional() }),
       loadInto('load_synth_from_file', 'set_synth', 'synth'),
       loadInto('load_song_from_file', 'set_song', 'song'),
       proxy('compile', 'Compile the current song+synth in the browser. Returns "compiled OK" or the exact compiler error. Call after every edit.', {}),

--- a/wasmaudioworklet/app.html.js
+++ b/wasmaudioworklet/app.html.js
@@ -71,6 +71,10 @@ export default /*html*/ `<link rel="stylesheet" href="https://cdnjs.cloudflare.c
       <span>faust</span>
     </label>
     <span style="flex-grow: 1"></span>
+    <label title="studio agent (AI assistant)">
+      <input type="checkbox" id="studioagenttogglecheckbox" onclick="toggleStudioAgent(this.checked)" />
+      <span>agent</span>
+    </label>
   </div>
   <div class="editors">
     <div id="editor" class="editor"></div>
@@ -88,6 +92,16 @@ export default /*html*/ `<link rel="stylesheet" href="https://cdnjs.cloudflare.c
       </div>
       <div id="faustcodemirror" style="flex-grow: 1; height: calc(100% - 32px);"></div>
     </div>
+  </div>
+
+  <div id="studioagentpanel" style="display: none">
+    <div id="studioagentstatus" class="sa-status">agent: connecting…</div>
+    <div id="studioagentlog" class="sa-log"></div>
+    <form id="studioagentform" class="sa-form">
+      <textarea id="studioagentinput" rows="2"
+        placeholder="Ask the studio agent…  e.g. 'make a song with a four-on-the-floor beat and a bassline'"></textarea>
+      <button type="submit" id="studioagentsend">Send</button>
+    </form>
   </div>
 
   <div id="errormessages">

--- a/wasmaudioworklet/app.js
+++ b/wasmaudioworklet/app.js
@@ -2,6 +2,7 @@ import { } from './audioworkletpolyfill.js';
 import { initAudioWorkletNode } from './audioworkletnode.js';
 import { initVisualizer, setCurrentTimeSeconds as setVisualizerCurrentTimeSeconds } from './visualizer/defaultvisualizer.js';
 import { initEditor } from './editorcontroller.js';
+import { initStudioAgent } from './studio-agent-client.js';
 import { toggleSpinner } from './common/ui/progress-spinner.js';
 import { modalAlert } from './common/ui/modal.js';
 import apphtml from './app.html.js';
@@ -37,6 +38,7 @@ customElements.define('app-javascriptmusic',
           '\n\nThe spinner is cleared but the editor may not be fully usable. See the console for details.');
       }
       enablePlayAndSaveButtons();
+      initStudioAgent(this.shadowRoot);
 
       appReadyPromises.forEach(p => p());
       appReadyPromises = null;

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -208,6 +208,9 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
             console.warn('Failed to list faust files', e);
         }
     }
+    // Exposed so the studio-agent (which writes .dsp files straight to OPFS) can
+    // refresh the Faust file dropdown after authoring an instrument.
+    window.refreshFaustFileList = refreshFaustFileList;
 
     async function loadFaustFile(path) {
         try {

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -31,7 +31,8 @@
         "test-near-git": "npx playwright test e2e/near-git.spec.js",
         "test-claude-bridge": "npx playwright test e2e/claude-bridge.spec.js",
         "near-sandbox": "docker run --rm -p 3030:8080 ghcr.io/petersalomonsen/near-git-storage/sandbox:main",
-        "test-faust": "node ../tools/faust2as/generate-test-sources.js && npx playwright test e2e/faust2as-compilation.spec.js"
+        "test-faust": "node ../tools/faust2as/generate-test-sources.js && npx playwright test e2e/faust2as-compilation.spec.js",
+        "test-agent-tools": "node --test studio-agent-tools-core.test.mjs"
     },
     "resolutions": {
         "playwright": "1.59.1"

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -8,6 +8,7 @@
 import { songsourceeditor, synthsourceeditor } from './editorcontroller.js';
 import { transpileDspSource } from './faust/browser-transpile.js';
 import { readfile, writefileandstage, listfiles, gitCommand, gitLog } from './wasmgit/wasmgitclient.js';
+import { applyEditToText, grepText, normDsp, faustRegistrationHint } from './studio-agent-tools-core.js';
 
 const DEFAULT_PORT = 17891;
 const FAUST_DIR = 'faust/';
@@ -19,35 +20,18 @@ let sessionId = null;
 let agentMsgEl = null; // the in-progress assistant message element
 let toolQueue = Promise.resolve(); // serialize tool execution (see tool_call below)
 
-// Surgical find-and-replace on an editor doc — mirrors the Edit tool's semantics
-// so the agent can change a large document (e.g. the 14k-line DX7 bundle) without
-// rewriting the whole thing.
-function applyEdit(editor, { old_string, new_string, replace_all }) {
-  const cur = editor.doc.getValue();
-  if (old_string === new_string) return { __error: 'old_string and new_string are identical' };
-  const count = old_string ? cur.split(old_string).length - 1 : 0;
-  if (count === 0) return { __error: 'old_string not found in the document' };
-  if (count > 1 && !replace_all) return { __error: `old_string is not unique (${count} matches); add more surrounding context or set replace_all` };
-  const next = replace_all ? cur.split(old_string).join(new_string) : cur.replace(old_string, new_string);
-  editor.doc.setValue(next);
-  return `applied ${replace_all ? count : 1} edit(s)`;
+// Editor wrappers around the pure logic in studio-agent-tools-core.js.
+function applyEdit(editor, args) {
+  const r = applyEditToText(editor.doc.getValue(), args);
+  if (r.error) return { __error: r.error };
+  editor.doc.setValue(r.text);
+  return `applied ${r.count} edit(s)`;
 }
 
-// Grep the in-browser doc so the agent can locate anchors in a big document
-// without pulling the whole thing into context.
-function grepDoc(editor, { pattern, context = 0 }) {
-  let re;
-  try { re = new RegExp(pattern, 'i'); } catch (e) { return { __error: `bad regex: ${e.message}` }; }
-  const lines = editor.doc.getValue().split('\n');
-  const out = [];
-  for (let i = 0; i < lines.length && out.length < 120; i++) {
-    if (re.test(lines[i])) {
-      for (let j = Math.max(0, i - context); j <= Math.min(lines.length - 1, i + context); j++) {
-        out.push(`${j + 1}: ${lines[j].slice(0, 200)}`);
-      }
-    }
-  }
-  return out.length ? out.join('\n') : '(no matches)';
+function grepDoc(editor, args) {
+  const r = grepText(editor.doc.getValue(), args);
+  if (r && r.error) return { __error: r.error };
+  return r;
 }
 
 // ---- the tool registry: tool name -> async fn acting on the app -------------
@@ -107,17 +91,7 @@ const registry = {
       await writefileandstage(FAUST_DIR + stem + '.ts', ts);
       // refresh the app's Faust file dropdown so the user sees the new instrument
       if (typeof window.refreshFaustFileList === 'function') { try { await window.refreshFaustFileList(); } catch { /* non-fatal */ } }
-      const classes = [...ts.matchAll(/export class (\w+)/g)].map((m) => m[1]);
-      const voice = classes.find((c) => !/Channel$/.test(c)) || 'Xxx';
-      const chan = classes.find((c) => /Channel$/.test(c));
-      // Only import the classes that actually exist; register with the generated
-      // channel class if there is one, otherwise the base MidiChannel.
-      const reg = chan
-        ? `midichannels[N] = new ${chan}(8, (channel: MidiChannel) => new ${voice}(channel));`
-        : `midichannels[N] = new MidiChannel(8, (channel: MidiChannel) => new ${voice}(channel));   // no ${voice}Channel was generated — use the base MidiChannel`;
-      return `transpiled OK → faust/${stem}.ts exports: ${classes.join(', ') || '(none)'}. ` +
-        `In synth.ts: import { ${classes.join(', ')} } from '../faust/${stem}';  (import ONLY these exact names) ` +
-        `then ${reg}`;
+      return faustRegistrationHint(ts, stem).message;
     } catch (e) { return faustUnavailable(e); }
   },
   compile: async () => {
@@ -133,12 +107,7 @@ const registry = {
   stop: async () => { window.stopaudio(); return 'stopped'; },
 };
 
-// Faust file helpers
-function normDsp(path) {
-  let rel = String(path || '').replace(/^faust\//, '');
-  if (!rel.endsWith('.dsp')) rel += '.dsp';
-  return rel;
-}
+// Faust file helpers (normDsp is imported from studio-agent-tools-core.js)
 function faustUnavailable(e) {
   const msg = String(e?.message || e);
   return { __error: `Faust/OPFS not available (${msg}). The app must be opened with a ?gitrepo=… URL so the OPFS git working tree exists.` };

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -1,0 +1,245 @@
+// In-app client for the local studio-agent (tools/studio-agent).
+//
+// Connects to the local agent over WebSocket. The agent streams chat text and
+// issues tool_call messages; we execute each tool against the running app (the
+// editors, the compiler, the audio worklet) and send the result back. This is
+// the "full in-app" path: tool calls operate on the browser, not on disk.
+
+import { songsourceeditor, synthsourceeditor } from './editorcontroller.js';
+import { transpileDspSource } from './faust/browser-transpile.js';
+import { readfile, writefileandstage, listfiles } from './wasmgit/wasmgitclient.js';
+
+const DEFAULT_PORT = 17891;
+const FAUST_DIR = 'faust/';
+const RECONNECT_MS = 3000;
+
+let shadow = null;
+let socket = null;
+let sessionId = null;
+let agentMsgEl = null; // the in-progress assistant message element
+
+// Surgical find-and-replace on an editor doc — mirrors the Edit tool's semantics
+// so the agent can change a large document (e.g. the 14k-line DX7 bundle) without
+// rewriting the whole thing.
+function applyEdit(editor, { old_string, new_string, replace_all }) {
+  const cur = editor.doc.getValue();
+  if (old_string === new_string) return { __error: 'old_string and new_string are identical' };
+  const count = old_string ? cur.split(old_string).length - 1 : 0;
+  if (count === 0) return { __error: 'old_string not found in the document' };
+  if (count > 1 && !replace_all) return { __error: `old_string is not unique (${count} matches); add more surrounding context or set replace_all` };
+  const next = replace_all ? cur.split(old_string).join(new_string) : cur.replace(old_string, new_string);
+  editor.doc.setValue(next);
+  return `applied ${replace_all ? count : 1} edit(s)`;
+}
+
+// Grep the in-browser doc so the agent can locate anchors in a big document
+// without pulling the whole thing into context.
+function grepDoc(editor, { pattern, context = 0 }) {
+  let re;
+  try { re = new RegExp(pattern, 'i'); } catch (e) { return { __error: `bad regex: ${e.message}` }; }
+  const lines = editor.doc.getValue().split('\n');
+  const out = [];
+  for (let i = 0; i < lines.length && out.length < 120; i++) {
+    if (re.test(lines[i])) {
+      for (let j = Math.max(0, i - context); j <= Math.min(lines.length - 1, i + context); j++) {
+        out.push(`${j + 1}: ${lines[j].slice(0, 200)}`);
+      }
+    }
+  }
+  return out.length ? out.join('\n') : '(no matches)';
+}
+
+// ---- the tool registry: tool name -> async fn acting on the app -------------
+// Returning an object with `__error` marks a failed tool result.
+const registry = {
+  get_song: async () => songsourceeditor.doc.getValue(),
+  set_song: async ({ source }) => { songsourceeditor.doc.setValue(source); return 'song updated'; },
+  get_synth: async () => synthsourceeditor.doc.getValue(),
+  set_synth: async ({ source }) => { synthsourceeditor.doc.setValue(source); return 'synth updated'; },
+  edit_synth: async (args) => applyEdit(synthsourceeditor, args),
+  edit_song: async (args) => applyEdit(songsourceeditor, args),
+  grep_synth: async (args) => grepDoc(synthsourceeditor, args),
+  grep_song: async (args) => grepDoc(songsourceeditor, args),
+
+  // ---- Faust instrument authoring (OPFS faust/ folder; needs ?gitrepo= mode) ----
+  list_faust: async () => {
+    try {
+      const all = await listfiles(FAUST_DIR);
+      const dsp = all.filter((f) => f.endsWith('.dsp')).map((f) => f.slice(FAUST_DIR.length));
+      return dsp.length ? dsp.join('\n') : '(no .dsp instruments yet)';
+    } catch (e) { return faustUnavailable(e); }
+  },
+  read_faust: async ({ path }) => {
+    try { return await readfile(FAUST_DIR + normDsp(path)); }
+    catch (e) { return faustUnavailable(e); }
+  },
+  // Write a .dsp AND transpile it to AssemblyScript (same as the app's faust save):
+  // persists faust/<name>.dsp + faust/<name>.ts and reports the generated classes.
+  write_faust: async ({ path, source }) => {
+    const rel = normDsp(path);
+    const stem = rel.replace(/\.dsp$/, '');
+    try {
+      await writefileandstage(FAUST_DIR + rel, source);
+      let ts;
+      try {
+        ({ ts } = await transpileDspSource(source, rel, {}));
+      } catch (e) {
+        return { __error: `Faust transpile failed for ${rel}: ${e?.message || e}` };
+      }
+      await writefileandstage(FAUST_DIR + stem + '.ts', ts);
+      // refresh the app's Faust file dropdown so the user sees the new instrument
+      if (typeof window.refreshFaustFileList === 'function') { try { await window.refreshFaustFileList(); } catch { /* non-fatal */ } }
+      const classes = [...ts.matchAll(/export class (\w+)/g)].map((m) => m[1]);
+      return `transpiled OK → faust/${stem}.ts exports: ${classes.join(', ') || '(none)'}. ` +
+        `In synth.ts: import { ${classes.join(', ')} } from '../faust/${stem}'; ` +
+        `then register e.g. midichannels[N] = new ${classes.find((c) => /Channel$/.test(c)) || 'XxxChannel'}(8, (ch) => new ${classes.find((c) => !/Channel$/.test(c)) || 'Xxx'}(ch));`;
+    } catch (e) { return faustUnavailable(e); }
+  },
+  compile: async () => {
+    try {
+      await window.compileSong();
+    } catch (e) {
+      return { __error: String(e?.message || e) };
+    }
+    const err = readErrorPanel();
+    return err ? { __error: err } : 'compiled OK';
+  },
+  play: async () => { await window.startaudio(); return 'playing'; },
+  stop: async () => { window.stopaudio(); return 'stopped'; },
+};
+
+// Faust file helpers
+function normDsp(path) {
+  let rel = String(path || '').replace(/^faust\//, '');
+  if (!rel.endsWith('.dsp')) rel += '.dsp';
+  return rel;
+}
+function faustUnavailable(e) {
+  const msg = String(e?.message || e);
+  return { __error: `Faust/OPFS not available (${msg}). The app must be opened with a ?gitrepo=… URL so the OPFS git working tree exists.` };
+}
+
+function readErrorPanel() {
+  const el = shadow && shadow.getElementById('errormessages');
+  if (!el || el.style.display === 'none') return '';
+  const span = el.querySelector('span');
+  return span ? span.innerText.trim() : '';
+}
+
+// ---- WebSocket lifecycle ----------------------------------------------------
+function connect() {
+  const port = window.STUDIO_AGENT_PORT || DEFAULT_PORT;
+  setStatus(`connecting to ws://localhost:${port}…`);
+  socket = new WebSocket(`ws://localhost:${port}`);
+
+  socket.onopen = () => setStatus('connected');
+  socket.onclose = () => { setStatus('disconnected — retrying…'); setTimeout(connect, RECONNECT_MS); };
+  socket.onerror = () => setStatus('connection error (is studio-agent running?)');
+  socket.onmessage = (ev) => onMessage(JSON.parse(ev.data));
+}
+
+async function onMessage(msg) {
+  switch (msg.t) {
+    case 'session':
+      sessionId = msg.sessionId;
+      break;
+    case 'text':
+      appendAgentText(msg.text);
+      break;
+    case 'tool': // assistant decided to use a tool (informational)
+      addLine('tool', `⚙ ${shortName(msg.name)}`);
+      break;
+    case 'tool_call': // request to EXECUTE a tool in the browser
+      await runTool(msg);
+      break;
+    case 'done':
+      finishAgentMessage();
+      setBusy(false);
+      break;
+    case 'error':
+      addLine('error', `⚠ ${msg.error}`);
+      finishAgentMessage();
+      setBusy(false);
+      break;
+  }
+}
+
+async function runTool({ id, name, args }) {
+  const fn = registry[name];
+  if (!fn) return reply(id, false, `unknown tool ${name}`);
+  try {
+    const result = await fn(args || {});
+    if (result && result.__error) reply(id, false, result.__error);
+    else reply(id, true, result);
+  } catch (e) {
+    reply(id, false, String(e?.message || e));
+  }
+}
+
+function reply(id, ok, result) {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ t: 'tool_result', id, ok, result }));
+  }
+}
+
+function sendChat(text) {
+  if (!socket || socket.readyState !== WebSocket.OPEN) { setStatus('not connected'); return; }
+  addLine('user', text);
+  startAgentMessage();
+  setBusy(true);
+  socket.send(JSON.stringify({ t: 'chat', text, sessionId }));
+}
+
+// ---- tiny UI helpers --------------------------------------------------------
+const shortName = (n) => (n || '').replace(/^mcp__studio__/, '');
+
+function el(id) { return shadow.getElementById(id); }
+function setStatus(s) { const e = el('studioagentstatus'); if (e) e.textContent = `agent: ${s}`; }
+function setBusy(b) {
+  const send = el('studioagentsend');
+  if (send) { send.disabled = b; send.textContent = b ? '…' : 'Send'; }
+}
+
+function addLine(kind, text) {
+  const log = el('studioagentlog');
+  const line = document.createElement('div');
+  line.className = `sa-msg-${kind}`;
+  line.textContent = text;
+  log.appendChild(line);
+  log.scrollTop = log.scrollHeight;
+  return line;
+}
+function startAgentMessage() { agentMsgEl = addLine('agent', ''); }
+function appendAgentText(t) {
+  if (!agentMsgEl) startAgentMessage();
+  agentMsgEl.textContent += t;
+  const log = el('studioagentlog');
+  log.scrollTop = log.scrollHeight;
+}
+function finishAgentMessage() { agentMsgEl = null; }
+
+// ---- public init (called from app.js once the editors exist) ----------------
+export function initStudioAgent(shadowRoot) {
+  shadow = shadowRoot;
+  const panel = el('studioagentpanel');
+  const form = el('studioagentform');
+  const input = el('studioagentinput');
+
+  window.toggleStudioAgent = (checked) => {
+    panel.style.display = checked ? 'flex' : 'none';
+    if (checked) input.focus();
+  };
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = '';
+    sendChat(text);
+  });
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); form.requestSubmit(); }
+  });
+
+  connect();
+}

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -7,7 +7,7 @@
 
 import { songsourceeditor, synthsourceeditor } from './editorcontroller.js';
 import { transpileDspSource } from './faust/browser-transpile.js';
-import { readfile, writefileandstage, listfiles } from './wasmgit/wasmgitclient.js';
+import { readfile, writefileandstage, listfiles, gitCommand, gitLog } from './wasmgit/wasmgitclient.js';
 
 const DEFAULT_PORT = 17891;
 const FAUST_DIR = 'faust/';
@@ -72,6 +72,23 @@ const registry = {
   read_faust: async ({ path }) => {
     try { return await readfile(FAUST_DIR + normDsp(path)); }
     catch (e) { return faustUnavailable(e); }
+  },
+
+  // ---- git history (OPFS repo) — inspect commits / restore a committed file ----
+  git_log: async () => {
+    try { return (await gitLog()) || '(no commits yet)'; }
+    catch (e) { return faustUnavailable(e); }
+  },
+  // Read a file's committed content at a git ref (default HEAD). Use to restore
+  // something that was overwritten in the editor but is safe in a commit.
+  read_committed: async ({ path, ref = 'HEAD' }) => {
+    const spec = `${ref}:${path}`;
+    try {
+      try { return await gitCommand('show', [spec]); }
+      catch { return await gitCommand('cat-file', ['-p', spec]); }
+    } catch (e) {
+      return { __error: `couldn't read ${spec} from git: ${String(e?.error || e?.message || e)}` };
+    }
   },
   // Write a .dsp AND transpile it to AssemblyScript (same as the app's faust save):
   // persists faust/<name>.dsp + faust/<name>.ts and reports the generated classes.

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -108,9 +108,16 @@ const registry = {
       // refresh the app's Faust file dropdown so the user sees the new instrument
       if (typeof window.refreshFaustFileList === 'function') { try { await window.refreshFaustFileList(); } catch { /* non-fatal */ } }
       const classes = [...ts.matchAll(/export class (\w+)/g)].map((m) => m[1]);
+      const voice = classes.find((c) => !/Channel$/.test(c)) || 'Xxx';
+      const chan = classes.find((c) => /Channel$/.test(c));
+      // Only import the classes that actually exist; register with the generated
+      // channel class if there is one, otherwise the base MidiChannel.
+      const reg = chan
+        ? `midichannels[N] = new ${chan}(8, (channel: MidiChannel) => new ${voice}(channel));`
+        : `midichannels[N] = new MidiChannel(8, (channel: MidiChannel) => new ${voice}(channel));   // no ${voice}Channel was generated — use the base MidiChannel`;
       return `transpiled OK → faust/${stem}.ts exports: ${classes.join(', ') || '(none)'}. ` +
-        `In synth.ts: import { ${classes.join(', ')} } from '../faust/${stem}'; ` +
-        `then register e.g. midichannels[N] = new ${classes.find((c) => /Channel$/.test(c)) || 'XxxChannel'}(8, (ch) => new ${classes.find((c) => !/Channel$/.test(c)) || 'Xxx'}(ch));`;
+        `In synth.ts: import { ${classes.join(', ')} } from '../faust/${stem}';  (import ONLY these exact names) ` +
+        `then ${reg}`;
     } catch (e) { return faustUnavailable(e); }
   },
   compile: async () => {

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -17,6 +17,7 @@ let shadow = null;
 let socket = null;
 let sessionId = null;
 let agentMsgEl = null; // the in-progress assistant message element
+let toolQueue = Promise.resolve(); // serialize tool execution (see tool_call below)
 
 // Surgical find-and-replace on an editor doc — mirrors the Edit tool's semantics
 // so the agent can change a large document (e.g. the 14k-line DX7 bundle) without
@@ -167,7 +168,10 @@ async function onMessage(msg) {
       addLine('tool', `⚙ ${shortName(msg.name)}`);
       break;
     case 'tool_call': // request to EXECUTE a tool in the browser
-      await runTool(msg);
+      // Run STRICTLY one at a time: the agent can fire several tool calls at once,
+      // and concurrent heavy ops (faust transpile / wasm-git worker / compile) share
+      // single-instance resources and stall if overlapped. Queue keeps arrival order.
+      toolQueue = toolQueue.then(() => runTool(msg));
       break;
     case 'done':
       finishAgentMessage();

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -153,6 +153,7 @@ function connect() {
   socket.onopen = () => setStatus('connected');
   socket.onclose = () => {
     if (activityTimer) { clearInterval(activityTimer); activityTimer = null; setBusy(false); }
+    const s = el('studioagentstatus'); if (s) s.classList.remove('working');
     setStatus('disconnected — retrying…');
     setTimeout(connect, RECONNECT_MS);
   };
@@ -264,6 +265,8 @@ let spinIdx = 0;
 function startActivity() {
   turnStartMs = Date.now();
   activityPhase = 'thinking…';
+  const s = el('studioagentstatus');
+  if (s) { s.classList.add('working'); s.classList.remove('idle'); }
   if (activityTimer) clearInterval(activityTimer);
   activityTimer = setInterval(renderActivity, 150);
   renderActivity();
@@ -276,6 +279,8 @@ function renderActivity() {
 }
 function stopActivity(msg) {
   if (activityTimer) { clearInterval(activityTimer); activityTimer = null; }
+  const s = el('studioagentstatus');
+  if (s) { s.classList.remove('working'); s.classList.add('idle'); }
   const secs = Math.floor((Date.now() - turnStartMs) / 1000);
   setStatus(`${msg} — ${secs}s`);
 }

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -151,7 +151,11 @@ function connect() {
   socket = new WebSocket(`ws://localhost:${port}`);
 
   socket.onopen = () => setStatus('connected');
-  socket.onclose = () => { setStatus('disconnected — retrying…'); setTimeout(connect, RECONNECT_MS); };
+  socket.onclose = () => {
+    if (activityTimer) { clearInterval(activityTimer); activityTimer = null; setBusy(false); }
+    setStatus('disconnected — retrying…');
+    setTimeout(connect, RECONNECT_MS);
+  };
   socket.onerror = () => setStatus('connection error (is studio-agent running?)');
   socket.onmessage = (ev) => onMessage(JSON.parse(ev.data));
 }
@@ -160,12 +164,15 @@ async function onMessage(msg) {
   switch (msg.t) {
     case 'session':
       sessionId = msg.sessionId;
+      setPhase('thinking…');
       break;
     case 'text':
       appendAgentText(msg.text);
+      setPhase('responding…');
       break;
     case 'tool': // assistant decided to use a tool (informational)
       addLine('tool', `⚙ ${shortName(msg.name)}`);
+      setPhase(`running ${shortName(msg.name)}…`);
       break;
     case 'tool_call': // request to EXECUTE a tool in the browser
       // Run STRICTLY one at a time: the agent can fire several tool calls at once,
@@ -175,11 +182,13 @@ async function onMessage(msg) {
       break;
     case 'done':
       finishAgentMessage();
+      stopActivity('done ✓');
       setBusy(false);
       break;
     case 'error':
       addLine('error', `⚠ ${msg.error}`);
       finishAgentMessage();
+      stopActivity('error ✗');
       setBusy(false);
       break;
   }
@@ -190,10 +199,16 @@ async function runTool({ id, name, args }) {
   if (!fn) return reply(id, false, `unknown tool ${name}`);
   try {
     const result = await fn(args || {});
-    if (result && result.__error) reply(id, false, result.__error);
-    else reply(id, true, result);
+    if (result && result.__error) {
+      addLine('error', `✗ ${shortName(name)}: ${result.__error}`);
+      reply(id, false, result.__error);
+    } else {
+      reply(id, true, result);
+    }
   } catch (e) {
-    reply(id, false, String(e?.message || e));
+    const emsg = String(e?.message || e);
+    addLine('error', `✗ ${shortName(name)}: ${emsg}`);
+    reply(id, false, emsg);
   }
 }
 
@@ -208,6 +223,7 @@ function sendChat(text) {
   addLine('user', text);
   startAgentMessage();
   setBusy(true);
+  startActivity();
   socket.send(JSON.stringify({ t: 'chat', text, sessionId }));
 }
 
@@ -238,6 +254,31 @@ function appendAgentText(t) {
   log.scrollTop = log.scrollHeight;
 }
 function finishAgentMessage() { agentMsgEl = null; }
+
+// ---- activity indicator: shows the agent is alive, what it's doing, elapsed time ----
+const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+let activityTimer = null;
+let turnStartMs = 0;
+let activityPhase = '';
+let spinIdx = 0;
+function startActivity() {
+  turnStartMs = Date.now();
+  activityPhase = 'thinking…';
+  if (activityTimer) clearInterval(activityTimer);
+  activityTimer = setInterval(renderActivity, 150);
+  renderActivity();
+}
+function setPhase(p) { activityPhase = p; if (activityTimer) renderActivity(); }
+function renderActivity() {
+  spinIdx = (spinIdx + 1) % SPIN.length;
+  const secs = Math.floor((Date.now() - turnStartMs) / 1000);
+  setStatus(`${SPIN[spinIdx]} ${activityPhase}  ${secs}s`);
+}
+function stopActivity(msg) {
+  if (activityTimer) { clearInterval(activityTimer); activityTimer = null; }
+  const secs = Math.floor((Date.now() - turnStartMs) / 1000);
+  setStatus(`${msg} — ${secs}s`);
+}
 
 // ---- public init (called from app.js once the editors exist) ----------------
 export function initStudioAgent(shadowRoot) {

--- a/wasmaudioworklet/studio-agent-tools-core.js
+++ b/wasmaudioworklet/studio-agent-tools-core.js
@@ -1,0 +1,55 @@
+// Pure, browser-free logic behind the studio-agent tools, split out so it can be
+// unit-tested in Node. The browser client (studio-agent-client.js) wraps these
+// for CodeMirror editors / OPFS.
+
+// Surgical find-and-replace (mirrors the Edit tool). Returns { text, count } on
+// success or { error } on failure.
+export function applyEditToText(cur, { old_string, new_string, replace_all }) {
+  if (old_string === new_string) return { error: 'old_string and new_string are identical' };
+  const count = old_string ? cur.split(old_string).length - 1 : 0;
+  if (count === 0) return { error: 'old_string not found in the document' };
+  if (count > 1 && !replace_all) return { error: `old_string is not unique (${count} matches); add more surrounding context or set replace_all` };
+  const text = replace_all ? cur.split(old_string).join(new_string) : cur.replace(old_string, new_string);
+  return { text, count: replace_all ? count : 1 };
+}
+
+// Regex-grep over text. Returns "line: content" lines (with optional context),
+// capped at 120 output lines, or { error } on a bad pattern.
+export function grepText(text, { pattern, context = 0 }) {
+  let re;
+  try { re = new RegExp(pattern, 'i'); } catch (e) { return { error: `bad regex: ${e.message}` }; }
+  const lines = text.split('\n');
+  const out = [];
+  for (let i = 0; i < lines.length && out.length < 120; i++) {
+    if (re.test(lines[i])) {
+      for (let j = Math.max(0, i - context); j <= Math.min(lines.length - 1, i + context); j++) {
+        out.push(`${j + 1}: ${lines[j].slice(0, 200)}`);
+      }
+    }
+  }
+  return out.length ? out.join('\n') : '(no matches)';
+}
+
+// Normalize a faust path to a repo-relative .dsp filename.
+export function normDsp(path) {
+  let rel = String(path || '').replace(/^faust\//, '');
+  if (!rel.endsWith('.dsp')) rel += '.dsp';
+  return rel;
+}
+
+// Build the write_faust success hint from a transpiled .ts: which classes to
+// import and how to register the channel. Uses the base MidiChannel when no
+// <Name>Channel was generated (fixes the recurring "no exported member" error).
+export function faustRegistrationHint(ts, stem) {
+  const classes = [...ts.matchAll(/export class (\w+)/g)].map((m) => m[1]);
+  const voice = classes.find((c) => !/Channel$/.test(c)) || 'Xxx';
+  const chan = classes.find((c) => /Channel$/.test(c));
+  const reg = chan
+    ? `midichannels[N] = new ${chan}(8, (channel: MidiChannel) => new ${voice}(channel));`
+    : `midichannels[N] = new MidiChannel(8, (channel: MidiChannel) => new ${voice}(channel));   // no ${voice}Channel was generated — use the base MidiChannel`;
+  const message =
+    `transpiled OK → faust/${stem}.ts exports: ${classes.join(', ') || '(none)'}. ` +
+    `In synth.ts: import { ${classes.join(', ')} } from '../faust/${stem}';  (import ONLY these exact names) ` +
+    `then ${reg}`;
+  return { classes, voice, chan, message };
+}

--- a/wasmaudioworklet/studio-agent-tools-core.test.mjs
+++ b/wasmaudioworklet/studio-agent-tools-core.test.mjs
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyEditToText, grepText, normDsp, faustRegistrationHint } from './studio-agent-tools-core.js';
+
+test('applyEditToText: unique replace', () => {
+  assert.deepEqual(applyEditToText('a b c', { old_string: 'b', new_string: 'X' }), { text: 'a X c', count: 1 });
+});
+test('applyEditToText: not found → error', () => {
+  assert.match(applyEditToText('abc', { old_string: 'z', new_string: 'y' }).error, /not found/);
+});
+test('applyEditToText: non-unique without replace_all → error', () => {
+  assert.match(applyEditToText('x x x', { old_string: 'x', new_string: 'y' }).error, /not unique \(3/);
+});
+test('applyEditToText: replace_all replaces every occurrence', () => {
+  assert.deepEqual(applyEditToText('x x x', { old_string: 'x', new_string: 'y', replace_all: true }), { text: 'y y y', count: 3 });
+});
+test('applyEditToText: identical old/new → error', () => {
+  assert.match(applyEditToText('a', { old_string: 'a', new_string: 'a' }).error, /identical/);
+});
+
+test('grepText: reports 1-indexed line numbers', () => {
+  assert.equal(grepText('foo\nbar\nbaz', { pattern: 'ba' }), '2: bar\n3: baz');
+});
+test('grepText: includes context lines', () => {
+  assert.equal(grepText('a\nHIT\nc', { pattern: 'HIT', context: 1 }), '1: a\n2: HIT\n3: c');
+});
+test('grepText: no matches', () => {
+  assert.equal(grepText('a\nb', { pattern: 'zzz' }), '(no matches)');
+});
+test('grepText: invalid regex → error', () => {
+  assert.match(grepText('a', { pattern: '(' }).error, /bad regex/);
+});
+
+test('normDsp: adds .dsp and strips faust/ prefix', () => {
+  assert.equal(normDsp('bass'), 'bass.dsp');
+  assert.equal(normDsp('faust/lead.dsp'), 'lead.dsp');
+});
+
+test('faustRegistrationHint: instrument WITH a channel class uses it', () => {
+  const ts = 'export class Pad extends MidiVoice {}\nexport class PadChannel extends MidiChannel {}';
+  const h = faustRegistrationHint(ts, 'pad');
+  assert.deepEqual(h.classes, ['Pad', 'PadChannel']);
+  assert.match(h.message, /new PadChannel\(8/);
+});
+test('faustRegistrationHint: instrument WITHOUT a channel class uses base MidiChannel (regression for TS2305)', () => {
+  const ts = 'export class Bass extends MidiVoice {}';
+  const h = faustRegistrationHint(ts, 'bass');
+  assert.deepEqual(h.classes, ['Bass']);
+  assert.match(h.message, /new MidiChannel\(8, \(channel: MidiChannel\) => new Bass/);
+  assert.doesNotMatch(h.message, /new BassChannel/);          // must NOT instantiate a phantom channel class
+  assert.doesNotMatch(h.message, /import \{ Bass, BassChannel \}/); // must NOT import one either
+});

--- a/wasmaudioworklet/style.css
+++ b/wasmaudioworklet/style.css
@@ -136,6 +136,23 @@ input::placeholder {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+/* WORKING state — bright, bold, pulsing so it's obvious the agent is busy */
+.sa-status.working {
+    color: #072;
+    background-color: #ffd23f;
+    font-weight: bold;
+    font-size: 13px;
+    padding: 6px 10px;
+    animation: sa-pulse 1.1s ease-in-out infinite;
+}
+@keyframes sa-pulse {
+    0%, 100% { background-color: #ffd23f; }
+    50%      { background-color: #ffb300; }
+}
+/* IDLE/done state — calm confirmation */
+.sa-status.idle {
+    color: #6c6;
+}
 .sa-log {
     flex: 1;
     overflow-y: auto;

--- a/wasmaudioworklet/style.css
+++ b/wasmaudioworklet/style.css
@@ -112,3 +112,52 @@ input::placeholder {
     left: 0px;
     display: none;
 }
+
+#studioagentpanel {
+    position: fixed;
+    top: 70px;
+    bottom: 20px;
+    right: 0px;
+    width: 400px;
+    max-width: 90vw;
+    background-color: #0b140b;
+    border-left: 3px solid #4a4;
+    display: flex;
+    flex-direction: column;
+    z-index: 50;
+    color: #cfc;
+}
+.sa-status {
+    padding: 4px 10px;
+    font-size: 12px;
+    color: #8c8;
+    border-bottom: 1px solid #2a2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.sa-log {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px;
+    font-size: 13px;
+    line-height: 1.4;
+}
+.sa-log > div { white-space: pre-wrap; word-break: break-word; margin-bottom: 8px; }
+.sa-msg-user { color: #9ecbff; }
+.sa-msg-agent { color: #dfe; }
+.sa-msg-tool { color: #7a7; font-style: italic; margin-bottom: 2px; }
+.sa-msg-error { color: #f88; }
+.sa-form { display: flex; gap: 4px; padding: 6px; border-top: 1px solid #2a2; }
+.sa-form textarea {
+    flex: 1;
+    resize: none;
+    background-color: #000;
+    color: #cfc;
+    border: 1px solid #2a2;
+    border-radius: 6px;
+    font-family: monospace;
+    font-size: 13px;
+    padding: 6px;
+}
+#studioagentsend { min-width: 56px; }

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -46,6 +46,24 @@ async function callAndWaitForWorker(message) {
     });
 }
 
+// Generic git command passthrough — returns the captured stdout. Used by the
+// studio agent to inspect history and restore committed files from OPFS.
+export async function gitCommand(command, args = []) {
+    const res = await callAndWaitForWorker({ command, args });
+    return res.result;
+}
+
+// `git log` uses a dedicated worker branch that replies with { log } (no id).
+export async function gitLog() {
+    return await new Promise((resolve) => {
+        workerMessageListeners.push((msg) => {
+            if (msg.data.log !== undefined) { resolve(msg.data.log); return; }
+            return true;
+        });
+        worker.postMessage({ command: 'log' });
+    });
+}
+
 export async function initWASMGitClient(gitrepo, remoteUrl) {
     worker = new Worker(new URL('wasmgitworker.js', import.meta.url));
     worker.onmessage = (msg) => {


### PR DESCRIPTION
An **in-app AI assistant** for the WebAssembly Music app. A chat panel in the browser talks over WebSocket to a small local process running the **Claude Agent SDK**, authenticated with a **Max/Pro subscription** (no API key, no per-token billing). The agent's tool calls execute **inside the browser** — on the editors, the wasm compiler, and the audio worklet — so nothing syncs to disk. Distinct from `claude-bridge`, which stays the local-Claude file-mirror tool.

## Components
**Local process — `tools/studio-agent/`**
- `server.mjs` — WS server + Agent SDK loop + in-process MCP tools; serial tool execution; per-boot JSONL session logs under `logs/` (gitignored).
- `prompt.mjs` — system prompt (sequence DSL, Faust-first authoring, DX7 patch model, scope discipline, recorded-take editing, surgical large-synth edits).

**In-app — `wasmaudioworklet/`**
- `studio-agent-client.js` — WS client + tool registry + chat UI + live activity indicator.
- `studio-agent-tools-core.js` — browser-free pure logic (edit/grep/path/faust-hint), unit-tested.
- `app.html.js` / `app.js` / `style.css` — chat panel, boot, styles.
- `editorcontroller.js` — expose `window.refreshFaustFileList` for `write_faust`.

## Tools the agent drives (in the browser)
- `get/set/edit/grep_{song,synth}` — read / replace / surgical-edit / regex-search the editors (edit+grep let it change the 14k-line DX7 bundle without a rewrite).
- `write/read/list_faust` — **author instruments in Faust** (`.dsp` → transpile → wire generated classes into `synth.ts`).
- `load_{song,synth}_from_file` — load large repo files without shuttling them through model context.
- `git_log` / `read_committed` — inspect OPFS git history / restore a committed file.
- `compile` / `play` / `stop`.

## Design principles (arrived at iteratively)
- **Faust-first instruments**; `synth.ts` is only the multitimbral combiner (no hand-written AS DSP).
- **DX7 patches live in the song** (NRPN), not the synth — avoids the "only a sine wave" trap. `examples/dx7/dx7-drumbeat.js` is a ready template.
- **Scope discipline**: do only what's asked — never overwrite the song/synth unless explicitly requested.
- **Never shuttle large files through context** (`load_*_from_file`, `write_faust`).

## UX / robustness
- Live status readout: bright pulsing "working" state with phase + elapsed seconds; calm "done ✓" when idle.
- `STUDIO_AGENT_MODEL` env var for the speed/depth tradeoff.
- Tool calls serialized so concurrent heavy ops (faust transpile / wasm-git / compile) can't contend.

## Tests
- `wasmaudioworklet/studio-agent-tools-core.test.mjs` — 12 `node:test` unit tests for the pure edit/grep/path/faust-hint logic (`npm run test-agent-tools`), incl. a regression for the channel-class wiring bug.
- The SDK-driven end-to-end path was validated during development with a headless fake-browser harness and live browser sessions; deterministic coverage of that layer (mocked SDK) is a follow-up.

## Notes / follow-ups
- Faust authoring needs the app opened with `?gitrepo=…` (OPFS). Local-only persistence landed separately (#151).
- Next: store agent sessions in the OPFS repo + per-repo agent instructions; deterministic tests for the server/WS layer; smoother global-effect (`postprocess`) authoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)