### PR TITLE
Token prompt via modal + persist agent conversations in the repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,22 @@ jobs:
         run: |
           grep -rq --include '*.spec.js' \.only\( . && echo 'You have .only() in your tests!' && exit 1
           exit 0
+  unit-tests:
+    name: Unit tests (node:test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Run node:test unit suites
+        run: |
+          # Pure-logic unit tests — no deps, no browser (studio-agent tool core,
+          # git CORS proxy incl. NEP-413/JWT crypto).
+          cd wasmaudioworklet
+          npm run test-agent-tools
+          npm run test-gitproxy
   web-test-runner:
     name: Web Test Runner
     runs-on: ubuntu-latest

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -13,12 +13,30 @@ import { applyEditToText, grepText, normDsp, faustRegistrationHint } from './stu
 const DEFAULT_PORT = 17891;
 const FAUST_DIR = 'faust/';
 const RECONNECT_MS = 3000;
+const SESSION_FILE = 'studioagent-session.json'; // conversation stored in the OPFS repo
 
 let shadow = null;
 let socket = null;
 let sessionId = null;
 let agentMsgEl = null; // the in-progress assistant message element
 let toolQueue = Promise.resolve(); // serialize tool execution (see tool_call below)
+let conversation = []; // [{ role: 'user' | 'agent', text }] persisted to the repo
+
+// Persist the conversation + SDK session id into the OPFS repo so it survives a
+// reload (and travels with the project). No-op when not in ?gitrepo= mode.
+async function saveSession() {
+  try { await writefileandstage(SESSION_FILE, JSON.stringify({ sessionId, conversation }, null, 1)); }
+  catch (e) { /* no OPFS repo — in-memory only */ }
+}
+async function loadSession() {
+  try {
+    const data = JSON.parse(await readfile(SESSION_FILE));
+    sessionId = data.sessionId || null;
+    conversation = Array.isArray(data.conversation) ? data.conversation : [];
+    for (const m of conversation) addLine(m.role === 'user' ? 'user' : 'agent', m.text);
+    if (conversation.length) { addLine('tool', `— resumed ${conversation.length} messages —`); }
+  } catch (e) { /* no saved session yet */ }
+}
 
 // Editor wrappers around the pure logic in studio-agent-tools-core.js.
 function applyEdit(editor, args) {
@@ -141,6 +159,7 @@ async function onMessage(msg) {
   switch (msg.t) {
     case 'session':
       sessionId = msg.sessionId;
+      saveSession();
       setPhase('thinking…');
       break;
     case 'text':
@@ -157,11 +176,14 @@ async function onMessage(msg) {
       // single-instance resources and stall if overlapped. Queue keeps arrival order.
       toolQueue = toolQueue.then(() => runTool(msg));
       break;
-    case 'done':
+    case 'done': {
+      const agentText = agentMsgEl ? agentMsgEl.textContent : '';
+      if (agentText) { conversation.push({ role: 'agent', text: agentText }); saveSession(); }
       finishAgentMessage();
       stopActivity('done ✓');
       setBusy(false);
       break;
+    }
     case 'error':
       addLine('error', `⚠ ${msg.error}`);
       finishAgentMessage();
@@ -198,6 +220,8 @@ function reply(id, ok, result) {
 function sendChat(text) {
   if (!socket || socket.readyState !== WebSocket.OPEN) { setStatus('not connected'); return; }
   addLine('user', text);
+  conversation.push({ role: 'user', text });
+  saveSession();
   startAgentMessage();
   setBusy(true);
   startActivity();
@@ -284,5 +308,6 @@ export function initStudioAgent(shadowRoot) {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); form.requestSubmit(); }
   });
 
+  loadSession(); // restore prior conversation from the OPFS repo (if any)
   connect();
 }

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -1,6 +1,6 @@
 import { initNear, authdata as nearAuthData, login as nearLogin, logout as nearLogout } from './nearacl.js';
 import { toggleSpinner } from '../common/ui/progress-spinner.js';
-import { modal } from '../common/ui/modal.js';
+import { modal, modalPrompt } from '../common/ui/modal.js';
 
 async function registerNearGitServiceWorker() {
     await navigator.serviceWorker.register('/near-git-sw.js', { type: 'module' });
@@ -88,7 +88,8 @@ async function applyStoredGitToken(promptIfMissing) {
     let stored = null;
     try { stored = JSON.parse(sessionStorage.getItem(GIT_TOKEN_KEY) || 'null'); } catch (e) { /* ignore */ }
     if ((!stored || !stored.token) && promptIfMissing) {
-        const token = window.prompt('GitHub token to clone/push this repo (fine-grained PAT, Contents: read/write). Leave empty for a public repo:', '');
+        const token = await modalPrompt('GitHub token',
+            'Fine-grained PAT (Contents: read/write) to clone/push this repo. Leave empty for a public repo.', '');
         if (token) {
             stored = { token, username: 'wasmmusic', useremail: 'wasmmusic@users.noreply.github.com' };
             try { sessionStorage.setItem(GIT_TOKEN_KEY, JSON.stringify(stored)); } catch (e) { /* ignore */ }


### PR DESCRIPTION
Two follow-ups requested after the clone-from-remote work (#156):

1. **Token prompt uses the in-app modal** — `applyStoredGitToken` now calls `modalPrompt` (the app's in-shell modal) instead of `window.prompt`, so entering a GitHub token to clone/push renders inside the app.

2. **Agent conversations persist in the OPFS repo** — the studio-agent chat transcript + SDK `sessionId` are written to `studioagent-session.json` in the repo after each turn and **restored on load**, so the conversation survives a reload (and travels with the project / can be committed & synced). No-op when not in `?gitrepo=` mode. On reload the next message resumes the SDK session via the restored `sessionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)