### PR TITLE
Sequence API instruction fixes: loopHere() semantics + expose waitDuration() global

### DIFF
--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -24,7 +24,7 @@ The user's work is precious and much of it (recorded MIDI takes especially) exis
 ## SONG format & the COMPLETE sequence command set
 The song is JavaScript run by the sequencer. The full DSL is below — if a capability exists, it's one of these. The authoritative reference with exact signatures is \`wasmaudioworklet/docs/song-api.md\`; READ it whenever you're unsure of a command or its arguments. NEVER invent commands or guess what a request maps to — if the user names a sequencing behaviour you don't recognise, check the doc.
 
-- **Tempo / flow:** \`setBPM(bpm)\`; \`await waitForBeat(beat)\`; \`playFromHere()\`.
+- **Tempo / flow:** \`setBPM(bpm)\`; \`await waitForBeat(beat)\` (absolute) or \`await waitDuration(beats)\` (relative, advances the clock) — both exist as globals AND track methods; \`playFromHere()\`.
 - **\`loopHere()\` — the END-of-song marker.** When playback reaches it, it jumps back to the START (beat 0). Everything sequenced AFTER it is DISCARDED and never plays, so it MUST be the very last statement. It is NOT a "loop back to here" target and NOT a section boundary — the loop always returns to the beginning. To add a section at the end, put it BEFORE \`loopHere()\`, never after.
 - **Instruments / structure:** \`addInstrument('name')\` — the Nth call is channel N (0-based); order MUST match the synth's midichannels[]. \`definePartStart('name')\` / \`definePartEnd('name')\`.
 - **Tracks:** \`const t = createTrack(channel, stepsPerBeat?, defaultVelocity?)\`. Then:

--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -24,7 +24,8 @@ The user's work is precious and much of it (recorded MIDI takes especially) exis
 ## SONG format & the COMPLETE sequence command set
 The song is JavaScript run by the sequencer. The full DSL is below — if a capability exists, it's one of these. The authoritative reference with exact signatures is \`wasmaudioworklet/docs/song-api.md\`; READ it whenever you're unsure of a command or its arguments. NEVER invent commands or guess what a request maps to — if the user names a sequencing behaviour you don't recognise, check the doc.
 
-- **Tempo / flow:** \`setBPM(bpm)\`; \`await waitForBeat(beat)\`; \`playFromHere()\`; \`loopHere()\` (marks the loop point — usually the last line).
+- **Tempo / flow:** \`setBPM(bpm)\`; \`await waitForBeat(beat)\`; \`playFromHere()\`.
+- **\`loopHere()\` — the END-of-song marker.** When playback reaches it, it jumps back to the START (beat 0). Everything sequenced AFTER it is DISCARDED and never plays, so it MUST be the very last statement. It is NOT a "loop back to here" target and NOT a section boundary — the loop always returns to the beginning. To add a section at the end, put it BEFORE \`loopHere()\`, never after.
 - **Instruments / structure:** \`addInstrument('name')\` — the Nth call is channel N (0-based); order MUST match the synth's midichannels[]. \`definePartStart('name')\` / \`definePartEnd('name')\`.
 - **Tracks:** \`const t = createTrack(channel, stepsPerBeat?, defaultVelocity?)\`. Then:
   - \`await t.steps(stepsPerBeat, [ ...notes ])\` — step grid; empty slot = rest; \`[...].repeat(n)\`.

--- a/wasmaudioworklet/docs/song-api.md
+++ b/wasmaudioworklet/docs/song-api.md
@@ -45,7 +45,10 @@ await waitForBeat(4);
 Resets playback to start from the current position, keeping only control change messages.
 
 ### `loopHere()`
-Marks the current position as a loop point.
+Marks the **end** of the song. When playback reaches this point it loops back to
+the **start** (beat 0). Anything sequenced *after* `loopHere()` is discarded and
+never plays — so call it once, as the last statement. It is not a "loop back to
+here" target; the loop always returns to the beginning.
 
 ---
 

--- a/wasmaudioworklet/docs/song-api.md
+++ b/wasmaudioworklet/docs/song-api.md
@@ -41,6 +41,15 @@ Waits until the specified beat number is reached.
 await waitForBeat(4);
 ```
 
+### `waitDuration(beats)`
+Advances the shared clock by `beats` beats **from the current position** (relative;
+`waitForBeat` is absolute). Also available as a track method (`track.waitDuration(...)`).
+
+**Example:**
+```javascript
+await waitDuration(16); // advance 16 beats before scheduling the next section
+```
+
 ### `playFromHere()`
 Resets playback to start from the current position, keeping only control change messages.
 

--- a/wasmaudioworklet/midisequencer/pattern.js
+++ b/wasmaudioworklet/midisequencer/pattern.js
@@ -64,6 +64,13 @@ export async function waitForBeat(beatNo) {
     return pushPendingEvent(timeout);
 }
 
+// Global counterpart to Pattern.waitDuration — advances the shared clock by
+// `duration` beats from the current position (symmetric with the global
+// waitForBeat above, which waits until an absolute beat).
+export async function waitDuration(duration) {
+    return pushPendingEvent((duration * 60 * 1000) / bpm);
+}
+
 export class Pattern {
     constructor(output) {
         this.output = output;

--- a/wasmaudioworklet/midisequencer/songcompiler.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.js
@@ -1,4 +1,4 @@
-import { resetTick, setBPM, nextTick, currentTime, waitForBeat } from './pattern.js';
+import { resetTick, setBPM, nextTick, currentTime, waitForBeat, waitDuration } from './pattern.js';
 import { TrackerPattern, pitchbend, controlchange, createNoteFunctions, noteFunctionKeys } from './trackerpattern.js';
 import { SEQ_MSG_LOOP, SEQ_MSG_START_RECORDING, SEQ_MSG_STOP_RECORDING, SEQ_MSG_BROADCAST_SEND, SEQ_MSG_BROADCAST_WAIT } from './sequenceconstants.js';
 import { setVideoSchedule } from '../visualizer/videoscheduler.js';
@@ -146,6 +146,7 @@ const songargs = {
     'pitchbend': pitchbend,
     'controlchange': controlchange,
     'waitForBeat': waitForBeat,
+    'waitDuration': waitDuration,
     'startRecording': startRecording,
     'stopRecording': stopRecording,
     'startVideo': startVideo,


### PR DESCRIPTION
Two fixes surfaced from a studio-agent session review:

**1. `loopHere()` was described confusingly.** The agent read "marks the loop point" as a "loop back to *here*" target and placed it mid-song, which **truncates the rest** (`songcompiler.js` slices the event list at the loop message) and loops playback back to beat 0 — so the trailing section never played. Now stated explicitly (agent prompt + `song-api.md`): it's the **end-of-song marker**, reaching it loops to the **start**, anything after it is discarded, must be the last statement.

**2. `waitDuration()` wasn't exposed as a global.** `waitForBeat` is both a module-level export (in the song's global scope) and a `Pattern` method; `waitDuration` existed **only** as a `Pattern` method, so a bare global `waitDuration(4)` was undefined → compile error. Added the module-level `waitDuration` (relative clock advance, counterpart to the absolute `waitForBeat`) and registered it in the song scope. Documented as a global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)