### PR TITLE
Bump faust compiler module to 0.16.1-asc.2

### DIFF
--- a/wasmaudioworklet/faust/faust-rs-transpile.js
+++ b/wasmaudioworklet/faust/faust-rs-transpile.js
@@ -26,7 +26,7 @@ import { toggleSpinner } from '../common/ui/progress-spinner.js';
 // next to this file), CDN-published binary as the fallback for deployments
 // where the gitignored local artifact doesn't exist.
 const WASM_URL = new URL('./faust_wasm_ffi.wasm', import.meta.url);
-const COMPILER_MODULE_VERSION = '0.16.1-asc.1';
+const COMPILER_MODULE_VERSION = '0.16.1-asc.2';
 const WASM_CDN_URL = `https://cdn.jsdelivr.net/npm/@psalomo/faustwasm@${COMPILER_MODULE_VERSION}/faust-compiler-module.wasm`;
 
 let modulePromise = null;


### PR DESCRIPTION
Rebuilt from the latest compiler main (vector mode and ondemand primitives merged upstream). CDN module verified byte-identical to the local build; e2e transpile + dx7 audio specs pass (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)