### PR TITLE
Upgrade wasm-git to 0.0.17; fix SW push races it surfaced

### DIFF
--- a/wasmaudioworklet/devserver.js
+++ b/wasmaudioworklet/devserver.js
@@ -4,7 +4,7 @@ import { join, extname } from 'node:path';
 
 const PORT = 8080;
 const STATIC_ROOT = new URL('.', import.meta.url).pathname;
-const WASM_GIT_UNPKG = 'https://unpkg.com/wasm-git@0.0.14/';
+const WASM_GIT_UNPKG = 'https://unpkg.com/wasm-git@0.0.17/';
 
 const MIME_TYPES = {
   '.html': 'text/html',

--- a/wasmaudioworklet/e2e/near-git-helpers.js
+++ b/wasmaudioworklet/e2e/near-git-helpers.js
@@ -104,7 +104,13 @@ export async function pushBaseline(page, repoName, content) {
         const pushReply = await next();
         worker.terminate();
         if (pushReply && pushReply.error) {
-            throw new Error('pushBaseline failed: ' + pushReply.error);
+            let swError = '';
+            try {
+                const dbg = await caches.open('near-git-debug');
+                const resp = await dbg.match('/last-push-error');
+                if (resp) swError = ' | SW: ' + await resp.text();
+            } catch (e) { }
+            throw new Error('pushBaseline failed: ' + pushReply.error + swError);
         }
     }, {
         repoUrl: `http://localhost:8080/near-repo/${repoName}`,

--- a/wasmaudioworklet/functions/wasm-git/[[path]].js
+++ b/wasmaudioworklet/functions/wasm-git/[[path]].js
@@ -1,4 +1,4 @@
-const WASM_GIT_UNPKG = 'https://unpkg.com/wasm-git@0.0.14/';
+const WASM_GIT_UNPKG = 'https://unpkg.com/wasm-git@0.0.17/';
 
 export async function onRequest(context) {
   const url = new URL(context.request.url);

--- a/wasmaudioworklet/near-git-sw.js
+++ b/wasmaudioworklet/near-git-sw.js
@@ -157,6 +157,12 @@ function uint8ToBase64(bytes) {
     return btoa(binary);
 }
 
+// Highest nonce already used per access key. The optimistic-finality
+// view_access_key query can return a stale nonce right after a recent
+// transaction, and reusing it makes the RPC reject the tx with InvalidNonce
+// (surfaced to git as a failed push).
+const lastUsedNonces = {};
+
 async function nearFunctionCall(ctx, method, args) {
     const { auth } = ctx;
 
@@ -167,7 +173,9 @@ async function nearFunctionCall(ctx, method, args) {
         public_key: `ed25519:${auth.publicKey}`,
     });
     if (accessKeyRes.error) throw new Error(JSON.stringify(accessKeyRes.error));
-    const nonce = accessKeyRes.result.nonce + 1;
+    const nonceKey = `${auth.accountId}:${auth.publicKey}`;
+    const nonce = Math.max(accessKeyRes.result.nonce, lastUsedNonces[nonceKey] || 0) + 1;
+    lastUsedNonces[nonceKey] = nonce;
     const blockHash = accessKeyRes.result.block_hash;
 
     let argsBytes;
@@ -215,20 +223,35 @@ async function nearFunctionCall(ctx, method, args) {
         argsBytes = new TextEncoder().encode(JSON.stringify(args));
     }
 
-    const signedTxBase64 = create_signed_transaction(
-        auth.accountId,
-        auth.publicKey,
-        auth.privateKey,
-        ctx.contractId,
-        method,
-        argsBytes,
-        BigInt(nonce),
-        blockHash,
-        BigInt(300_000_000_000_000), // 300 TGas
-        '0',
-    );
+    let txNonce = nonce;
+    let broadcastRes;
+    for (let attempt = 0; ; attempt++) {
+        const signedTxBase64 = create_signed_transaction(
+            auth.accountId,
+            auth.publicKey,
+            auth.privateKey,
+            ctx.contractId,
+            method,
+            argsBytes,
+            BigInt(txNonce),
+            blockHash,
+            BigInt(300_000_000_000_000), // 300 TGas
+            '0',
+        );
 
-    const broadcastRes = await nearRpc(ctx, 'broadcast_tx_commit', [signedTxBase64]);
+        broadcastRes = await nearRpc(ctx, 'broadcast_tx_commit', [signedTxBase64]);
+        // The lastUsedNonces tracking only covers this SW instance — a tx sent
+        // before the SW restarted can still make our nonce stale. The error
+        // carries the chain's current nonce, so retry from there.
+        const invalidNonce = broadcastRes.error?.data?.TxExecutionError?.InvalidTxError?.InvalidNonce;
+        if (invalidNonce && attempt < 2) {
+            txNonce = invalidNonce.ak_nonce + 1;
+            lastUsedNonces[nonceKey] = txNonce;
+            console.warn(`[near-git-sw] stale nonce, retrying with ${txNonce}`);
+            continue;
+        }
+        break;
+    }
     if (broadcastRes.error) {
         return { success: false, error: JSON.stringify(broadcastRes.error) };
     }
@@ -463,9 +486,28 @@ async function handleReceivePack(ctx, body) {
                 ref_updates: refUpdates,
             });
             if (!pushResult.success) {
-                return makeReceivePackResponse([`ng unpack ${pushResult.error}`]);
+                try {
+                    const dbg = await caches.open('near-git-debug');
+                    await dbg.put('/last-push-error', new Response(pushResult.error));
+                } catch (e) { }
+                // report-status framing: first line must be "unpack <status>",
+                // then one "ng <refname> <reason>" per rejected ref. A bare
+                // "ng unpack ..." first line makes libgit2 fail with the opaque
+                // "report-status: protocol error", hiding the real cause.
+                return makeReceivePackResponse([
+                    `unpack ${pushResult.error}`,
+                    ...refUpdates.map(u => `ng ${u.name} ${pushResult.error}`),
+                ]);
             }
         }
+    }
+
+    // Read-your-writes: optimistic-finality views can lag broadcast_tx_commit
+    // by several seconds, so a clone right after this push would see the old
+    // refs (stale editor content, CAS failures on the next push). Hold the
+    // push response until get_refs reflects what we just pushed.
+    if (refUpdates.length > 0) {
+        await waitForRefsToCatchUp(ctx, refUpdates);
     }
 
     const statusLines = ['unpack ok'];
@@ -473,6 +515,28 @@ async function handleReceivePack(ctx, body) {
         statusLines.push(`ok ${update.name}`);
     }
     return makeReceivePackResponse(statusLines);
+}
+
+async function waitForRefsToCatchUp(ctx, refUpdates, timeoutMs = 10000) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        try {
+            const refs = await nearViewCall(ctx, 'get_refs', {});
+            const refMap = Object.fromEntries(refs);
+            const caughtUp = refUpdates.every(u =>
+                u.new_sha === ZERO_SHA
+                    ? !(u.name in refMap)
+                    : refMap[u.name] === u.new_sha);
+            if (caughtUp) return;
+        } catch (e) {
+            console.warn('[near-git-sw] get_refs poll failed', e);
+        }
+        if (Date.now() >= deadline) {
+            console.warn('[near-git-sw] refs still stale after push, giving up wait');
+            return;
+        }
+        await new Promise(r => setTimeout(r, 250));
+    }
 }
 
 async function handleUploadPack(ctx, body) {

--- a/wasmaudioworklet/playwright.config.js
+++ b/wasmaudioworklet/playwright.config.js
@@ -7,6 +7,9 @@ export default defineConfig({
   // timing-sensitive and occasionally flake on slower runners. Locally,
   // failures should still surface immediately.
   retries: process.env.CI ? 2 : 0,
+  // The near-git specs all mutate the same sandbox repo, so files must not
+  // run in parallel (CI already passes --workers=1; make local runs match).
+  workers: 1,
   use: {
     baseURL: 'http://localhost:8080',
     video: 'on',


### PR DESCRIPTION
## Summary
- Bump wasm-git 0.0.14 → 0.0.17 (libgit2 1.9.4, Emscripten 6.0.3) in the devserver unpkg proxy and the Cloudflare Pages Function. API-compatible — the `lg2_opfs.js` transport and all Emscripten APIs the wasmgit worker uses are unchanged.
- Fix three race bugs in `near-git-sw.js` that the faster 0.0.15+ builds surfaced (validated via A/B runs against fresh sandboxes):
  1. **Stale nonce** — optimistic-finality `view_access_key` can lag a just-committed tx → `InvalidNonce`. Now tracks the highest used nonce per access key and retries from the error's `ak_nonce`.
  2. **report-status framing** — failed pushes replied `ng unpack <err>` as the first pkt-line; libgit2 requires `unpack <status>` first and surfaced the opaque `report-status: protocol error`. Now sends proper `unpack`/`ng` lines and stashes the raw NEAR error in the Cache API; `pushBaseline` in the e2e helpers appends it to failure messages.
  3. **Read-your-writes** — optimistic `get_refs` lags `broadcast_tx_commit` by seconds, so clone-after-push saw stale refs (stale editor content, CAS failures on the next push). The push response is now held until `get_refs` reflects the pushed refs.
- Set `workers: 1` in `playwright.config.js`: the near-git specs all mutate the same sandbox repo, and Playwright's default file-level parallelism made them race each other locally (CI already passes `--workers=1`).

## Test plan
- Near-git specs (`near-git`, `commit-stages-unstaged`, `commit-empty-diff-hang`, `anonymous-clone-auth`): 8/8 consecutive clean runs against a fresh sandbox (previously ~1 failure per run).
- Full e2e suite: 38 passed, 1 skipped (claude-bridge; relay not running), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)