### PR TITLE
docs: state GPL-3.0 license in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ And you can listen to the song [songs/upbeat.js](songs/upbeat.js) here:
 https://soundcloud.com/psalomo/80s-nostalgica
 
 Run directly from nodejs, only dependes on the node midi package, and connect to a midi device.
+
+# License
+
+This project is licensed under the **GNU General Public License v3.0** — see [LICENSE](LICENSE) for the full text. Bundled third-party components (e.g. [4klang](4klang)) retain their own licenses.


### PR DESCRIPTION
The README didn't mention the license. Add a short **License** section pointing to `LICENSE` (GPL-3.0), and note that bundled third-party components (e.g. 4klang) keep their own licenses.

Follow-up to #153 (which removed the MIT dual-license option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)