### PR TITLE
Bump quickjs-wasm to 0.0.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           cd wasmaudioworklet
           # --legacy-peer-deps: pre-existing @as-pect/cli peer conflict with
           # assemblyscript 0.28 that yarn (used by the other jobs) ignores.
-          npm install --no-save --no-audit --no-fund --legacy-peer-deps quickjs-wasm@0.0.2
+          npm install --no-save --no-audit --no-fund --legacy-peer-deps quickjs-wasm@0.0.3
           npm run test-agent-tools
           npm run test-gitproxy
           npm run test-quickjs-sandbox

--- a/wasmaudioworklet/midisequencer/quickjssandbox.js
+++ b/wasmaudioworklet/midisequencer/quickjssandbox.js
@@ -14,7 +14,7 @@
 // from the installed npm package in Node (Node cannot import https: URLs).
 // Keep the version in sync with the quickjs-wasm devDependency in
 // package.json.
-const QUICKJS_WASM_VERSION = '0.0.2';
+const QUICKJS_WASM_VERSION = '0.0.3';
 
 async function getCreateQuickJS() {
     const { createQuickJS } = (typeof process !== 'undefined' && process.versions && process.versions.node)

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -51,7 +51,7 @@
         "chai": "^4.3.7",
         "http-server": "^14.1.1",
         "mocha": "^10.2.0",
-        "quickjs-wasm": "0.0.2",
+        "quickjs-wasm": "0.0.3",
         "rollup": "^4.1.5",
         "rollup-plugin-terser": "^7.0.2",
         "ws": "^7.5.10"

--- a/wasmaudioworklet/yarn.lock
+++ b/wasmaudioworklet/yarn.lock
@@ -5288,10 +5288,10 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-quickjs-wasm@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/quickjs-wasm/-/quickjs-wasm-0.0.2.tgz#c654fda432cf9b7d124fbd141315ec73b128a950"
-  integrity sha512-I5+svgrA+y6h5rZCtxvn5SNL31AqG4fBJdlw2+WaupZuGgMlnfuxojSoDGJB+S5aeBprGpHsZvVf2rRhJrKAIw==
+quickjs-wasm@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/quickjs-wasm/-/quickjs-wasm-0.0.3.tgz#6fc3df6b6c42daae0abe5e9ddd38ae91e560237d"
+  integrity sha512-24ILjuqMAi+V4+llSUCJC/3ZZ4UH1APmXyElRiMygxz+iuG3BCDVADkR5EYODr+FnjoQUC61q4W6+9zQGbb5kQ==
 
 qw@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Moves the last unmerged commit off `quickjs-sandbox-poc` (everything before it landed in #173), plus the lockfile update that commit was missing.

## The bump

quickjs-wasm 0.0.3 changes three things that matter to the song sandbox:

- **Frees wasm-heap allocations made on every crossing of the host boundary** — a long song compile can no longer exhaust the fixed 16.5MB heap.
- **Reports out-of-memory properly** instead of failing opaquely.
- **Compiles the wasm module once per page** rather than once per sandbox, making each `createQuickJS()` ~4x cheaper.

The version appears in three places that must stay in sync, and the cherry-picked commit updates all three: the CI install in `main.yml`, `QUICKJS_WASM_VERSION` in `quickjssandbox.js` (the jsDelivr URL for the browser path), and the `package.json` devDependency (the Node path).

## The lockfile

`yarn.lock` still pinned `quickjs-wasm@0.0.2` while `package.json` asked for `0.0.3`. CI runs plain `yarn install` — no `--frozen-lockfile` — so it silently re-resolved to 0.0.3 instead of failing. Nothing would have broken, but the lockfile stopped describing what CI actually installs, and anyone running `yarn install --frozen-lockfile` locally would have hit an error. Second commit fixes it; `--frozen-lockfile` now succeeds and yarn leaves the rest of the file untouched.

## Test

- `npm run test-quickjs-sandbox` — 5/5 against 0.0.3, including the network-isolation and interrupt-runaway-song cases
- `npm run test-agent-tools` (25) and `npm run test-gitproxy` (31) — pass
- `yarn install --frozen-lockfile` — resolves, installs 0.0.3
- Browser path verified: `js/quickjs.js`, `js/wasi.js` and `jseval.wasm` all serve 200 from jsDelivr at 0.0.3 (the wasm is at the package root, resolved via `import.meta.url`, not under `js/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)