### PR TITLE
studio-agent: compile=save (play tool removed), fix audio-worklet deadlocks + stale-visualizer clock, queue-aware timeouts, auto-compact with repo-portable summary

### DIFF
--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -21,6 +21,7 @@ The user's work is precious and much of it (recorded MIDI takes especially) exis
 - **If doing what's asked seems to require changing something the user didn't mention, STOP and ask** in a one-line chat reply instead of guessing.
 - To play/preview without a song, you may compile; do not fabricate a song to hear it.
 - **Adding or changing a PART for an existing instrument is a SONG edit only.** Do NOT re-run write_faust for instruments that already exist (use list_faust if unsure) — write_faust is only for creating a NEW sound. Reserve heavy tools (write_faust) for what's actually new; issue them one at a time, not in a batch.
+- **If a heavy tool (write_faust/compile) reports a TIMEOUT, do NOT resend the same call.** The browser is usually STILL finishing it (a big Faust chain can transpile for minutes) and tool calls run one at a time — a resend just queues another heavy run behind the first and times out too. Instead VERIFY what landed (read_faust for the .dsp, compile for the build) and only re-issue if the content is actually missing or stale.
 
 ## SONG format & the COMPLETE sequence command set
 The song is JavaScript run by the sequencer. The full DSL is below — if a capability exists, it's one of these. The authoritative reference with exact signatures is \`wasmaudioworklet/docs/song-api.md\`; READ it whenever you're unsure of a command or its arguments. NEVER invent commands or guess what a request maps to — if the user names a sequencing behaviour you don't recognise, check the doc.
@@ -46,7 +47,7 @@ A song plays through ONE synth document. To add a different instrument (say a wa
 2. Find anchors in the CURRENT synth with grep_synth (the in-browser doc is what compiles; don't assume it equals the on-disk file): grep for \`export function initializeMidiSynth\`, for the \`midichannels[<n>] = \` line you want to add/replace, and for the import block at the top.
 3. edit_synth to (a) add any needed import line, (b) insert the new voice class (anchor on a unique line just before initializeMidiSynth), and (c) add or replace the \`midichannels[N] = new MidiChannel(maxVoices, (ch) => new YourVoice(ch));\` registration. Keep all existing DX7 channels intact.
 4. Make sure the song's addInstrument() count covers channel N, then write that channel's part. A non-FM voice (waveguide/subtractive) does NOT need NRPN patch data — only DX7/FM channels do.
-5. compile; if an import or symbol doesn't resolve, grep_synth/Read to find the right path and fix with edit_synth. Repeat until "compiled OK", then play.
+5. compile; if an import or symbol doesn't resolve, grep_synth/Read to find the right path and fix with edit_synth. Repeat until "compiled OK".
 
 ## Authoring an instrument in FAUST (the primary way to make a sound)
 Use \`write_faust(path, source)\` — it writes \`faust/<path>.dsp\` AND transpiles it to \`faust/<path>.ts\`, returning the generated class names (or the exact transpile error to fix). Requires the app opened with \`?gitrepo=…\` (OPFS). Then synth.ts imports those classes.
@@ -87,7 +88,7 @@ export function postprocess(): void {}
 1. write_faust('bass', '<faust source>') → note the reported classes + fix any transpile error by editing the .dsp and calling write_faust again.
 2. Wire it into synth.ts: if the synth is small, set_synth the whole combiner; if it's a large existing bundle, edit_synth to add the import + the midichannels[N] line (see the large-synth section above).
 3. addInstrument in the song at the matching index and write the part.
-4. compile → fix → play.
+4. compile → fix → recompile until "compiled OK". Do NOT call play (see the playback policy).
 
 ## Your tools
 You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try to use anything else.
@@ -100,8 +101,8 @@ You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try
 - read_faust(path) / list_faust() — read a .dsp / list the .dsp instruments in faust/.
 - git_log() / read_committed(path, ref?) — inspect the OPFS repo history / read a file's COMMITTED content (default HEAD). The user commits their work to OPFS git. To RESTORE something that was overwritten in the editor, read_committed the repo-relative path (e.g. 'song.js') and set_song/set_synth it back. This is how you recover a lost song — check git before saying it's gone.
 - load_synth_from_file(path) / load_song_from_file(path) — load a repo file DIRECTLY into the synth/song editor. The file content never enters your context — you only pass a repo-relative path. **Use this for any large file** (e.g. the DX7 bundle).
-- compile — compile song+synth in the browser; returns "compiled OK" or the exact compiler error. ALWAYS compile after editing and FIX errors before continuing.
-- play / stop — start/stop live audio (play compiles first).
+- compile — SAVE + compile song+synth in the browser (same as the app's save button); returns "compiled OK" or the exact compiler error. ALWAYS compile after editing and FIX errors before continuing. Compiling applies the changes to a track that is ALREADY playing — the user hears them immediately, no play call needed.
+- play / stop — start/stop live audio. ONLY on the user's explicit request (see the playback policy).
 
 ## CRITICAL: never shuttle large files through your context
 Some references (notably examples/dx7/dx7-synth.ts, ~14k lines) are far too large to Read in full or to paste into set_synth. NEVER try to read a big bundle chunk-by-chunk to reproduce it. To put a large file into an editor, call load_synth_from_file / load_song_from_file with its path. Use Read/Grep only to inspect SMALL files or specific ranges so you understand structure (channel layout, note mapping) — not to copy big files.
@@ -111,7 +112,7 @@ Some references (notably examples/dx7/dx7-synth.ts, ~14k lines) are far too larg
 2. For a NEW instrument sound: author it with write_faust (design the DSP in Faust), then wire the returned classes into synth.ts. Do NOT hand-write the DSP in AssemblyScript. For DX7 specifically, the ready bundle path still applies (see below).
 3. Put things in place: write small synth.ts combiners with set_synth, or edit large ones with edit_synth; write/edit the song. When ADDING to an existing song/synth, get_song/grep_synth first and edit it — don't discard what's there. Keep channel order consistent between synth and song.
 4. compile. If it errors, read the error, fix, compile again. Repeat until "compiled OK". (A Faust transpile error comes back from write_faust — fix the .dsp; an AS error comes back from compile — fix synth.ts.)
-5. If the user asked to hear it, call play. Reply briefly; don't paste source unless asked.
+5. **PLAYBACK POLICY — never auto-play.** compile already saves and applies the changes: if the track is playing, the user hears them immediately; if it's stopped, the work is saved and ready. Call play ONLY when the user explicitly asks to play/hear/start it in THIS request (and stop only on request). Finishing an edit is NOT a reason to play. Reply briefly; don't paste source unless asked.
 
 **Asking the user:** you have NO interactive dialog tool — do not attempt one. If a request is genuinely ambiguous and the interpretations lead to very different results, ask ONE short clarifying question in your text reply and stop; the user answers in their next message. But prefer the most likely interpretation and proceed when the choice is minor.
 
@@ -125,7 +126,7 @@ Then pick the cheapest correct SONG path:
 - **Full demo / verify sound:** \`load_song_from_file('examples/dx7/dx7-sequence.js')\`.
 - **Custom melodic part:** copy that channel's nrpn() patch block from dx7-sequence.js into your song before its notes — line ranges: E.Piano 26-178, Bass 181-333, Strings 336-488, Bells 492-644, Drums 648-1131. Read only the range you need; never paste a whole channel from memory.
 
-Then compile, fix any error, play.
+Then compile and fix any error until "compiled OK".
 
 ## Editing recorded performances (the user plays live; you clean it up)
 When the user records live MIDI, the captured notes appear as \`createTrack(N).play([...])\` arrays inside the \`startRecording()\`/\`stopRecording()\` markers. You cannot press the app's record button — the user does that; your job is to set up channels and edit the takes. Common requests:

--- a/tools/studio-agent/prompt.mjs
+++ b/tools/studio-agent/prompt.mjs
@@ -88,7 +88,7 @@ export function postprocess(): void {}
 1. write_faust('bass', '<faust source>') → note the reported classes + fix any transpile error by editing the .dsp and calling write_faust again.
 2. Wire it into synth.ts: if the synth is small, set_synth the whole combiner; if it's a large existing bundle, edit_synth to add the import + the midichannels[N] line (see the large-synth section above).
 3. addInstrument in the song at the matching index and write the part.
-4. compile → fix → recompile until "compiled OK". Do NOT call play (see the playback policy).
+4. compile → fix → recompile until "compiled OK". (You cannot start playback — see the playback policy.)
 
 ## Your tools
 You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try to use anything else.
@@ -101,8 +101,8 @@ You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try
 - read_faust(path) / list_faust() — read a .dsp / list the .dsp instruments in faust/.
 - git_log() / read_committed(path, ref?) — inspect the OPFS repo history / read a file's COMMITTED content (default HEAD). The user commits their work to OPFS git. To RESTORE something that was overwritten in the editor, read_committed the repo-relative path (e.g. 'song.js') and set_song/set_synth it back. This is how you recover a lost song — check git before saying it's gone.
 - load_synth_from_file(path) / load_song_from_file(path) — load a repo file DIRECTLY into the synth/song editor. The file content never enters your context — you only pass a repo-relative path. **Use this for any large file** (e.g. the DX7 bundle).
-- compile — SAVE + compile song+synth in the browser (same as the app's save button); returns "compiled OK" or the exact compiler error. ALWAYS compile after editing and FIX errors before continuing. Compiling applies the changes to a track that is ALREADY playing — the user hears them immediately, no play call needed.
-- play / stop — start/stop live audio. ONLY on the user's explicit request (see the playback policy).
+- compile — SAVE + compile song+synth in the browser (same as the app's save button); returns "compiled OK" or the exact compiler error. ALWAYS compile after editing and FIX errors before continuing. Compiling applies the changes to a track that is ALREADY playing — the user hears them immediately.
+- stop — stop live audio, only on the user's request. There is NO play tool: the user starts playback themselves with the app's play button; do not attempt to start audio.
 
 ## CRITICAL: never shuttle large files through your context
 Some references (notably examples/dx7/dx7-synth.ts, ~14k lines) are far too large to Read in full or to paste into set_synth. NEVER try to read a big bundle chunk-by-chunk to reproduce it. To put a large file into an editor, call load_synth_from_file / load_song_from_file with its path. Use Read/Grep only to inspect SMALL files or specific ranges so you understand structure (channel layout, note mapping) — not to copy big files.
@@ -112,7 +112,7 @@ Some references (notably examples/dx7/dx7-synth.ts, ~14k lines) are far too larg
 2. For a NEW instrument sound: author it with write_faust (design the DSP in Faust), then wire the returned classes into synth.ts. Do NOT hand-write the DSP in AssemblyScript. For DX7 specifically, the ready bundle path still applies (see below).
 3. Put things in place: write small synth.ts combiners with set_synth, or edit large ones with edit_synth; write/edit the song. When ADDING to an existing song/synth, get_song/grep_synth first and edit it — don't discard what's there. Keep channel order consistent between synth and song.
 4. compile. If it errors, read the error, fix, compile again. Repeat until "compiled OK". (A Faust transpile error comes back from write_faust — fix the .dsp; an AS error comes back from compile — fix synth.ts.)
-5. **PLAYBACK POLICY — never auto-play.** compile already saves and applies the changes: if the track is playing, the user hears them immediately; if it's stopped, the work is saved and ready. Call play ONLY when the user explicitly asks to play/hear/start it in THIS request (and stop only on request). Finishing an edit is NOT a reason to play. Reply briefly; don't paste source unless asked.
+5. **PLAYBACK POLICY — you cannot start playback (there is no play tool).** compile already saves and applies the changes: if the track is playing, the user hears them immediately; if it's stopped, the work is saved and ready for the user to press play. If asked to "play it", explain that compile has applied everything and they can hit the play button. Reply briefly; don't paste source unless asked.
 
 **Asking the user:** you have NO interactive dialog tool — do not attempt one. If a request is genuinely ambiguous and the interpretations lead to very different results, ask ONE short clarifying question in your text reply and stop; the user answers in their next message. But prefer the most likely interpretation and proceed when the choice is minor.
 

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -35,6 +35,12 @@ const HEAVY_TOOLS = new Set(['write_faust', 'compile']);
 // Optional model override for speed/depth tradeoff, e.g. STUDIO_AGENT_MODEL=sonnet
 // (faster) vs opus (deeper). Unset = the SDK/Claude Code default.
 const MODEL = process.env.STUDIO_AGENT_MODEL || undefined;
+// Proactive compaction threshold (tokens of per-call context). The SDK only
+// auto-compacts near the model's context LIMIT (~1M on opus) — far beyond the
+// point where every turn is already slow and expensive (a ~570k-token session
+// was thinking 35-80s per stretch at $1-6/turn). When a turn ends above this,
+// we run /compact on the session right away, while the user reads the reply.
+const COMPACT_THRESHOLD = Number(process.env.STUDIO_AGENT_COMPACT_THRESHOLD || 200000);
 
 // ---- session logging: one JSONL file per server boot, for later review ------
 const LOG_DIR = resolve(__dirname, 'logs');
@@ -84,6 +90,7 @@ function safeResolve(p) {
 // ---- WebSocket plumbing: one browser at a time -----------------------------
 let pending = new Map();   // id -> { resolve }
 let nextId = 1;
+let chatChain = Promise.resolve(); // serialize chat turns (and post-turn auto-compact)
 
 function callBrowser(ws, name, args) {
   return new Promise((resolveCall, rejectCall) => {
@@ -180,6 +187,7 @@ async function handleChat(ws, { text, sessionId }) {
   const send = (obj) => { if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(obj)); };
   const studio = makeStudioServer(ws);
   let sid = sessionId || null;
+  let contextTokens = 0; // last model call's input size (fresh + cached)
   dlog('chat:', JSON.stringify(text).slice(0, 100), sessionId ? `(resume ${sessionId.slice(0, 8)})` : '(new)');
   logEvent({ kind: 'chat', sessionId: sid, resumed: !!sessionId, text });
 
@@ -216,6 +224,10 @@ async function handleChat(ws, { text, sessionId }) {
         logEvent({ kind: 'compact', sessionId: sid, metadata: m.compact_metadata });
         send({ t: 'compact', metadata: m.compact_metadata });
       } else if (m.type === 'assistant') {
+        // Each assistant message's usage reports THIS call's full input size
+        // (fresh + cached) — i.e. the session's current context footprint.
+        const u = m.message?.usage;
+        if (u) contextTokens = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
         for (const block of m.message?.content ?? []) {
           if (block.type === 'text' && block.text) { dlog('text:', block.text.slice(0, 80).replace(/\n/g, ' ')); logEvent({ kind: 'text', sessionId: sid, text: block.text }); send({ t: 'text', text: block.text }); }
           else if (block.type === 'tool_use') { dlog('tool_use →', block.name, JSON.stringify(block.input).slice(0, 80)); logEvent({ kind: 'tool_use', sessionId: sid, name: block.name, input: truncInput(block.input) }); send({ t: 'tool', name: block.name, input: block.input }); }
@@ -237,10 +249,38 @@ async function handleChat(ws, { text, sessionId }) {
       }
     }
     dlog('query loop ended');
+    if (sid && contextTokens > COMPACT_THRESHOLD) {
+      await autoCompact(send, sid, contextTokens);
+    }
   } catch (e) {
     dlog('EXCEPTION', e?.message || e);
     logEvent({ kind: 'error', sessionId: sid, error: String(e?.message || e) });
     send({ t: 'error', error: String(e?.message || e) });
+  }
+}
+
+// Run /compact on the session between turns (chats are serialized through
+// chatChain, so a message the user sends meanwhile simply waits for this).
+async function autoCompact(send, sid, contextTokens) {
+  dlog(`auto-compact: context ~${Math.round(contextTokens / 1000)}k tokens > ${Math.round(COMPACT_THRESHOLD / 1000)}k threshold`);
+  send({ t: 'compacting', tokens: contextTokens });
+  logEvent({ kind: 'autocompact', sessionId: sid, contextTokens });
+  try {
+    for await (const m of query({
+      prompt: '/compact',
+      options: { resume: sid, model: MODEL, cwd: REPO_ROOT, systemPrompt: SYSTEM_PROMPT, maxTurns: 2 },
+    })) {
+      if (m.type === 'system' && m.subtype === 'compact_boundary') {
+        dlog('context compacted', JSON.stringify(m.compact_metadata || {}));
+        logEvent({ kind: 'compact', sessionId: sid, metadata: m.compact_metadata });
+        send({ t: 'compact', metadata: m.compact_metadata });
+      } else if (m.type === 'result') {
+        logEvent({ kind: 'result', sessionId: sid, subtype: 'autocompact-' + m.subtype, turns: m.num_turns, costUsd: m.total_cost_usd, usage: m.usage });
+      }
+    }
+  } catch (e) {
+    dlog('auto-compact failed', e?.message || e);
+    logEvent({ kind: 'error', sessionId: sid, error: 'auto-compact: ' + String(e?.message || e) });
   }
 }
 
@@ -262,7 +302,7 @@ wss.on('connection', (ws) => {
       const p = pending.get(msg.id);
       if (p && typeof p.started === 'function') p.started();
     } else if (msg.t === 'chat') {
-      handleChat(ws, msg);
+      chatChain = chatChain.then(() => handleChat(ws, msg));
     }
   });
   ws.on('close', () => { clearInterval(keepalive); console.log('  browser disconnected'); });

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -66,7 +66,7 @@ const STUDIO_TOOLS = [
   'write_faust', 'read_faust', 'list_faust',
   'git_log', 'read_committed',
   'load_synth_from_file', 'load_song_from_file',
-  'compile', 'play', 'stop',
+  'compile', 'stop',
 ];
 const ALLOWED = new Set([
   ...STUDIO_TOOLS.map((n) => `mcp__studio__${n}`),
@@ -166,8 +166,7 @@ function makeStudioServer(ws) {
       proxy('read_committed', 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use to restore something overwritten in the editor: read_committed then set_song/set_synth it back.', { path: z.string(), ref: z.string().optional() }),
       loadInto('load_synth_from_file', 'set_synth', 'synth'),
       loadInto('load_song_from_file', 'set_song', 'song'),
-      proxy('compile', 'SAVE + compile the current song+synth in the browser (same as the app\'s save button). If a track is already playing, the changes are applied and audible immediately. Returns "compiled OK" or the exact compiler error. Call after every edit.', {}),
-      proxy('play', 'Start live audio playback in the browser. ONLY call this when the user explicitly asked to play/hear it — compile already applies changes to a playing track.', {}),
+      proxy('compile', 'SAVE + compile the current song+synth in the browser (same as the app\'s save button). If a track is already playing, the changes are applied and audible immediately. Returns "compiled OK" or the exact compiler error. Call after every edit. There is NO play tool — the user starts playback themselves.', {}),
       proxy('stop', 'Stop live audio playback. Only on the user\'s request.', {}),
     ],
   });

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -13,6 +13,7 @@
 
 import { WebSocketServer } from 'ws';
 import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { mkdirSync, createWriteStream } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -183,7 +184,7 @@ function makeStudioServer(ws) {
 const t0 = () => new Date().toISOString().slice(11, 23);
 const dlog = (...a) => console.log(`  [${t0()}]`, ...a);
 
-async function handleChat(ws, { text, sessionId }) {
+async function handleChat(ws, { text, sessionId, summary }, isRetry = false) {
   const send = (obj) => { if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(obj)); };
   const studio = makeStudioServer(ws);
   let sid = sessionId || null;
@@ -223,6 +224,7 @@ async function handleChat(ws, { text, sessionId }) {
         dlog('context compacted', JSON.stringify(m.compact_metadata || {}));
         logEvent({ kind: 'compact', sessionId: sid, metadata: m.compact_metadata });
         send({ t: 'compact', metadata: m.compact_metadata });
+        await sendCompactSummary(send, sid);
       } else if (m.type === 'assistant') {
         // Each assistant message's usage reports THIS call's full input size
         // (fresh + cached) — i.e. the session's current context footprint.
@@ -253,9 +255,53 @@ async function handleChat(ws, { text, sessionId }) {
       await autoCompact(send, sid, contextTokens);
     }
   } catch (e) {
-    dlog('EXCEPTION', e?.message || e);
-    logEvent({ kind: 'error', sessionId: sid, error: String(e?.message || e) });
-    send({ t: 'error', error: String(e?.message || e) });
+    const emsg = String(e?.message || e);
+    // SDK sessions are per-machine: a repo opened on another machine carries a
+    // sessionId this machine has never seen. Start FRESH, seeded with the
+    // compact summary the browser keeps in the repo (studioagent-session.json).
+    if (!isRetry && sessionId && /no conversation found/i.test(emsg)) {
+      dlog('resume failed — starting a fresh session' + (summary ? ' from the saved summary' : ''));
+      logEvent({ kind: 'freshsession', sessionId, hadSummary: !!summary });
+      send({ t: 'freshsession' });
+      const prompt = summary
+        ? `A previous session (possibly on another machine) was compacted to this summary:\n\n${summary}\n\n---\nContinue from that context. The user's request:\n${text}`
+        : text;
+      return handleChat(ws, { text: prompt, sessionId: null }, true);
+    }
+    dlog('EXCEPTION', emsg);
+    logEvent({ kind: 'error', sessionId: sid, error: emsg });
+    send({ t: 'error', error: emsg });
+  }
+}
+
+// After a compaction, pull the summary text out of the SDK's session store so
+// the browser can persist it into the OPFS repo: SDK sessions are per-machine,
+// so a repo cloned elsewhere can't resume the sessionId — but it CAN seed a
+// fresh session from this summary. The session jsonl marks the summary entry
+// with isCompactSummary: true.
+async function extractCompactSummary(sid) {
+  try {
+    const projDir = resolve(homedir(), '.claude', 'projects', REPO_ROOT.replace(/[/.]/g, '-'));
+    const lines = (await readFile(resolve(projDir, `${sid}.jsonl`), 'utf8')).trim().split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      let e;
+      try { e = JSON.parse(lines[i]); } catch { continue; }
+      if (e.isCompactSummary) {
+        const c = e.message?.content;
+        return typeof c === 'string' ? c : (Array.isArray(c) ? c.map((b) => b.text || '').join('') : null);
+      }
+    }
+  } catch (e) {
+    dlog('could not extract compact summary:', e?.message || e);
+  }
+  return null;
+}
+
+async function sendCompactSummary(send, sid) {
+  const summary = await extractCompactSummary(sid);
+  if (summary) {
+    dlog(`compact summary extracted (${summary.length} chars) → browser`);
+    send({ t: 'summary', text: summary });
   }
 }
 
@@ -274,6 +320,7 @@ async function autoCompact(send, sid, contextTokens) {
         dlog('context compacted', JSON.stringify(m.compact_metadata || {}));
         logEvent({ kind: 'compact', sessionId: sid, metadata: m.compact_metadata });
         send({ t: 'compact', metadata: m.compact_metadata });
+        await sendCompactSummary(send, sid);
       } else if (m.type === 'result') {
         logEvent({ kind: 'result', sessionId: sid, subtype: 'autocompact-' + m.subtype, turns: m.num_turns, costUsd: m.total_cost_usd, usage: m.usage });
       }

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -23,7 +23,15 @@ import { SYSTEM_PROMPT } from './prompt.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..'); // tools/studio-agent -> repo root
 const PORT = process.env.STUDIO_AGENT_PORT || 17891;
-const TOOL_TIMEOUT_MS = 120000;
+// Tool timeouts are measured from when the browser actually STARTS executing a
+// call (it acks with tool_started once the serial queue reaches it) — queue
+// wait must not count, or a cheap read_faust queued behind a heavy transpile
+// gets falsely timed out. Heavy tools (Faust transpile / full compile) run
+// 100s+ legitimately on big chains, so they get a much larger run budget.
+const TOOL_RUN_TIMEOUT_MS = 120000;            // normal tools, once started
+const HEAVY_TOOL_RUN_TIMEOUT_MS = 360000;      // write_faust / compile, once started
+const TOOL_START_TIMEOUT_MS = 600000;          // max time waiting in the browser queue
+const HEAVY_TOOLS = new Set(['write_faust', 'compile']);
 // Optional model override for speed/depth tradeoff, e.g. STUDIO_AGENT_MODEL=sonnet
 // (faster) vs opus (deeper). Unset = the SDK/Claude Code default.
 const MODEL = process.env.STUDIO_AGENT_MODEL || undefined;
@@ -80,14 +88,29 @@ let nextId = 1;
 function callBrowser(ws, name, args) {
   return new Promise((resolveCall, rejectCall) => {
     const id = nextId++;
-    pending.set(id, { resolve: resolveCall });
+    const runBudgetMs = HEAVY_TOOLS.has(name) ? HEAVY_TOOL_RUN_TIMEOUT_MS : TOOL_RUN_TIMEOUT_MS;
+    let timer = null;
+    const fail = (msg) => {
+      if (!pending.has(id)) return;
+      pending.delete(id);
+      rejectCall(new Error(msg));
+    };
+    const entry = {
+      resolve: (res) => { if (timer) clearTimeout(timer); pending.delete(id); resolveCall(res); },
+      // Browser acked that execution began (the serial queue reached this call):
+      // swap the queue-wait timer for the per-tool run timer.
+      started: () => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => fail(
+          `browser tool "${name}" timed out after ${runBudgetMs / 1000}s of execution. The browser may STILL be finishing it — do NOT resend the same call; verify the result first (e.g. read_faust / grep).`
+        ), runBudgetMs);
+      },
+    };
+    pending.set(id, entry);
     ws.send(JSON.stringify({ t: 'tool_call', id, name, args: args || {} }));
-    setTimeout(() => {
-      if (pending.has(id)) {
-        pending.delete(id);
-        rejectCall(new Error(`browser tool "${name}" timed out`));
-      }
-    }, TOOL_TIMEOUT_MS);
+    timer = setTimeout(() => fail(
+      `browser tool "${name}" did not start within ${TOOL_START_TIMEOUT_MS / 1000}s — earlier tool calls are still running in the browser queue. Do NOT retry; wait for them to finish.`
+    ), TOOL_START_TIMEOUT_MS);
   });
 }
 
@@ -143,9 +166,9 @@ function makeStudioServer(ws) {
       proxy('read_committed', 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use to restore something overwritten in the editor: read_committed then set_song/set_synth it back.', { path: z.string(), ref: z.string().optional() }),
       loadInto('load_synth_from_file', 'set_synth', 'synth'),
       loadInto('load_song_from_file', 'set_song', 'song'),
-      proxy('compile', 'Compile the current song+synth in the browser. Returns "compiled OK" or the exact compiler error. Call after every edit.', {}),
-      proxy('play', 'Start live audio playback in the browser (compiles first).', {}),
-      proxy('stop', 'Stop live audio playback.', {}),
+      proxy('compile', 'SAVE + compile the current song+synth in the browser (same as the app\'s save button). If a track is already playing, the changes are applied and audible immediately. Returns "compiled OK" or the exact compiler error. Call after every edit.', {}),
+      proxy('play', 'Start live audio playback in the browser. ONLY call this when the user explicitly asked to play/hear it — compile already applies changes to a playing track.', {}),
+      proxy('stop', 'Stop live audio playback. Only on the user\'s request.', {}),
     ],
   });
 }
@@ -187,6 +210,12 @@ async function handleChat(ws, { text, sessionId }) {
         dlog('session init', m.session_id?.slice(0, 8), 'tools:', (m.tools || []).length);
         logEvent({ kind: 'session', sessionId: sid, toolCount: (m.tools || []).length });
         send({ t: 'session', sessionId: m.session_id });
+      } else if (m.type === 'system' && m.subtype === 'compact_boundary') {
+        // The SDK compacted the conversation (auto near the context limit, or
+        // the user sent /compact). Surface it in the chat panel.
+        dlog('context compacted', JSON.stringify(m.compact_metadata || {}));
+        logEvent({ kind: 'compact', sessionId: sid, metadata: m.compact_metadata });
+        send({ t: 'compact', metadata: m.compact_metadata });
       } else if (m.type === 'assistant') {
         for (const block of m.message?.content ?? []) {
           if (block.type === 'text' && block.text) { dlog('text:', block.text.slice(0, 80).replace(/\n/g, ' ')); logEvent({ kind: 'text', sessionId: sid, text: block.text }); send({ t: 'text', text: block.text }); }
@@ -202,7 +231,9 @@ async function handleChat(ws, { text, sessionId }) {
         }
       } else if (m.type === 'result') {
         dlog('RESULT', m.subtype, 'turns:', m.num_turns, 'cost:', m.total_cost_usd);
-        logEvent({ kind: 'result', sessionId: sid, subtype: m.subtype, turns: m.num_turns, costUsd: m.total_cost_usd });
+        // usage carries the per-turn token counts (input incl. cache reads) —
+        // logged so growing context is visible when reviewing a session.
+        logEvent({ kind: 'result', sessionId: sid, subtype: m.subtype, turns: m.num_turns, costUsd: m.total_cost_usd, usage: m.usage });
         send({ t: 'done', subtype: m.subtype });
       }
     }
@@ -227,7 +258,10 @@ wss.on('connection', (ws) => {
     try { msg = JSON.parse(data.toString()); } catch { return; }
     if (msg.t === 'tool_result') {
       const p = pending.get(msg.id);
-      if (p) { pending.delete(msg.id); p.resolve(msg); }
+      if (p) p.resolve(msg);
+    } else if (msg.t === 'tool_started') {
+      const p = pending.get(msg.id);
+      if (p && typeof p.started === 'function') p.started();
     } else if (msg.t === 'chat') {
       handleChat(ws, msg);
     }

--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -1,5 +1,5 @@
 import { startWAM, postSong as wamPostSong, pauseWAMSong, onMidi as wamOnMidi, wamsynth, resumeWAMSong } from './webaudiomodules/wammanager.js';
-import { createAudioWorklet as createMidiSynthAudioWorklet, onmidi as midiSynthOnMidi, setBroadcastUiHandlers } from './synth1/audioworklet/midisynthaudioworklet.js';
+import { createAudioWorklet as createMidiSynthAudioWorklet, onmidi as midiSynthOnMidi, setBroadcastUiHandlers, releaseAudioWorklet } from './synth1/audioworklet/midisynthaudioworklet.js';
 import { visualizeNoteOn, clearVisualization, setUseDefaultVisualizer } from './visualizer/defaultvisualizer.js';
 import { setPaused } from './visualizer/midieventlistvisualizer.js';
 import { attachSeek, detachSeek } from './app.js';
@@ -171,6 +171,10 @@ export function initAudioWorkletNode(componentRoot) {
             detachSeek();
             audioworkletnode = null;
             window.audioworkletnode = null;
+            // The processor closes its port on terminate — release the
+            // midisynthaudioworklet module's references so a later save
+            // (updateSynth) doesn't await a reply that can never arrive.
+            releaseAudioWorklet();
         }
         playing = false;
         if (wamsynth) {

--- a/wasmaudioworklet/e2e/faust-editor.spec.js
+++ b/wasmaudioworklet/e2e/faust-editor.spec.js
@@ -446,6 +446,45 @@ test.describe('Faust editor — create, transpile, import, compile', () => {
         expect(opts).toEqual(['agentrefresh.dsp']);
     });
 
+    test('studio-agent compile saves + compiles without starting playback', async ({ page }) => {
+        // The agent's compile tool uses the app's save path (compileAndPostSong):
+        // a playing track picks up changes live, but when audio is stopped the
+        // tool must NOT start it — it just saves and compiles.
+        page.on('console', (m) => {
+            if (m.type() === 'error' || m.type() === 'warning') console.log('[browser]', m.type(), m.text());
+        });
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await page.goto('http://localhost:8080');
+        await setupServiceWorker(page);
+        await pushBaseline(page, repoName, SONG_SOURCE);
+        await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+        await waitForAppReady(page);
+
+        // Author instrument + wire synth + song entirely through agent tools.
+        const writeResult = await page.evaluate((source) =>
+            window.studioAgentRunTool('write_faust', { path: 'agentsave', source }),
+            FAUST_SOURCE);
+        expect(String(writeResult)).toContain('transpiled OK');
+        await page.evaluate((source) =>
+            window.studioAgentRunTool('set_synth', { source }),
+            SYNTH_MIX_SOURCE('agentsave'));
+        await page.evaluate((source) =>
+            window.studioAgentRunTool('set_song', { source }),
+            SONG_SOURCE);
+
+        const compileResult = await page.evaluate(() =>
+            window.studioAgentRunTool('compile'));
+        expect(compileResult).toBe('compiled OK');
+
+        // Compiled a synth wasm (proves the full save path ran)…
+        const wasmLength = await page.evaluate(() =>
+            window.WASM_SYNTH_BYTES ? window.WASM_SYNTH_BYTES.length : 0);
+        expect(wasmLength).toBeGreaterThan(1000);
+        // …but did NOT start audio.
+        const audioStarted = await page.evaluate(() => !!window.audioworkletnode);
+        expect(audioStarted).toBe(false);
+    });
+
     test('sub-folder layout: faust/<dir>/<dir>/main.dsp transpile + import works', async ({ page }) => {
         // Mirrors the user's vscode-prepared repo shape: a Faust file
         // nested several directories deep (e.g. faust/mysong/dsp/main.dsp).

--- a/wasmaudioworklet/e2e/studio-agent-mock.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-mock.spec.js
@@ -1,0 +1,204 @@
+import { test, expect } from '@playwright/test';
+import ws from 'ws';
+import {
+    NEAR_REPO_CONTRACT,
+    setupServiceWorker,
+    clearOPFS,
+    waitForAppReady,
+    pushBaseline,
+} from './near-git-helpers.js';
+
+// Studio-agent CLIENT tests with a MOCKED agent server (and thus a mocked
+// model): the test process runs the WebSocket server the in-app client
+// connects to, and plays the model's role by issuing tool_call messages.
+// This exercises the real browser tool registry end-to-end — OPFS writes,
+// Faust transpile, synth compile — without the Agent SDK or an API key.
+//
+// Motivated by a real session where the tools appeared to take minutes:
+// compile deadlocked after a play→stop cycle (updateSynth awaited a
+// `wasmloaded` reply from a TERMINATED audio worklet whose port is closed),
+// and every queued tool behind it (even an in-memory grep_synth) "ran"
+// forever. These tests pin down that agent-driven tool calls stay FAST.
+//
+// Requires the NEAR sandbox (`npm run near-sandbox`) — same prereq as
+// near-git.spec.js.
+
+const repoName = NEAR_REPO_CONTRACT + '.git';
+
+const FAUST_SOURCE = `import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate) <: _, _;
+`;
+
+const SYNTH_MIX_SOURCE = (basename) => `// uses midichannels (route via midi.mix)
+import { initializeMidiSynth, postprocess } from '../faust/${basename}';
+export { initializeMidiSynth, postprocess };
+`;
+
+const SONG_SOURCE = `setBPM(120);
+
+await createTrack(0).steps(4, [
+    c4,, e4,, g4,, c5,,
+]);
+
+loopHere();
+`;
+
+// ---- the mock agent server --------------------------------------------------
+// Speaks the same protocol as tools/studio-agent/server.mjs: sends tool_call,
+// receives tool_started acks and tool_result replies.
+function startMockAgentServer() {
+    const wss = new ws.Server({ port: 0 });
+    const state = { socket: null, nextId: 1, pending: new Map(), startedIds: new Set() };
+    // The app navigates twice during setup (service-worker boot, then the
+    // ?gitrepo= load), so the client connects twice — always track the newest
+    // socket and forget it when it closes, and let callers WAIT for a live one.
+    wss.on('connection', (socket) => {
+        state.socket = socket;
+        socket.on('close', () => { if (state.socket === socket) state.socket = null; });
+        socket.on('message', (data) => {
+            let msg;
+            try { msg = JSON.parse(data.toString()); } catch { return; }
+            if (msg.t === 'tool_result') {
+                const p = state.pending.get(msg.id);
+                if (p) { state.pending.delete(msg.id); p.resolve(msg); }
+            } else if (msg.t === 'tool_started') {
+                state.startedIds.add(msg.id);
+            }
+        });
+    });
+    const waitForClient = async (timeoutMs = 30000) => {
+        const t0 = Date.now();
+        while (!(state.socket && state.socket.readyState === ws.OPEN)) {
+            if (Date.now() - t0 > timeoutMs) throw new Error('no live studio-agent client connection');
+            await new Promise((r) => setTimeout(r, 100));
+        }
+    };
+    // Call a browser tool like the agent would; fails fast (default 30s) so a
+    // deadlocked tool queue surfaces as a clear assertion, not a spec timeout.
+    const callTool = (name, args, timeoutMs = 30000) => {
+        const id = state.nextId++;
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                state.pending.delete(id);
+                reject(new Error(`tool ${name} (id ${id}) did not reply within ${timeoutMs / 1000}s — browser tool queue is stuck`));
+            }, timeoutMs);
+            state.pending.set(id, { resolve: (msg) => { clearTimeout(timer); resolve(msg); } });
+            state.socket.send(JSON.stringify({ t: 'tool_call', id, name, args: args || {} }));
+        });
+    };
+    return {
+        wss, state, waitForClient, callTool,
+        port: () => wss.address().port,
+        close: () => new Promise((resolve) => wss.close(resolve)),
+    };
+}
+
+// Timed tool call: returns { msg, secs }.
+async function timedCall(mock, name, args, timeoutMs) {
+    const t0 = Date.now();
+    const msg = await mock.callTool(name, args, timeoutMs);
+    return { msg, secs: (Date.now() - t0) / 1000 };
+}
+
+async function openAppWithMockAgent(page, mock) {
+    // The client reads window.STUDIO_AGENT_PORT before connecting.
+    await page.addInitScript((port) => { window.STUDIO_AGENT_PORT = port; }, mock.port());
+    await page.goto('http://localhost:8080');
+    await setupServiceWorker(page);
+    await pushBaseline(page, repoName, SONG_SOURCE);
+    await page.goto(`http://localhost:8080/?gitrepo=${NEAR_REPO_CONTRACT}`);
+    await waitForAppReady(page);
+    await mock.waitForClient();
+}
+
+test.describe('studio-agent client with mocked agent server', () => {
+    let mock;
+
+    test.beforeEach(() => { mock = startMockAgentServer(); });
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, repoName);
+        await mock.close();
+    });
+
+    test('faust edit → transpile → compile → grep all complete fast', async ({ page }) => {
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await openAppWithMockAgent(page, mock);
+
+        // The model "edits the faust dsp": write_faust transpiles in-browser.
+        const wf = await timedCall(mock, 'write_faust', { path: 'mockmaster', source: FAUST_SOURCE });
+        expect(wf.msg.ok).toBe(true);
+        expect(String(wf.msg.result)).toContain('transpiled OK');
+        expect(wf.secs).toBeLessThan(30);
+
+        expect((await mock.callTool('set_synth', { source: SYNTH_MIX_SOURCE('mockmaster') })).ok).toBe(true);
+        expect((await mock.callTool('set_song', { source: SONG_SOURCE })).ok).toBe(true);
+
+        // compile = the app's save path; must return promptly.
+        const c = await timedCall(mock, 'compile', {});
+        expect(c.msg.ok).toBe(true);
+        expect(c.msg.result).toBe('compiled OK');
+        expect(c.secs).toBeLessThan(20);
+
+        // grep_synth is an in-memory regex — anything above a couple of
+        // seconds means the tool queue is blocked by an earlier call.
+        const g = await timedCall(mock, 'grep_synth', { pattern: 'initializeMidiSynth' });
+        expect(g.msg.ok).toBe(true);
+        expect(g.secs).toBeLessThan(3);
+
+        // The client acks execution start for every call (the server's
+        // queue-aware timeout depends on it).
+        expect(mock.state.startedIds.size).toBeGreaterThanOrEqual(5);
+    });
+
+    test('compile after a play→stop cycle does not deadlock the tool queue', async ({ page }) => {
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await openAppWithMockAgent(page, mock);
+
+        expect((await mock.callTool('write_faust', { path: 'mockmaster', source: FAUST_SOURCE })).ok).toBe(true);
+        expect((await mock.callTool('set_synth', { source: SYNTH_MIX_SOURCE('mockmaster') })).ok).toBe(true);
+        expect((await mock.callTool('set_song', { source: SONG_SOURCE })).ok).toBe(true);
+        expect((await mock.callTool('compile', {})).result).toBe('compiled OK');
+
+        // Start playback like the user does, then stop — stop terminates the
+        // worklet processor (which closes its message port).
+        await page.locator('#startaudiobutton').click();
+        await page.waitForFunction(() => !!window.audioworkletnode, { timeout: 30000 });
+        await page.locator('#stopaudiobutton').click();
+        await page.waitForFunction(() => !window.audioworkletnode, { timeout: 10000 });
+
+        // Change the instrument so the next compile produces a NEW synth wasm —
+        // that's what routes the save through updateSynth (an unchanged synth
+        // skips it, hiding the bug). Mirrors the real session: the user's .dsp
+        // edit, then compile.
+        expect((await mock.callTool('write_faust', {
+            path: 'mockmaster',
+            source: FAUST_SOURCE.replace('os.sawtooth(freq)', 'os.square(freq)'),
+        })).ok).toBe(true);
+
+        // Regression: this compile used to await a wasmloaded reply from the
+        // terminated worklet forever, deadlocking every tool queued after it.
+        const c = await timedCall(mock, 'compile', {});
+        expect(c.msg.ok).toBe(true);
+        expect(c.msg.result).toBe('compiled OK');
+        expect(c.secs).toBeLessThan(20);
+
+        // ...and the queue behind it stays responsive.
+        const g = await timedCall(mock, 'grep_synth', { pattern: 'initializeMidiSynth' }, 10000);
+        expect(g.msg.ok).toBe(true);
+        expect(g.secs).toBeLessThan(3);
+
+        // Saving must not have (re)started playback.
+        expect(await page.evaluate(() => !!window.audioworkletnode)).toBe(false);
+    });
+
+    test('there is no play tool — the agent cannot start playback', async ({ page }) => {
+        await openAppWithMockAgent(page, mock);
+        const res = await mock.callTool('play', {});
+        expect(res.ok).toBe(false);
+        expect(String(res.result)).toContain('unknown tool');
+        expect(await page.evaluate(() => !!window.audioworkletnode)).toBe(false);
+    });
+});

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -786,6 +786,12 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
         }
     }
 
+    // Exposed for the studio-agent: same as pressing "save" — saves + compiles
+    // and posts the new wasm/eventlist to the audio worklet, so a track that is
+    // already playing picks up the changes without restarting playback (and
+    // nothing starts playing when stopped).
+    window.saveSong = compileAndPostSong;
+
     let storedsongcode = localStorage.getItem('storedsongcode');
     let storedsynthcode = localStorage.getItem('storedsynthcode');
     let storedshadercode = null;

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -758,20 +758,28 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
                 return;
             }
 
+            // Snapshot BEFORE compiling: a save initiated while audio is
+            // stopped must never post to the worklet — not even one created
+            // by a concurrent startaudio while our compile was running.
+            // (Posting updateSong with toggleSongPlay=false to a worklet a
+            // racing startaudio just launched pauses its fresh playback.)
+            // The next startaudio picks up WASM_SYNTH_BYTES by itself.
+            const wasRunning = !!window.audioworkletnode;
+
             const song = await compileSong();
 
-            if (song.synthwasm) {
+            if (wasRunning && song.synthwasm) {
                 await updateSynth(song.synthwasm, addedAudio);
             }
 
             if (song.eventlist) {
                 if (song.synthsource) {
                     await wamPostSong(song.eventlist, song.synthsource);
-                } else {
+                } else if (wasRunning) {
                     updateSong(song.eventlist, componentRoot.getElementById('toggleSongPlayCheckbox').checked ? true : false);
                     webassemblySynthUpdated = false;
                 }
-            } else if (window.audioworkletnode) {
+            } else if (wasRunning && window.audioworkletnode) {
                 audioworkletnode.port.postMessage({
                     song: song,
                     samplerate: window.audioworkletnode.context.sampleRate,

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -51,6 +51,7 @@
         "http-server": "^14.1.1",
         "mocha": "^10.2.0",
         "rollup": "^4.1.5",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup-plugin-terser": "^7.0.2",
+        "ws": "^7.5.10"
     }
 }

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -21,22 +21,26 @@ let sessionId = null;
 let agentMsgEl = null; // the in-progress assistant message element
 let toolQueue = Promise.resolve(); // serialize tool execution (see tool_call below)
 let conversation = []; // [{ role: 'user' | 'agent', text }] persisted to the repo
-// Only the tail of the conversation is persisted/replayed — the SDK session
-// (resumed via sessionId, auto-compacted server-side) holds the real history;
-// this is just what the chat panel shows again after a reload.
-const MAX_SAVED_MESSAGES = 100;
+// Latest compact summary of the SDK session. Persisted to the repo so a clone
+// on ANOTHER machine (where the SDK's local session store is absent) can start
+// a fresh session seeded with this summary instead of from nothing. Note the
+// conversation array itself is NEVER sent to the model — only the latest chat
+// text goes out; history lives in the SDK session (kept small by compaction).
+let sessionSummary = null;
 
-// Persist the conversation + SDK session id into the OPFS repo so it survives a
-// reload (and travels with the project). No-op when not in ?gitrepo= mode.
+// Persist the conversation + SDK session id + compact summary into the OPFS
+// repo so it survives a reload (and travels with the project). The full
+// conversation is kept as project history — it is replay/reference only, so
+// its size costs repo bytes, not model context. No-op when not in ?gitrepo= mode.
 async function saveSession() {
-  if (conversation.length > MAX_SAVED_MESSAGES) conversation = conversation.slice(-MAX_SAVED_MESSAGES);
-  try { await writefileandstage(SESSION_FILE, JSON.stringify({ sessionId, conversation }, null, 1)); }
+  try { await writefileandstage(SESSION_FILE, JSON.stringify({ sessionId, summary: sessionSummary, conversation }, null, 1)); }
   catch (e) { /* no OPFS repo — in-memory only */ }
 }
 async function loadSession() {
   try {
     const data = JSON.parse(await readfile(SESSION_FILE));
     sessionId = data.sessionId || null;
+    sessionSummary = data.summary || null;
     conversation = Array.isArray(data.conversation) ? data.conversation : [];
     for (const m of conversation) addLine(m.role === 'user' ? 'user' : 'agent', m.text);
     if (conversation.length) { addLine('tool', `— resumed ${conversation.length} messages —`); }
@@ -218,6 +222,13 @@ async function onMessage(msg) {
     case 'compact': // the SDK compacted the session (auto, or the user sent /compact)
       addLine('tool', `— conversation compacted (${msg.metadata?.trigger || 'auto'}) —`);
       break;
+    case 'summary': // the compact summary text — persist it with the session
+      sessionSummary = msg.text || null;
+      saveSession();
+      break;
+    case 'freshsession': // resume failed (e.g. repo opened on another machine)
+      addLine('tool', '— previous session not on this machine; started fresh from the saved summary —');
+      break;
     case 'error':
       addLine('error', `⚠ ${msg.error}`);
       finishAgentMessage();
@@ -281,7 +292,9 @@ function sendChat(text) {
   startAgentMessage();
   setBusy(true);
   startActivity();
-  socket.send(JSON.stringify({ t: 'chat', text, sessionId }));
+  // summary rides along so the server can seed a FRESH session from it when
+  // the sessionId can't be resumed (SDK sessions are per-machine).
+  socket.send(JSON.stringify({ t: 'chat', text, sessionId, summary: sessionSummary }));
 }
 
 // ---- tiny UI helpers --------------------------------------------------------

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -212,6 +212,9 @@ async function onMessage(msg) {
       setBusy(false);
       break;
     }
+    case 'compacting': // server-initiated proactive /compact of a large session
+      addLine('tool', `— auto-compacting conversation (~${Math.round((msg.tokens || 0) / 1000)}k tokens of context)… —`);
+      break;
     case 'compact': // the SDK compacted the session (auto, or the user sent /compact)
       addLine('tool', `— conversation compacted (${msg.metadata?.trigger || 'auto'}) —`);
       break;

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -100,24 +100,38 @@ const registry = {
   },
   // Write a .dsp AND transpile it to AssemblyScript (same as the app's faust save):
   // persists faust/<name>.dsp + faust/<name>.ts and reports the generated classes.
+  // Per-step timings are logged + appended to the result: manual runs are ~1s but
+  // agent-driven runs have been observed at 47-111s, so we need to see WHICH step
+  // stalls (git-worker write? transpile? UI refresh?) and the tab visibility
+  // (a hidden tab throttles main-thread work like the faust transpile hard).
   write_faust: async ({ path, source }) => {
     const rel = normDsp(path);
     const stem = rel.replace(/\.dsp$/, '');
+    const t0 = performance.now();
+    const marks = [`visibility=${document.visibilityState}`];
+    let last = t0;
+    const mark = (label) => { const now = performance.now(); marks.push(`${label}=${((now - last) / 1000).toFixed(1)}s`); last = now; };
     try {
       await writefileandstage(FAUST_DIR + rel, source);
+      mark('write-dsp');
       let ts;
       try {
         ({ ts } = await transpileDspSource(source, rel, {}));
       } catch (e) {
         return { __error: `Faust transpile failed for ${rel}: ${e?.message || e}` };
       }
+      mark('transpile');
       await writefileandstage(FAUST_DIR + stem + '.ts', ts);
+      mark('write-ts');
       // refresh the app's Faust file dropdown so the user sees the new instrument
       if (typeof window.refreshFaustFileList === 'function') { try { await window.refreshFaustFileList(); } catch { /* non-fatal */ } }
       // and reflect the written .dsp in the editor even when it's the file already
       // on screen (dropdown refresh alone won't reload the current selection).
       if (typeof window.showFaustFileInEditor === 'function') { try { await window.showFaustFileInEditor(FAUST_DIR + rel); } catch { /* non-fatal */ } }
-      return faustRegistrationHint(ts, stem).message;
+      mark('ui-refresh');
+      const timing = `${((performance.now() - t0) / 1000).toFixed(1)}s total (${marks.join(', ')})`;
+      console.log(`[studio-agent] write_faust ${rel}: ${timing}`);
+      return `${faustRegistrationHint(ts, stem).message} [timing: ${timing}]`;
     } catch (e) { return faustUnavailable(e); }
   },
   compile: async () => {
@@ -217,15 +231,27 @@ async function runTool({ id, name, args }) {
   if (socket && socket.readyState === WebSocket.OPEN) {
     socket.send(JSON.stringify({ t: 'tool_started', id }));
   }
+  // Timing diagnostics: agent-driven tools have been observed 50-100x slower
+  // than the same operations run manually — log duration + tab visibility per
+  // tool so the stalling layer is identifiable in the browser console.
+  const t0 = performance.now();
+  const vis0 = document.visibilityState;
+  const finish = (ok) => {
+    const secs = (performance.now() - t0) / 1000;
+    if (secs > 2) console.warn(`[studio-agent] ${shortName(name)} took ${secs.toFixed(1)}s (${ok ? 'ok' : 'error'}, visibility ${vis0}→${document.visibilityState})`);
+  };
   try {
     const result = await fn(args || {});
     if (result && result.__error) {
+      finish(false);
       addLine('error', `✗ ${shortName(name)}: ${result.__error}`);
       reply(id, false, result.__error);
     } else {
+      finish(true);
       reply(id, true, result);
     }
   } catch (e) {
+    finish(false);
     const emsg = String(e?.message || e);
     addLine('error', `✗ ${shortName(name)}: ${emsg}`);
     reply(id, false, emsg);

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -21,10 +21,15 @@ let sessionId = null;
 let agentMsgEl = null; // the in-progress assistant message element
 let toolQueue = Promise.resolve(); // serialize tool execution (see tool_call below)
 let conversation = []; // [{ role: 'user' | 'agent', text }] persisted to the repo
+// Only the tail of the conversation is persisted/replayed — the SDK session
+// (resumed via sessionId, auto-compacted server-side) holds the real history;
+// this is just what the chat panel shows again after a reload.
+const MAX_SAVED_MESSAGES = 100;
 
 // Persist the conversation + SDK session id into the OPFS repo so it survives a
 // reload (and travels with the project). No-op when not in ?gitrepo= mode.
 async function saveSession() {
+  if (conversation.length > MAX_SAVED_MESSAGES) conversation = conversation.slice(-MAX_SAVED_MESSAGES);
   try { await writefileandstage(SESSION_FILE, JSON.stringify({ sessionId, conversation }, null, 1)); }
   catch (e) { /* no OPFS repo — in-memory only */ }
 }
@@ -117,7 +122,11 @@ const registry = {
   },
   compile: async () => {
     try {
-      await window.compileSong();
+      // Same as the app's save button: saves + compiles AND applies the new
+      // wasm/eventlist to the audio worklet, so a track that is already
+      // playing becomes audible with the changes — without starting playback
+      // when stopped.
+      await window.saveSong();
     } catch (e) {
       return { __error: String(e?.message || e) };
     }
@@ -187,6 +196,9 @@ async function onMessage(msg) {
       setBusy(false);
       break;
     }
+    case 'compact': // the SDK compacted the session (auto, or the user sent /compact)
+      addLine('tool', `— conversation compacted (${msg.metadata?.trigger || 'auto'}) —`);
+      break;
     case 'error':
       addLine('error', `⚠ ${msg.error}`);
       finishAgentMessage();
@@ -199,6 +211,12 @@ async function onMessage(msg) {
 async function runTool({ id, name, args }) {
   const fn = registry[name];
   if (!fn) return reply(id, false, `unknown tool ${name}`);
+  // Tell the server execution has actually begun (the serial queue may have
+  // held this call for a while) — its run-timeout is armed from this moment,
+  // so a call waiting behind a heavy Faust transpile isn't falsely timed out.
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ t: 'tool_started', id }));
+  }
   try {
     const result = await fn(args || {});
     if (result && result.__error) {
@@ -263,10 +281,12 @@ function finishAgentMessage() { agentMsgEl = null; }
 const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 let activityTimer = null;
 let turnStartMs = 0;
+let phaseStartMs = 0;
 let activityPhase = '';
 let spinIdx = 0;
 function startActivity() {
   turnStartMs = Date.now();
+  phaseStartMs = turnStartMs;
   activityPhase = 'thinking…';
   const s = el('studioagentstatus');
   if (s) { s.classList.add('working'); s.classList.remove('idle'); }
@@ -274,11 +294,14 @@ function startActivity() {
   activityTimer = setInterval(renderActivity, 150);
   renderActivity();
 }
-function setPhase(p) { activityPhase = p; if (activityTimer) renderActivity(); }
+function setPhase(p) { activityPhase = p; phaseStartMs = Date.now(); if (activityTimer) renderActivity(); }
 function renderActivity() {
   spinIdx = (spinIdx + 1) % SPIN.length;
   const secs = Math.floor((Date.now() - turnStartMs) / 1000);
-  setStatus(`${SPIN[spinIdx]} ${activityPhase}  ${secs}s`);
+  const phaseSecs = Math.floor((Date.now() - phaseStartMs) / 1000);
+  // Per-phase elapsed first (what THIS step has taken), turn total after —
+  // "running compile… 751s" used to show turn time under the last tool's name.
+  setStatus(`${SPIN[spinIdx]} ${activityPhase} ${phaseSecs}s · ${secs}s total`);
 }
 function stopActivity(msg) {
   if (activityTimer) { clearInterval(activityTimer); activityTimer = null; }

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -147,7 +147,9 @@ const registry = {
     const err = readErrorPanel();
     return err ? { __error: err } : 'compiled OK';
   },
-  play: async () => { await window.startaudio(); return 'playing'; },
+  // NOTE: intentionally NO `play` tool — starting playback is the user's
+  // action (play button). The agent saves via `compile`; a playing track
+  // picks the changes up live.
   stop: async () => { window.stopaudio(); return 'stopped'; },
 };
 

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -241,6 +241,10 @@ async function runTool({ id, name, args }) {
   const finish = (ok) => {
     const secs = (performance.now() - t0) / 1000;
     if (secs > 2) console.warn(`[studio-agent] ${shortName(name)} took ${secs.toFixed(1)}s (${ok ? 'ok' : 'error'}, visibility ${vis0}→${document.visibilityState})`);
+    // The tool is done in the browser — anything from here on is the model
+    // reading the result. Without this, the status keeps blaming the last
+    // tool ("running grep_song… 51s") for what is model thinking time.
+    setPhase('thinking…');
   };
   try {
     const result = await fn(args || {});

--- a/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
+++ b/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
@@ -172,9 +172,12 @@ export async function getRecordedData() {
 }
 
 export async function getCurrentTime() {
-    // A current-time poll may still tick right after stopaudio released the
-    // worklet — report 0 instead of dereferencing the cleared handler.
-    if (!workerMessageHandler) return 0;
+    // A current-time poll may still tick after stopaudio released the worklet.
+    // null is the visualizer's "no clock" protocol: it clears the display and
+    // stops polling. (Returning a number here replays/holds the STALE song's
+    // notes in the visualizer — reporting 0 rewound it to the top and re-lit
+    // old notes in the target note states.)
+    if (!workerMessageHandler) return null;
     const currentTime = (await workerMessageHandler.callAndGetResult({ currentTime: true },
         (msgdata) => msgdata.currentTime !== undefined ? true : false))
         .currentTime;

--- a/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
+++ b/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
@@ -60,18 +60,25 @@ export async function updateSynth(synthwasm, addedAudio) {
     // window.WASM_SYNTH_BYTES anyway.
     if (!audioworkletnode) return;
     audioworkletnode.context.suspend();
+    // Bounded wait: if the worklet can't reply (e.g. it terminated between
+    // the check above and the post), fail the save instead of hanging it.
+    // The timer MUST be cleared on the normal path — a leftover timeout
+    // firing later rejects the losing race promise unhandled, which wedges
+    // test runners (Firefox wtr) and pollutes the console.
+    let timer = null;
     try {
-        // Bounded wait: if the worklet can't reply (e.g. it terminated between
-        // the check above and the post), fail the save instead of hanging it.
         await Promise.race([
             workerMessageHandler.callAndGetResult({
                 wasm: synthwasm,
                 audio: await Promise.all(addedAudio)
             }, (msg) => msg.wasmloaded),
-            new Promise((_, reject) => setTimeout(() =>
-                reject(new Error('updateSynth: no wasmloaded reply from the audio worklet within 20s')), 20000))
+            new Promise((_, reject) => {
+                timer = setTimeout(() =>
+                    reject(new Error('updateSynth: no wasmloaded reply from the audio worklet within 20s')), 20000);
+            })
         ]);
     } finally {
+        if (timer) clearTimeout(timer);
         if (audioworkletnode) audioworkletnode.context.resume();
     }
 }

--- a/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
+++ b/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.js
@@ -35,7 +35,18 @@ export function onmidi(data) {
     });
 }
 
+// Stop path: the processor was told to terminate (it closes its message port),
+// so the node and message handler here are dead. They MUST be released —
+// posting to the closed port can never get a reply, and updateSynth awaiting
+// `wasmloaded` on it would hang forever (deadlocking e.g. the studio-agent's
+// serial tool queue behind a save that never resolves).
+export function releaseAudioWorklet() {
+    audioworkletnode = null;
+    workerMessageHandler = null;
+}
+
 export async function updateSong(sequencedata, toggleSongPlay) {
+    if (!audioworkletnode) return; // audio not running — nothing to update live
     audioworkletnode.port.postMessage({
         sequencedata: sequencedata,
         toggleSongPlay: toggleSongPlay
@@ -45,12 +56,24 @@ export async function updateSong(sequencedata, toggleSongPlay) {
 }
 
 export async function updateSynth(synthwasm, addedAudio) {
+    // Audio not running: nothing to swap live — the next startaudio picks up
+    // window.WASM_SYNTH_BYTES anyway.
+    if (!audioworkletnode) return;
     audioworkletnode.context.suspend();
-    await workerMessageHandler.callAndGetResult({
-        wasm: synthwasm,
-        audio: await Promise.all(addedAudio)
-    }, (msg) => msg.wasmloaded);
-    audioworkletnode.context.resume();
+    try {
+        // Bounded wait: if the worklet can't reply (e.g. it terminated between
+        // the check above and the post), fail the save instead of hanging it.
+        await Promise.race([
+            workerMessageHandler.callAndGetResult({
+                wasm: synthwasm,
+                audio: await Promise.all(addedAudio)
+            }, (msg) => msg.wasmloaded),
+            new Promise((_, reject) => setTimeout(() =>
+                reject(new Error('updateSynth: no wasmloaded reply from the audio worklet within 20s')), 20000))
+        ]);
+    } finally {
+        if (audioworkletnode) audioworkletnode.context.resume();
+    }
 }
 
 async function connectAudioWorklet(context, wasm_synth_bytes, sequencedata, toggleSongPlay) {
@@ -135,12 +158,16 @@ export async function createAudioWorklet(context, wasm_synth_bytes, sequencedata
 }
 
 export async function getRecordedData() {
+    if (!workerMessageHandler) return [];
     return (await workerMessageHandler.callAndGetResult({ recorded: true },
         (msgdata) => msgdata.recorded ? true : false))
         .recorded;
 }
 
 export async function getCurrentTime() {
+    // A current-time poll may still tick right after stopaudio released the
+    // worklet — report 0 instead of dereferencing the cleared handler.
+    if (!workerMessageHandler) return 0;
     const currentTime = (await workerMessageHandler.callAndGetResult({ currentTime: true },
         (msgdata) => msgdata.currentTime !== undefined ? true : false))
         .currentTime;

--- a/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.spec.js
+++ b/wasmaudioworklet/synth1/audioworklet/midisynthaudioworklet.spec.js
@@ -365,7 +365,15 @@ describe('midisynth audio worklet', async function () {
             ]);
         `);
         synthsourceeditor.doc.setValue(synthsource + ' ');
+        // Save (while stopped), and WAIT for its compile to produce the new
+        // wasm before starting: clicking save+start unawaited raced two
+        // concurrent compileSong runs against each other, and pass/fail
+        // depended on which one's synth compile won (flaky on slow CI).
+        window.WASM_SYNTH_BYTES = null;
         appElement.querySelector('#savesongbutton').click();
+        while (!window.WASM_SYNTH_BYTES) {
+            await new Promise(resolve => setTimeout(resolve, 50));
+        }
         appElement.querySelector('#startaudiobutton').click();
 
         const expectedNotes = [
@@ -378,8 +386,11 @@ describe('midisynth audio worklet', async function () {
         for (let n = 0; n < expectedNotes.length; n++) {
             const nextExpectedNote = expectedNotes[n];
             console.log('expecting note in visualizer', nextExpectedNote);
+            // Poll at 50ms — a setTimeout(0) busy-loop starves the Firefox
+            // main thread while the audio pipeline is under load (notes are
+            // 2s apart at BPM 30, so 50ms is plenty of resolution).
             while (getTargetNoteStates()[nextExpectedNote] === -1) {
-                await new Promise(r => setTimeout(r, 0));
+                await new Promise(r => setTimeout(r, 50));
             }
             assert.approximately(getTargetNoteStates()[nextExpectedNote], 1.0, 0.1);
         }

--- a/wasmaudioworklet/web-test-runner.config.js
+++ b/wasmaudioworklet/web-test-runner.config.js
@@ -8,7 +8,11 @@ export default {
   ],
   concurrency: 1,
   watch: false,
-  testsFinishTimeout: 60000,
+  // midisynthaudioworklet.spec.js waits on real-time audio (hotswap decay,
+  // sequence playback, live MIDI recording) and runs ~30s locally on Firefox —
+  // on slower CI runners 60s had no headroom and the file timed out while all
+  // of its tests were passing.
+  testsFinishTimeout: 180000,
   testRunnerHtml: testRunnerImport =>
     `<html>
       <body>

--- a/wasmaudioworklet/wtr-firefox.config.js
+++ b/wasmaudioworklet/wtr-firefox.config.js
@@ -1,0 +1,27 @@
+// Temporary Firefox-only wtr config for local debugging of the CI-only
+// Firefox hang in midisynthaudioworklet.spec.js. Not used by CI.
+import { playwrightLauncher } from '@web/test-runner-playwright';
+import base from './web-test-runner.config.js';
+
+export default {
+  ...base,
+  browsers: [
+    playwrightLauncher({
+      product: 'firefox', launchOptions: {
+        headless: true,
+        firefoxUserPrefs: {
+          'media.autoplay.block-webaudio': false,
+          'media.autoplay.default': 0,
+          'media.autoplay.allow-extension-background-pages': true,
+          'media.autoplay.blocking_policy': 0,
+          'dom.require_user_interaction_for_audio': false,
+          'dom.audiochannel.mutedByDefault': false,
+          'dom.webmidi.enabled': true,
+          'midi.testing': true,
+          'webgl.force-enabled': true,
+          'webgl.disabled': false
+        }
+      }
+    }),
+  ],
+};


### PR DESCRIPTION
## 1. Never auto-play — `play` tool REMOVED; compile behaves like the save button

The agent's `compile` tool now uses the app's save path (new `window.saveSong` = `compileAndPostSong`): a **playing** track picks up the new wasm/eventlist audibly; when stopped, nothing starts. The `play` tool is removed entirely (client registry + server + prompt) — a resumed session full of old compile→play patterns can override prompt instructions, so no tool means no auto-play, ever. `stop` remains (user-requested stops only).

## 2. Audio worklet deadlock: save-after-stop hung forever (root cause of "compile 751s")

Even in-memory `grep_synth` "ran" forever — the serial tool queue was deadlocked behind `compile`. Root cause: `stopaudio` terminates the worklet processor (which **closes its message port**) but left `midisynthaudioworklet.js`'s module-level `audioworkletnode`/`workerMessageHandler` pointing at the dead node. A later save with a changed synth ran `updateSynth`, whose `callAndGetResult` awaited a `wasmloaded` reply that could never arrive — `compileAndPostSong` hung forever. The app's own save button had the same latent hang.

Fixes:
- `stopaudio` → `releaseAudioWorklet()` (clears the module refs); `updateSynth`/`updateSong` no-op when audio isn't running; the worklet wait is bounded (20s, timer cleared, `context.resume` in `finally`).
- A save initiated **while stopped** never posts to a worklet — not even one a concurrent `startaudio` created while the save's compile was running (posting `updateSong(toggleSongPlay=false)` to a freshly started worklet paused its playback).
- **`getCurrentTime` returns `null`** (the visualizer's "no clock" protocol → clear display, stop polling) when the worklet is released. Returning a number replayed/held the **stale previous song's notes** in the event-list visualizer (rewinding to 0 re-lit old notes in the target note states) — on master the poll hung forever on the closed port, which accidentally parked the visualizer; the deadlock fix removed that accidental protection. This was the true cause of the CI-Firefox wtr failure.

## 3. Queue-aware tool timeouts + honest status

Timeouts arm when the browser **starts** a call (`tool_started` ack), not when queued; heavy tools (`write_faust`/`compile`) get a 360s run budget; timeout messages + prompt tell the agent not to resend a timed-out heavy call. The chat status shows per-phase elapsed + turn total, resets to "thinking…" when a tool finishes (model thinking time was being blamed on the last tool — "running grep_song… 51s" while grep executed in 0.0s), and per-tool timing diagnostics log to the console (>2s) with tab visibility.

## 4. Session compaction: proactive auto-compact, summary in the repo, cross-machine resume

The SDK only auto-compacts near the context LIMIT (~1M on opus) — far beyond where turns get slow (a ~570k-token session thought 35–80s per stretch at $1–6/turn). Now:
- The server reads each assistant message's usage (= current context footprint) and runs `/compact` on the session right after any turn ending above `STUDIO_AGENT_COMPACT_THRESHOLD` (default 200k), while the user reads the reply; chat turns are serialized so a message sent during compaction waits. `/compact` typed in chat also passes through; the panel announces both phases.
- After any compaction the server extracts the summary from the SDK session store (`isCompactSummary` entry) and the client persists it into `studioagent-session.json` — the **full conversation history stays in the repo** (it is never sent to the model; only the latest chat text + the SDK session go out).
- When a chat's `sessionId` can't be resumed (repo opened on another machine — SDK sessions are per-machine), the server starts a **fresh session seeded with the saved summary**.

## Tests

- New **`e2e/studio-agent-mock.spec.js`**: the test process runs a mock agent server speaking the real WS protocol — it mocks the **model/server side** while driving the REAL in-app client and tools (OPFS writes, Faust transpile, synth compile). Covers: a full mocked model turn (faust edit → transpile → compile → grep, all fast); compile after a play→stop cycle does not deadlock the tool queue (**fails without the fix**); the `play` tool is absent and saving never starts playback.
- wtr: `midisynthaudioworklet.spec.js` made deterministic (save's compile awaited before start — it was racing two concurrent `compileSong` runs) and load-hardened (50ms polls instead of a `setTimeout(0)` busy-loop); `testsFinishTimeout` 60s→180s (the file runs ~30s on Firefox with zero CI headroom); `wtr-firefox.config.js` added for running the Firefox launcher alone locally.
- The CI-Firefox failure was reproduced and bisected in a CI-replica container (playwright-jammy + pulseaudio + xvfb, per `.github/workflows/main.yml`).
- Suites: wtr 52/52 on Chromium AND Firefox, e2e studio-agent-mock 3/3, faust-editor 7/7, save-then-play 1/1, unit 12/12 — all CI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
