### PR TITLE
Local-only OPFS repos: persist edits when a repo can't be cloned (#151)

### DIFF
--- a/wasmaudioworklet/docs/git-hosting.md
+++ b/wasmaudioworklet/docs/git-hosting.md
@@ -18,6 +18,38 @@ project; the code in this folder (`wasmgit/`) is the browser client.
 > `petersalomonsen.com/webassemblymusic/...` does **not**, so `?gitrepo=` will
 > silently fail to load there.
 
+## Local-only repos (no NEAR registration)
+
+You can also open `?gitrepo=<name>` with a name that is **not** a registered
+NEAR repo (e.g. `?gitrepo=mysketch`). When the clone fails because there is
+nothing to clone, the app falls back to a **persistent local git repo in OPFS**:
+`git init`, no remote round-trip. Edits — including the `faust/` folder — are
+committed/saved into that OPFS repo and **survive reload**. "Commit & Sync"
+still commits locally; the push half just fails until a reachable remote exists.
+
+This is the registration-free path for scratch projects and
+Studio-Agent-authored instruments. To attach a remote and push later, set one
+with the `remote=` param below.
+
+### Point a local repo at any remote — `&remote=<url>`
+
+Add `&remote=<url>` to override the git `origin` for pushing, e.g. a local git
+server:
+
+```
+http://localhost:8080/?gitrepo=mysketch&remote=http://localhost:9418/mysketch.git
+```
+
+The URL is written into `.git/config` (which lives in OPFS), so it **persists
+across reloads** — you only need the param once. `origin` still defaults to the
+NEAR url for `<name>` when `remote=` is omitted.
+
+> **Non-NEAR remotes need CORS + git-over-HTTP.** Only `/near-repo/*` requests
+> go through the NEAR service worker; any other remote is a normal browser
+> `fetch`, so the target server must speak the git smart-HTTP protocol and send
+> permissive CORS headers. Persisting locally and *configuring* the remote work
+> regardless; whether a given server accepts the push depends on that server.
+
 ## How it works
 
 - `?gitrepo=<name>.gitfactory.testnet` is resolved to `<origin>/near-repo/<name>.git`

--- a/wasmaudioworklet/e2e/local-repo-persistence.spec.js
+++ b/wasmaudioworklet/e2e/local-repo-persistence.spec.js
@@ -1,0 +1,167 @@
+import { test, expect } from '@playwright/test';
+import { setupServiceWorker, waitForAppReady, clearOPFS } from './near-git-helpers.js';
+
+// Regression for issue #151: opening `?gitrepo=<name>` for a repo that can't be
+// cloned (unregistered/unreachable remote) must fall back to a PERSISTENT local
+// OPFS repo, so edits survive reload instead of being lost to in-memory WASMFS.
+//
+// No NEAR sandbox needed: the service worker only intercepts /near-repo/*, and
+// we don't register it here, so a /near-repo/<name> URL simply 404s on the
+// static server — a clean stand-in for "remote can't be cloned".
+
+const REPO = 'local-persistence-test.git';
+const REPO_URL = `http://localhost:8080/near-repo/${REPO}`;
+const FAUST_FILE = 'faust/mysynth.dsp';
+const FAUST_CONTENT = 'import("stdfaust.lib");\nprocess = os.osc(440);\n';
+
+// Minimal worker driver mirroring the shared e2e helpers.
+async function driveWorker(page, steps) {
+    return await page.evaluate(async ({ repoUrl, steps }) => {
+        const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
+        const pending = [];
+        let resolveNext;
+        worker.onmessage = (msg) => {
+            if (resolveNext) { const r = resolveNext; resolveNext = null; r(msg.data); }
+            else pending.push(msg.data);
+        };
+        const nextRaw = () => pending.length ? Promise.resolve(pending.shift()) : new Promise(r => (resolveNext = r));
+        const next = (ms = 15000) => Promise.race([nextRaw(), new Promise(res => setTimeout(() => res({ __timeout: true }), ms))]);
+
+        const out = {};
+        let id = 1;
+        try {
+            for (const step of steps) {
+                if (step.cmd === 'synclocal') {
+                    worker.postMessage({ command: 'synclocal', url: repoUrl });
+                    out.synclocal = await next(8000);
+                } else if (step.cmd === 'clone') {
+                    worker.postMessage({ command: 'clone', url: repoUrl });
+                    out.clone = await next();
+                } else if (step.cmd === 'initlocal') {
+                    worker.postMessage({ command: 'initlocal', url: repoUrl, remoteUrl: step.remoteUrl });
+                    out.initlocal = await next();
+                } else if (step.cmd === 'write') {
+                    worker.postMessage({ command: 'writefileandstage', filename: step.filename, contents: step.contents });
+                    out.write = await next();
+                } else if (step.cmd === 'readfile') {
+                    worker.postMessage({ command: 'readfile', filename: step.filename });
+                    out[`read:${step.filename}`] = await next();
+                }
+            }
+        } finally {
+            worker.terminate();
+        }
+        return out;
+    }, { repoUrl: REPO_URL, steps });
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:8080');
+    await page.evaluate(async (name) => {
+        try { (await navigator.storage.getDirectory()).removeEntry(name, { recursive: true }); } catch (e) {}
+    }, REPO);
+});
+
+test.afterEach(async ({ page }) => {
+    await page.evaluate(async (name) => {
+        try { (await navigator.storage.getDirectory()).removeEntry(name, { recursive: true }); } catch (e) {}
+    }, REPO);
+});
+
+test('uncloneable repo falls back to a persistent local OPFS repo that survives reload', async ({ page }) => {
+    // ---- First load: synclocal(null) -> clone(fails) -> initlocal -> write ----
+    const first = await driveWorker(page, [
+        { cmd: 'synclocal' },
+        { cmd: 'clone' },
+        { cmd: 'initlocal' },
+        { cmd: 'write', filename: FAUST_FILE, contents: FAUST_CONTENT },
+    ]);
+
+    expect(first.synclocal.dircontents).toBeNull();          // nothing local yet
+    expect(first.clone.dircontents).toBeNull();              // clone reports failure honestly
+    expect(first.clone.cloneFailed).toBe(true);
+    expect(first.initlocal.dircontents).toContain('.git');   // real repo established
+    expect(first.write.dircontents).toContain('faust');      // faust write landed in the tree
+
+    // ---- Simulated reload: fresh worker, synclocal must restore from OPFS ----
+    const second = await driveWorker(page, [
+        { cmd: 'synclocal' },
+        { cmd: 'readfile', filename: FAUST_FILE },
+    ]);
+
+    expect(second.synclocal.dircontents).not.toBeNull();     // restored, NOT discarded
+    expect(second.synclocal.dircontents).toContain('.git');
+    const read = second[`read:${FAUST_FILE}`];
+    const contents = typeof read.filecontents === 'string'
+        ? read.filecontents
+        : new TextDecoder().decode(read.filecontents);
+    expect(contents).toBe(FAUST_CONTENT);                    // edit survived the reload
+});
+
+test('remote param sets origin url in persisted .git/config', async ({ page }) => {
+    const CUSTOM_REMOTE = 'http://localhost:9418/mygitserver/song.git';
+
+    await driveWorker(page, [
+        { cmd: 'synclocal' },
+        { cmd: 'clone' },
+        { cmd: 'initlocal', remoteUrl: CUSTOM_REMOTE },
+    ]);
+
+    // Fresh worker (reload): the origin url must have persisted in .git/config.
+    const after = await driveWorker(page, [
+        { cmd: 'synclocal' },
+        { cmd: 'readfile', filename: '.git/config' },
+    ]);
+    const cfg = after['read:.git/config'];
+    const text = typeof cfg.filecontents === 'string'
+        ? cfg.filecontents
+        : new TextDecoder().decode(cfg.filecontents);
+    expect(text).toContain(CUSTOM_REMOTE);
+});
+
+// Full app-level proof: boot the real app with an unregistered `?gitrepo=` name
+// (routes to the local sandbox RPC, get_refs fails → clone fails). Before the
+// fix this hung the boot spinner forever; now it must boot, and a saved edit
+// must survive a reload. Needs the near-git sandbox (`npm run near-sandbox`).
+test('app boots on an unregistered ?gitrepo= and the edit survives reload', async ({ page }) => {
+    // A `.sandbox` name the SW routes to the local RPC but which is NOT a
+    // registered repo contract, so get_refs errors and the clone fails.
+    const UNREGISTERED = 'unregistered-local-sketch.sandbox';
+    const OPFS_NAME = `${UNREGISTERED}.git`;
+    const url = `http://localhost:8080/?gitrepo=${UNREGISTERED}`;
+    const edited = '// authored offline in a local-only repo\nconsole.log("local");\n';
+
+    const setEditor = (p, text) => p.evaluate((t) => {
+        document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror.setValue(t);
+    }, text);
+    const getEditor = (p) => p.evaluate(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue());
+
+    await page.goto('http://localhost:8080');
+    await setupServiceWorker(page);
+    await clearOPFS(page, OPFS_NAME);
+
+    // First load: must NOT hang — boot completes with the local fallback repo.
+    await page.goto(url);
+    await waitForAppReady(page);
+
+    // Edit + save (writes song.js into the local OPFS repo).
+    await setEditor(page, edited);
+    await page.locator('#savesongbutton').click();
+    await expect(page.locator('progress-spinner')).not.toBeAttached({ timeout: 30000 });
+    await expect(page.locator('#syncRemoteButton')).toHaveText('Commit & Sync', { timeout: 15000 });
+
+    // Reload WITHOUT clearing OPFS — synclocal must restore the saved edit.
+    await page.goto(url);
+    await waitForAppReady(page);
+    await page.waitForFunction((expected) => {
+        const app = document.querySelector('app-javascriptmusic');
+        const editor = app && app.shadowRoot && app.shadowRoot.querySelector('#editor .CodeMirror');
+        return editor && editor.CodeMirror && editor.CodeMirror.getValue() === expected;
+    }, edited, { timeout: 30000 });
+
+    expect(await getEditor(page)).toBe(edited);
+
+    await clearOPFS(page, OPFS_NAME);
+});

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -779,6 +779,9 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
     const gistparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('gist=') === 0) : null;
     const gitrepoparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('gitrepo=') === 0) : null;
     const pngurlparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('pngurl=') === 0) : null;
+    // Optional override for the git origin remote (any git-http URL). Parsed via
+    // URLSearchParams so a remote URL containing '=' / ':' survives decoding.
+    const remoteparam = new URLSearchParams(location.search).get('remote');
 
     if (gistparam) {
         const gistid = gistparam.split('=')[1];
@@ -799,7 +802,7 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
         console.log(`loaded from gist ${gistid}: ${songfilename}`);
     } else if (gitrepoparam) {
         const repoName = gitrepoparam.split('=')[1];
-        gitrepoconfig = await initWASMGitClient(repoName);
+        gitrepoconfig = await initWASMGitClient(repoName, remoteparam);
         appendToSubtoolbar1(document.createElement('wasmgit-ui'));
         // wasm-git is ready — connect the bridge and pull the full tree.
         // Repo identity lets the relay isolate this tab into its own

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -46,7 +46,7 @@ async function callAndWaitForWorker(message) {
     });
 }
 
-export async function initWASMGitClient(gitrepo) {
+export async function initWASMGitClient(gitrepo, remoteUrl) {
     worker = new Worker(new URL('wasmgitworker.js', import.meta.url));
     worker.onmessage = (msg) => {
         workerMessageListeners = workerMessageListeners.filter(listener => listener(msg) === true);
@@ -83,7 +83,20 @@ export async function initWASMGitClient(gitrepo) {
     let dircontents = await synclocal();
 
     if (!dircontents) {
-        dircontents = await clone();
+        // Nothing local yet — try to clone the remote. A clone against an
+        // unregistered/unreachable remote returns null (see the worker's
+        // clone handler); fall back to a persistent local OPFS repo so edits
+        // survive reload instead of being lost to in-memory WASMFS. See #151.
+        try {
+            dircontents = await clone();
+        } catch (e) {
+            console.warn('clone failed, falling back to local repo', e);
+            dircontents = null;
+        }
+        if (!dircontents) {
+            console.log('no remote to clone — initializing a local OPFS repo');
+            dircontents = await initlocal(remoteUrl);
+        }
     } else {
         console.log('Repository is already local');
     }
@@ -95,6 +108,12 @@ export async function initWASMGitClient(gitrepo) {
             command: 'remote',
             args: ['add', 'origin', gitrepourl]
         });
+    }
+    // A `?…&remote=<url>` param overrides origin so "Commit & Sync" pushes to
+    // an arbitrary remote (e.g. a local git server) instead of the NEAR
+    // default. Persisted in .git/config (OPFS), so it survives reload.
+    if (remoteUrl && remoteUrl !== gitrepourl) {
+        await setremote(remoteUrl);
     }
     if (dircontents.indexOf(CONFIG_FILE) > -1) {
         try {
@@ -149,6 +168,23 @@ export async function synclocal() {
         url: gitrepourl
     });
     return await awaitDirContents();
+}
+
+// Create a persistent local OPFS repo (no clone) when the remote can't be
+// cloned. origin defaults to the NEAR url for this repo, or `remoteUrl` when
+// a `?…&remote=<url>` param was supplied. See issue #151.
+export async function initlocal(remoteUrl) {
+    worker.postMessage({
+        command: 'initlocal',
+        url: gitrepourl,
+        remoteUrl: remoteUrl || gitrepourl,
+    });
+    return await awaitDirContents();
+}
+
+// Point origin at an arbitrary URL and persist it to .git/config (OPFS).
+export async function setremote(url) {
+    return await callAndWaitForWorker({ command: 'setremote', url });
 }
 
 export async function deletelocal() {

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -276,6 +276,23 @@ onmessage = async (msg) => {
 
     callMainInDir(['clone', msg.data.url, currentRepoDir]);
 
+    // A failed clone (unreachable/unregistered remote) leaves no repo behind —
+    // libgit2 removes the partial target dir. Detect that instead of blindly
+    // chdir'ing: an absent currentRepoDir makes ensureChdir() silently land at
+    // the in-memory WASMFS root, so every later write goes to ephemeral memory
+    // and vanishes on reload. Report null so the client can fall back to a
+    // persistent local `initlocal`. See issue #151.
+    let cloned = false;
+    try {
+      cloned = FS.readdir(currentRepoDir).indexOf('.git') > -1;
+    } catch (e) { /* target dir doesn't exist — clone failed */ }
+
+    if (!cloned) {
+      console.log('clone failed, no repository at', currentRepoDir);
+      postMessage({ dircontents: null, cloneFailed: true });
+      return;
+    }
+
     // Create symlink workaround for WASMFS getcwd() bug
     try { FS.symlink(currentRepoDir, '/' + repoName); } catch (e) { }
     ensureChdir(currentRepoDir);
@@ -286,6 +303,37 @@ onmessage = async (msg) => {
 
     console.log(currentRepoDir, 'persisted via OPFS');
     postMessage({ dircontents: readdir() });
+  } else if (msg.data.command === 'initlocal') {
+    // Establish a persistent local OPFS repo when there's nothing to clone
+    // (unregistered/unreachable remote). Mkdir UNDER the OPFS mount so the
+    // working tree survives reload, then `git init` in place. origin is set to
+    // the requested URL so "Commit & Sync" can push once the remote exists.
+    // See issue #151.
+    const repoName = msg.data.url.substring(msg.data.url.lastIndexOf('/') + 1);
+    currentRepoDir = OPFS_MOUNT + '/' + repoName;
+    console.log('initlocal', currentRepoDir);
+
+    try { FS.mkdir(currentRepoDir); } catch (e) { /* already exists */ }
+    // Create symlink workaround for WASMFS getcwd() bug
+    try { FS.symlink(currentRepoDir, '/' + repoName); } catch (e) { }
+    ensureChdir(currentRepoDir);
+    callMainInDir(['init', '.']);
+    // Same 0o755 mode-bit workaround as clone/synclocal.
+    try { callMainInDir(['config', 'core.fileMode', 'false']); } catch (_) {}
+    const originUrl = msg.data.remoteUrl || msg.data.url;
+    try { callMainInDir(['remote', 'add', 'origin', originUrl]); } catch (_) {}
+
+    console.log(currentRepoDir, 'initialized local repo, persisted via OPFS');
+    postMessage({ dircontents: readdir() });
+  } else if (msg.data.command === 'setremote') {
+    // Point origin at an arbitrary URL (the `?…&remote=<url>` param). The URL
+    // is written to .git/config, which lives in OPFS and so persists across
+    // reloads. `remote set-url` isn't available in every wasm-git build, so
+    // remove-then-add for robustness (both are supported). Idempotent.
+    ensureChdir(currentRepoDir);
+    try { callMainInDir(['remote', 'remove', 'origin']); } catch (_) { /* no origin yet */ }
+    try { callMainInDir(['remote', 'add', 'origin', msg.data.url]); } catch (_) {}
+    postMessage({ id: msg.data.id, dircontents: readdir() });
   } else if (msg.data.command === 'diff') {
     try {
       callAndCaptureOutput(['status']);


### PR DESCRIPTION
Fixes #151.

## Problem
Opening `?gitrepo=<name>` for an unregistered/unreachable repo lost **all edits on reload**.

**Root cause (reproduced):** when the clone fails, libgit2 removes the target dir, but the worker still `chdir`'d into it — silently landing at the **in-memory WASMFS root**. The OPFS repo dir was never created, so every editor / Faust save went to ephemeral memory and vanished on reload. (The boot could also hang for 30s on the clone timeout.)

## Fix
- **`clone`** now detects failure (no `.git` in the target) and reports it honestly instead of returning a bogus root listing / hanging the boot.
- **`initlocal`** (new) establishes a *persistent* OPFS repo (`git init` under the OPFS mount) so an uncloneable repo degrades to a **local-only repo** whose working tree — including `faust/` — survives reload. `synclocal` restores it on reload exactly like a cloned repo.
- **`setremote`** + **`?gitrepo=name&remote=<url>`** let you point `origin` at any git-http remote (e.g. a local git server) to push later. The URL is persisted in `.git/config` (OPFS), so it's needed only once. Default `origin` stays the NEAR url.

## Tests
`e2e/local-repo-persistence.spec.js` (all green against the local NEAR sandbox):
- worker-level: uncloneable repo → persistent local repo, edit survives a worker restart
- `remote=` param lands in the persisted `.git/config`
- **full app-level**: boot the real app on an unregistered `?gitrepo=`, save an edit, reload → edit persists

Existing `near-git.spec.js` (registered-repo flow) still passes — the `clone` success path is unchanged.

## Caveat
Pushing to a **non-NEAR** remote goes through normal browser `fetch` (only `/near-repo/*` hits the service worker), so that server needs git-smart-HTTP + CORS. Persisting locally and *configuring* the remote work regardless. Documented in `docs/git-hosting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)