### PR TITLE
Bump quickjs-wasm to 0.0.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           cd wasmaudioworklet
           # --legacy-peer-deps: pre-existing @as-pect/cli peer conflict with
           # assemblyscript 0.28 that yarn (used by the other jobs) ignores.
-          npm install --no-save --no-audit --no-fund --legacy-peer-deps quickjs-wasm@0.0.3
+          npm install --no-save --no-audit --no-fund --legacy-peer-deps quickjs-wasm@0.0.4
           npm run test-agent-tools
           npm run test-gitproxy
           npm run test-quickjs-sandbox

--- a/wasmaudioworklet/midisequencer/quickjssandbox.js
+++ b/wasmaudioworklet/midisequencer/quickjssandbox.js
@@ -14,7 +14,7 @@
 // from the installed npm package in Node (Node cannot import https: URLs).
 // Keep the version in sync with the quickjs-wasm devDependency in
 // package.json.
-const QUICKJS_WASM_VERSION = '0.0.3';
+const QUICKJS_WASM_VERSION = '0.0.4';
 
 async function getCreateQuickJS() {
     const { createQuickJS } = (typeof process !== 'undefined' && process.versions && process.versions.node)

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -51,7 +51,7 @@
         "chai": "^4.3.7",
         "http-server": "^14.1.1",
         "mocha": "^10.2.0",
-        "quickjs-wasm": "0.0.3",
+        "quickjs-wasm": "0.0.4",
         "rollup": "^4.1.5",
         "rollup-plugin-terser": "^7.0.2",
         "ws": "^7.5.10"

--- a/wasmaudioworklet/yarn.lock
+++ b/wasmaudioworklet/yarn.lock
@@ -5288,10 +5288,10 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-quickjs-wasm@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/quickjs-wasm/-/quickjs-wasm-0.0.3.tgz#6fc3df6b6c42daae0abe5e9ddd38ae91e560237d"
-  integrity sha512-24ILjuqMAi+V4+llSUCJC/3ZZ4UH1APmXyElRiMygxz+iuG3BCDVADkR5EYODr+FnjoQUC61q4W6+9zQGbb5kQ==
+quickjs-wasm@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/quickjs-wasm/-/quickjs-wasm-0.0.4.tgz#19c751e99edf794ef689f547a892f7ce0a4ed959"
+  integrity sha512-Iu+aK0ct5bSrNfCBTS0nhNehqiQ7jjr3FXp/ZL3EDmHDnijjBKWZqW0C4Kr1OBf/a1a5hxpivw+y2g2KeXmgEQ==
 
 qw@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
[quickjs-wasm 0.0.4](https://www.npmjs.com/package/quickjs-wasm/v/0.0.4) fixes two things that matter for the song sandbox:

- **String returns no longer accumulate.** The `JSValue` behind a returned string was retained even after the string was copied out to the host, so around 30k string returns exhausted the fixed 16.5MB heap. Bounded per-execution before, but no longer a limit at all.
- **A failed compile throws at `compileToByteCode`.** It previously returned an empty buffer, which `loadByteCode` accepted, surfacing two calls later as `TypeError: not a function` — naming a guest function instead of the compile. Sources roughly 800KB–1.6MB hit that window, which is the range generated song JS grows into with sequence length.

Also adds `freeValue(handle)` for releasing object handles, which the sandbox does not currently need.

Four references updated: `package.json`, the CI install line, the `QUICKJS_WASM_VERSION` constant driving the jsDelivr URL for the browser path, and `yarn.lock` — the lockfile in the same commit this time, per #177's follow-up.

Verified with `yarn install --frozen-lockfile` (so the lockfile genuinely describes what is installed) and `npm run test-quickjs-sandbox` against the published 0.0.4 — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)