### PR TITLE
MIDI-sequencer starter as default song + auto workspace repo on landing

### DIFF
--- a/wasmaudioworklet/e2e/default-workspace.spec.js
+++ b/wasmaudioworklet/e2e/default-workspace.spec.js
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { clearOPFS, waitForAppReady } from './near-git-helpers.js';
+
+// Landing with no content source (no ?gitrepo/?gist, empty localStorage)
+// boots a local-only OPFS "workspace" repo seeded with the MIDI-sequencer
+// starter — the format the studio agent is tuned for — instead of the old
+// storage-less pattern-sequencer default. On localhost this behavior is
+// opt-in via ?defaultrepo (production hosts get it automatically), so the
+// other suites keep the classic boot. Needs NO NEAR sandbox: the workspace
+// repo is purely local.
+
+test('first visit boots a workspace repo with the MIDI starter; work survives reload', async ({ page }) => {
+    test.setTimeout(240000);
+    page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+
+    await page.goto('http://localhost:8080/?defaultrepo=1');
+    // wasmgit-ui appearing proves the workspace repo mode engaged.
+    await waitForAppReady(page);
+
+    // MIDI-sequencer starter in both editors (not the legacy pattern format).
+    const song = await page.evaluate(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue());
+    expect(song).toContain('setBPM');
+    expect(song).toContain('createTrack');
+    expect(song).not.toContain('playPatterns');
+    const synth = await page.evaluate(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#assemblyscripteditor .CodeMirror').CodeMirror.getValue());
+    expect(synth).toContain('midichannels');
+    expect(synth).toContain('initializeMidiSynth');
+
+    // The starter actually compiles to a synth wasm.
+    await page.evaluate(() => { window.WASM_SYNTH_BYTES = null; });
+    await page.locator('#savesongbutton').click();
+    await page.waitForFunction(() => window.WASM_SYNTH_BYTES != null, { timeout: 120000 });
+    expect(await page.evaluate(() => window.WASM_SYNTH_BYTES.length)).toBeGreaterThan(1000);
+
+    // Edit + save → persists in the OPFS repo across a reload (localStorage
+    // is NOT involved in repo mode — this is real workspace persistence).
+    await page.evaluate(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror
+        .setValue('setBPM(95); // my persistent workspace edit\n\nawait createTrack(0).steps(4, [c5,,,,]);\n\nloopHere();\n'));
+    await page.locator('#savesongbutton').click();
+    await page.waitForTimeout(1000); // async OPFS write inside compileSong
+
+    await page.goto('http://localhost:8080/?defaultrepo=1');
+    await waitForAppReady(page);
+    const reloaded = await page.evaluate(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue());
+    expect(reloaded).toContain('my persistent workspace edit');
+
+    await clearOPFS(page, 'workspace.git');
+    await clearOPFS(page, 'workspace');
+});
+
+test('without the opt-in, localhost keeps the classic no-repo boot with the MIDI starter', async ({ page }) => {
+    await page.goto('http://localhost:8080/');
+    await page.waitForFunction(() => {
+        const app = document.querySelector('app-javascriptmusic');
+        return app && app.shadowRoot && app.shadowRoot.querySelector('#editor .CodeMirror');
+    }, { timeout: 30000 });
+    // give the async default-template fetch a moment
+    await page.waitForFunction(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue().length > 0, { timeout: 15000 });
+
+    const song = await page.evaluate(() => document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue());
+    expect(song).toContain('setBPM');          // midi starter here too
+    expect(song).not.toContain('playPatterns');
+    // no repo UI in classic mode
+    expect(await page.evaluate(() => !!document.querySelector('app-javascriptmusic')
+        .shadowRoot.querySelector('wasmgit-ui'))).toBe(false);
+});

--- a/wasmaudioworklet/e2e/default-workspace.spec.js
+++ b/wasmaudioworklet/e2e/default-workspace.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clearOPFS, waitForAppReady } from './near-git-helpers.js';
+import { clearOPFS, waitForAppReady, readRepoFile } from './near-git-helpers.js';
 
 // Landing with no content source (no ?gitrepo/?gist, empty localStorage)
 // boots a local-only OPFS "workspace" repo seeded with the MIDI-sequencer
@@ -40,10 +40,23 @@ test('first visit boots a workspace repo with the MIDI starter; work survives re
         .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror
         .setValue('setBPM(95); // my persistent workspace edit\n\nawait createTrack(0).steps(4, [c5,,,,]);\n\nloopHere();\n'));
     await page.locator('#savesongbutton').click();
-    await page.waitForTimeout(1000); // async OPFS write inside compileSong
+    // The OPFS write inside compileSong is fire-and-forget — poll the repo
+    // file (via a fresh worker, like the near-git specs) until it landed
+    // before reloading, or the write could be lost mid-flight on slow CI.
+    await expect.poll(async () =>
+        (await readRepoFile(page, 'workspace', 'song.js'))
+        || (await readRepoFile(page, 'workspace.git', 'song.js'))
+        || '',
+    { timeout: 60000, intervals: [1000] }).toContain('my persistent workspace edit');
 
     await page.goto('http://localhost:8080/?defaultrepo=1');
     await waitForAppReady(page);
+    // Boot populates the editor asynchronously — wait for content.
+    await page.waitForFunction(() => {
+        const cm = document.querySelector('app-javascriptmusic')
+            .shadowRoot.querySelector('#editor .CodeMirror');
+        return cm && cm.CodeMirror.getValue().length > 0;
+    }, { timeout: 30000 });
     const reloaded = await page.evaluate(() => document.querySelector('app-javascriptmusic')
         .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue());
     expect(reloaded).toContain('my persistent workspace edit');

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -805,11 +805,25 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
     let storedshadercode = null;
 
     const gistparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('gist=') === 0) : null;
-    const gitrepoparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('gitrepo=') === 0) : null;
+    let gitrepoparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('gitrepo=') === 0) : null;
     const pngurlparam = location.search ? location.search.substring(1).split('&').find(param => param.indexOf('pngurl=') === 0) : null;
     // Optional override for the git origin remote (any git-http URL). Parsed via
     // URLSearchParams so a remote URL containing '=' / ':' survives decoding.
     const remoteparam = new URLSearchParams(location.search).get('remote');
+
+    // Landing with NO content source at all (no gitrepo/gist/pngurl and no
+    // previously stored localStorage work): boot into a local-only OPFS
+    // "workspace" repo instead of the storage-less localStorage mode — that
+    // gives new users persistence, Faust instrument authoring and studio-agent
+    // session storage out of the box. Gated off localhost so dev servers and
+    // the test suites keep the classic no-repo boot (opt in via ?defaultrepo).
+    const wantsDefaultRepo = location.hostname !== 'localhost'
+        || new URLSearchParams(location.search).has('defaultrepo');
+    if (!gitrepoparam && !gistparam && !pngurlparam && !storedsongcode
+        && wantsDefaultRepo
+        && typeof navigator.storage?.getDirectory === 'function') {
+        gitrepoparam = 'gitrepo=workspace';
+    }
 
     if (gistparam) {
         const gistid = gistparam.split('=')[1];
@@ -932,13 +946,15 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
     if (storedsongcode) {
         songsourceeditor.doc.setValue(storedsongcode);
     } else {
-        songsourceeditor.doc.setValue(await fetch('emptysong.js').then(r => r.text()));
+        // MIDI-sequencer starter (the format the studio agent is tuned for) —
+        // the legacy pattern-sequencer template lives on in emptysong.js.
+        songsourceeditor.doc.setValue(await fetch('emptysong-midi.js').then(r => r.text()));
     }
 
     if (storedsynthcode) {
         synthsourceeditor.doc.setValue(storedsynthcode);
     } else {
-        synthsourceeditor.doc.setValue(await fetch('synth1/assembly/mixes/empty.mix.ts').then(r => r.text()));
+        synthsourceeditor.doc.setValue(await fetch('synth1/assembly/mixes/emptymidi.mix.ts').then(r => r.text()));
     }
     if (storedshadercode) {
         shadersourceeditor.doc.setValue(storedshadercode);

--- a/wasmaudioworklet/emptysong-midi.js
+++ b/wasmaudioworklet/emptysong-midi.js
@@ -1,0 +1,10 @@
+setBPM(120);
+
+addInstrument('piano');
+
+await createTrack(0).steps(4, [
+    c5,, e5,, g5,, e5,,
+    c5,, f5,, a5,, f5,,
+]);
+
+loopHere();

--- a/wasmaudioworklet/synth1/assembly/mixes/emptymidi.mix.ts
+++ b/wasmaudioworklet/synth1/assembly/mixes/emptymidi.mix.ts
@@ -1,0 +1,31 @@
+import { midichannels, MidiChannel, MidiVoice, SineOscillator, Envelope, notefreq } from './globalimports';
+
+class Piano extends MidiVoice {
+    osc: SineOscillator = new SineOscillator();
+    env: Envelope = new Envelope(0.01, 0.1, 0.7, 0.2);
+
+    noteon(note: u8, velocity: u8): void {
+        super.noteon(note, velocity);
+        this.osc.frequency = notefreq(note);
+        this.env.attack();
+    }
+
+    noteoff(): void {
+        this.env.release();
+    }
+
+    isDone(): boolean {
+        return this.env.isDone();
+    }
+
+    nextframe(): void {
+        const signal = this.osc.next() * this.env.next() * this.velocity / 256;
+        this.channel.signal.add(signal, signal);
+    }
+}
+
+export function initializeMidiSynth(): void {
+    midichannels[0] = new MidiChannel(8, (channel: MidiChannel) => new Piano(channel));
+}
+
+export function postprocess(): void {}


### PR DESCRIPTION
Two onboarding fixes for the deployed app:

## 1. Default song is now the MIDI-sequencer format

The empty-song fallback was the legacy pattern-sequencer template (`emptysong.js` / `empty.mix.ts`) — the format the studio agent's prompt is *not* tuned for. New starters:
- **`emptysong-midi.js`** — `setBPM` / `addInstrument` / `await createTrack(0).steps(...)` / `loopHere()`
- **`mixes/emptymidi.mix.ts`** — a sine `Piano` MidiVoice on channel 0 (proven to compile to wasm in the new e2e)

Applies to both no-repo boots and freshly created empty repos. Legacy templates remain in the tree; the pattern format itself stays fully supported for existing songs.

## 2. Landing without `?gitrepo` boots a local "workspace" repo

Previously: no `?gitrepo` ⇒ localStorage-only mode — **no OPFS**, no `faust/` (so the agent's `write_faust` is unavailable), no agent-session persistence. Now a first visit with no content source (no `?gitrepo`/`?gist`/`?pngurl`, empty localStorage) boots a **local-only OPFS `workspace` repo**: persistence, Faust authoring, agent sessions, Commit & Sync UI — out of the box, no NEAR account needed.

Guard rails:
- Gated off `localhost` (opt-in via `?defaultrepo`) so dev servers and the wtr/e2e suites keep the classic boot.
- Users with existing localStorage work keep the classic boot — nothing silently migrates.

## Tests

New `e2e/default-workspace.spec.js` (no NEAR sandbox needed — the repo is purely local): workspace boots with the MIDI starter (not `playPatterns`), the starter **compiles to a real synth wasm**, an edit+save **survives reload via OPFS**, and the classic localhost boot still has no repo UI while getting the MIDI starter. Full suites green: wtr 52/52 on Chromium and Firefox, e2e 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)