### PR TITLE
Bump quickjs-wasm to 0.0.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           cd wasmaudioworklet
           # --legacy-peer-deps: pre-existing @as-pect/cli peer conflict with
           # assemblyscript 0.28 that yarn (used by the other jobs) ignores.
-          npm install --no-save --no-audit --no-fund --legacy-peer-deps quickjs-wasm@0.0.3
+          npm install --no-save --no-audit --no-fund --legacy-peer-deps quickjs-wasm@0.0.5
           npm run test-agent-tools
           npm run test-gitproxy
           npm run test-quickjs-sandbox

--- a/wasmaudioworklet/midisequencer/quickjssandbox.js
+++ b/wasmaudioworklet/midisequencer/quickjssandbox.js
@@ -14,7 +14,7 @@
 // from the installed npm package in Node (Node cannot import https: URLs).
 // Keep the version in sync with the quickjs-wasm devDependency in
 // package.json.
-const QUICKJS_WASM_VERSION = '0.0.3';
+const QUICKJS_WASM_VERSION = '0.0.5';
 
 async function getCreateQuickJS() {
     const { createQuickJS } = (typeof process !== 'undefined' && process.versions && process.versions.node)

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -51,7 +51,7 @@
         "chai": "^4.3.7",
         "http-server": "^14.1.1",
         "mocha": "^10.2.0",
-        "quickjs-wasm": "0.0.3",
+        "quickjs-wasm": "0.0.5",
         "rollup": "^4.1.5",
         "rollup-plugin-terser": "^7.0.2",
         "ws": "^7.5.10"

--- a/wasmaudioworklet/yarn.lock
+++ b/wasmaudioworklet/yarn.lock
@@ -5288,10 +5288,10 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-quickjs-wasm@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/quickjs-wasm/-/quickjs-wasm-0.0.3.tgz#6fc3df6b6c42daae0abe5e9ddd38ae91e560237d"
-  integrity sha512-24ILjuqMAi+V4+llSUCJC/3ZZ4UH1APmXyElRiMygxz+iuG3BCDVADkR5EYODr+FnjoQUC61q4W6+9zQGbb5kQ==
+quickjs-wasm@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/quickjs-wasm/-/quickjs-wasm-0.0.5.tgz#f84f0fb3784d127b63eef6fc07cc5c1f4d142cc7"
+  integrity sha512-EzmFACXcjUmJwf6VAc3CKz1lA5+qoBi+djmdqH/XKB+R7puV+KonmTCtxRIJCqx1giCEElteduoeOiPMPQlFyw==
 
 qw@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Supersedes #179 (0.0.4).

## Same runtime, better contract

`js/quickjs.js` and `jseval.wasm` are **byte-identical** between 0.0.4 and 0.0.5 — same sha256 on the wasm, which also confirms the reproducible build. So skipping 0.0.4 doesn't skip its behavior changes: the compile-throw and the string auto-free ship here unchanged. What 0.0.5 adds is a `CHANGELOG.md`, TypeScript declarations (`js/quickjs.d.ts`), and a README that states the retention policy explicitly.

That last part is what makes this the version worth landing. 0.0.4 documented `freeValue()` as a caller obligation, which made our `mod` and `promise` handles ([quickjssandbox.js:126-127](wasmaudioworklet/midisequencer/quickjssandbox.js#L126-L127)) — neither of which we free — read as a leak. 0.0.5 demotes it to an escape hatch:

> There is deliberately no disposal API. Nothing has to be released and nothing has to be tracked: create an instance, run a script, drop it.

That matches what this file actually does and wants to keep doing: one instance per song compile, dropped immediately, so no state carries between untrusted songs.

## Four pins, all moved together

The workflow install, `QUICKJS_WASM_VERSION` (the jsDelivr URL for the browser), the package.json devDependency, and `yarn.lock`. Lockfile integrity matches npm's published `dist.integrity` exactly, and `yarn install --frozen-lockfile` resolves.

## Test

- `test-quickjs-sandbox` 5/5, `test-agent-tools` 25/25, `test-gitproxy` 31/31
- Stress run at 800 and 2000 bars (207kB source, 31,997 events, 3 consecutive compiles): passes, unchanged from 0.0.3/0.0.4 — as expected, since a fresh instance per compile means the leak fixes are a no-op for this consumer
- Compile diagnostics confirmed: `Failed to compile songcompiler-sandbox.js: SyntaxError: expecting ';'`
- Browser path verified on jsDelivr at 0.0.5 — `js/quickjs.js`, `js/wasi.js`, and root `jseval.wasm` all 200 (no Node test covers the CDN path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)