### PR TITLE
fix: studio-agent write_faust now refreshes the editor showing that file

### DIFF
--- a/wasmaudioworklet/e2e/faust-editor.spec.js
+++ b/wasmaudioworklet/e2e/faust-editor.spec.js
@@ -408,6 +408,44 @@ test.describe('Faust editor — create, transpile, import, compile', () => {
         expect(secondWasmLen).not.toBe(firstWasmLen);
     });
 
+    test('studio-agent write_faust refreshes the editor showing that file (no file-switch needed)', async ({ page }) => {
+        // Regression: the agent's write_faust wrote straight to OPFS and only
+        // refreshed the dropdown, so overwriting the file already on screen
+        // left stale content in the editor until the user switched files and
+        // back. write_faust must now reflect the new bytes immediately.
+        page.on('console', (m) => {
+            if (m.type() === 'error' || m.type() === 'warning') console.log('[browser]', m.type(), m.text());
+        });
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await page.goto('http://localhost:8080');
+        await setupServiceWorker(page);
+        await pushBaseline(page, repoName, '// empty\n');
+        await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+        await waitForAppReady(page);
+
+        // Open agentrefresh.dsp in the editor (seeded with the stdfaust template).
+        await page.locator('#fausteditortogglecheckbox').check();
+        await newFaustFile(page, 'agentrefresh');
+        await page.waitForFunction(() => {
+            const cm = document.querySelector('app-javascriptmusic').shadowRoot
+                .querySelector('#faustcodemirror .CodeMirror');
+            return cm && cm.CodeMirror.getValue().includes('import("stdfaust.lib")');
+        }, { timeout: 10000 });
+
+        // Agent overwrites the SAME file that is currently on screen.
+        const result = await page.evaluate((source) =>
+            window.studioAgentRunTool('write_faust', { path: 'agentrefresh', source }),
+            FAUST_SOURCE);
+        expect(String(result)).toContain('transpiled OK');
+
+        // The editor shows the agent's content without any file switching.
+        const inEditor = await getFaustEditorContent(page);
+        expect(inEditor).toBe(FAUST_SOURCE);
+        // ...and the dropdown selection still points at the same file.
+        const opts = await getDropdownOptions(page);
+        expect(opts).toEqual(['agentrefresh.dsp']);
+    });
+
     test('sub-folder layout: faust/<dir>/<dir>/main.dsp transpile + import works', async ({ page }) => {
         // Mirrors the user's vscode-prepared repo shape: a Faust file
         // nested several directories deep (e.g. faust/mysong/dsp/main.dsp).

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -212,6 +212,17 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
     // refresh the Faust file dropdown after authoring an instrument.
     window.refreshFaustFileList = refreshFaustFileList;
 
+    // Exposed for the studio-agent: after it writes a .dsp straight to OPFS,
+    // reflect the new bytes in the editor. refreshFaustFileList() only reloads
+    // the editor when the selection changes, so a write to the file that's
+    // already on screen would otherwise show stale content until the user
+    // switches files and back. Re-read that file from OPFS into the editor.
+    window.showFaustFileInEditor = async (path) => {
+        const full = path.startsWith(FAUST_DIR) ? path : FAUST_DIR + path;
+        faustFileSelect.value = full;
+        await loadFaustFile(full);
+    };
+
     async function loadFaustFile(path) {
         try {
             const contents = await readfile(path);

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -109,6 +109,9 @@ const registry = {
       await writefileandstage(FAUST_DIR + stem + '.ts', ts);
       // refresh the app's Faust file dropdown so the user sees the new instrument
       if (typeof window.refreshFaustFileList === 'function') { try { await window.refreshFaustFileList(); } catch { /* non-fatal */ } }
+      // and reflect the written .dsp in the editor even when it's the file already
+      // on screen (dropdown refresh alone won't reload the current selection).
+      if (typeof window.showFaustFileInEditor === 'function') { try { await window.showFaustFileInEditor(FAUST_DIR + rel); } catch { /* non-fatal */ } }
       return faustRegistrationHint(ts, stem).message;
     } catch (e) { return faustUnavailable(e); }
   },
@@ -310,4 +313,8 @@ export function initStudioAgent(shadowRoot) {
 
   loadSession(); // restore prior conversation from the OPFS repo (if any)
   connect();
+
+  // Test hook: lets e2e specs invoke the agent's browser tools exactly as a
+  // tool_call from the server would (e.g. write_faust editor-refresh spec).
+  window.studioAgentRunTool = (name, args) => registry[name]?.(args || {});
 }


### PR DESCRIPTION
## Problem

When the studio-agent authored a `.dsp` via `write_faust`, the change wasn't visible in the Faust editor if that file was already open — the user had to switch to another file and back to see it.

`write_faust` writes straight to OPFS and called `refreshFaustFileList()`, but that only reloads the editor when the dropdown selection changes (i.e. for brand-new files). Overwriting the currently-displayed file left the CodeMirror doc stale; switching files and back worked only because the dropdown's `change` listener re-reads OPFS.

Other write paths are unaffected: `set_synth`/`set_song`/`edit_*`/`load_*_from_file` call `setValue` on the editor directly, and the claude-bridge's `_applyFile` already refreshes any editor showing the written path.

## Fix

- `editorcontroller.js`: new `window.showFaustFileInEditor(path)` — re-reads a `.dsp` from OPFS into the Faust editor (and syncs the dropdown selection).
- `studio-agent-client.js`: `write_faust` calls it after writing, so the on-screen file reflects the agent's content immediately.

## Test

- New e2e regression test in `faust-editor.spec.js`: opens a `.dsp` in the editor, invokes the real `write_faust` tool (via a new `window.studioAgentRunTool` test hook) on that same file, and asserts the editor updates without any file switching. Runs fully offline — the transpile uses the local `faust_wasm_ffi.wasm`.
- Verified the test **fails** with the fix disabled and **passes** with it.
- Full `faust-editor.spec.js` suite: 6/6 passed (with the NEAR sandbox running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)