### PR TITLE
Remove live network call from the NEAR AI proxy test

### DIFF
--- a/wasmaudioworklet/nearai-proxy.test.mjs
+++ b/wasmaudioworklet/nearai-proxy.test.mjs
@@ -35,8 +35,7 @@ test('OPTIONS preflight → 204 with CORS', async () => {
 });
 
 test('missing NEARAI_API_KEY secret → 503 with a clear message', async () => {
-  const res = await onRequest(chat({ messages: [] }, {}, ));
-  // rebuild with empty env
+  // empty env — no key, so this returns before any upstream call
   const res2 = await onRequest(ctx('POST', '/nearai/v1/chat/completions',
     { Origin: APP, 'Content-Type': 'application/json' }, '{"messages":[]}', {}));
   assert.equal(res2.status, 503);


### PR DESCRIPTION
## Why

CI went red on master ([run 30146498761](https://github.com/petersalomonsen/javascriptmusic/actions/runs/30146498761)) for a reason unrelated to the commit under test (#175). One failure, in the `Unit tests (node:test)` job:

```
not ok 21 - missing NEARAI_API_KEY secret → 503 with a clear message
  error: 'fetch failed'
  name: 'TypeError'
  async onRequest (.../functions/nearai/[[path]].js:116:28)
```

The test opened with a stray call whose result was never used:

```js
const res = await onRequest(chat({ messages: [] }, {}, ));
```

`chat()` builds its context from the default `ENV`, which *does* carry `NEARAI_API_KEY: 'SERVER_KEY'`, so it sailed past the 503 branch the test is about and ran the full happy path down to the upstream `fetch`. Being the second test in the file, it ran before any `captureFetch()` had replaced `globalThis.fetch` — so the call was live:

```
OUTBOUND FETCH -> https://cloud-api.near.ai/v1/chat/completions
```

Since #171 landed, every CI run has been sending a real chat/completions request to NEAR AI's production API with the fake key. Normally the runner reached the host, got a 401, and threw the response away. This time it couldn't, undici raised `TypeError: fetch failed`, and the job failed.

It's the only live call in the suite — `captureFetch()` overwrites `globalThis.fetch` for the remainder of the process, and the one test that runs earlier is an OPTIONS preflight that returns before any fetch.

## What

Delete the line. The assertion the test cares about is `res2`, built with an empty env, which returns 503 before reaching any upstream call.

No coverage is lost — `[[path]].js` measures identically with and without it:

| | line % | branch % | funcs % | uncovered |
|---|---|---|---|---|
| before | 98.45 | 85.71 | 100.00 | 94-95 |
| after | 98.45 | 85.71 | 100.00 | 94-95 |

## Test

`npm run test-gitproxy` (the CI step) — 31/31 pass. The `nearai-proxy` file drops from ~1.9s to ~0.1s now that it isn't waiting on a network round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)