### PR TITLE
Song-driven shader visuals: showText/setVisual + studio agent shader tools

### DIFF
--- a/examples/textoverlay/README.md
+++ b/examples/textoverlay/README.md
@@ -1,0 +1,73 @@
+# Text overlay — text on screen, driven from the sequencer
+
+A song that shows text in time with the music and picks **how** each line
+appears. The app renders text on a dedicated shader layer; the sequence decides
+the content, the moment and the style.
+
+## Files
+
+| File | Description |
+|---|---|
+| `song.js` | The sequence. `showText(...)` per line, `setVisual('textScale', ...)` for a ramped zoom, a slow pad on channel 0. |
+| `shaders/shader_textoverlay.glsl` | Music-reactive backdrop plus four text transitions (fade, wipe, rise, dissolve) selected by the `textTransition` uniform. |
+
+There's no `synth.ts` here — the chords play on channel 0 of whatever synth the
+project already has. Drop `song.js` and the shader into any song project (set
+`fragmentshader` in `wasmmusic.config.json` to the shader).
+
+## How it fits together
+
+```
+song.js                         app                          shader
+────────────────────────────────────────────────────────────────────────
+showText('Refrenget',    →   text image scheduled    →   uText / uTextPrev
+        { transition: 1,     at that song time;          uTextMix 0→1 over `fade`
+          fade: 1.2 })       transition rides on     →   textTransition
+                             the setVisual channel
+setVisual('textScale',   →   named float, ramped     →   textScale
+          1.6, 2.0)          over 2 seconds
+```
+
+The song never touches GLSL and the shader never knows what the text says —
+they meet at `uText` (what) and the named params (how). Adding a fifth
+transition is a shader edit plus a number in the song.
+
+## Render it headlessly
+
+From `wasmaudioworklet` (see [shaders.md](../../wasmaudioworklet/docs/shaders.md)):
+
+```sh
+# compile-check
+node ../tools/shadertest/render.mjs ../examples/textoverlay/shaders/shader_textoverlay.glsl --compile-only
+
+# a finished line
+node ../tools/shadertest/render.mjs ../examples/textoverlay/shaders/shader_textoverlay.glsl \
+  --text "Første vers\nandre linje" --textmix 1 --visual textTransition=0 --visual textScale=1
+
+# mid-transition between two lines — try textTransition 0..3
+node ../tools/shadertest/render.mjs ../examples/textoverlay/shaders/shader_textoverlay.glsl \
+  --text "Refrenget" --textprev "Første vers" --textmix 0.45 \
+  --visual textTransition=1 --visual textScale=1
+```
+
+## Transitions in this shader
+
+| `transition` | Effect |
+|---|---|
+| `0` | Crossfade — both lines overlap; the classic dissolve-in |
+| `1` | Wipe left→right; the new line owns everything left of the edge |
+| `2` | Rise into place — new text comes up from below, old text leaves upward |
+| `3` | Pixel dissolve, sequential: the old line breaks up over the first half of the fade, the new one forms over the second |
+
+`textScale` scales the text image around the centre (1.0 = fitted to the
+viewport height). Both names are this example's own convention — `setVisual`
+puts any name you like into the shader.
+
+## Notes
+
+- The text image is 1280×720 and letterboxed to fit, so lines keep their
+  proportions on any window shape.
+- Text is rendered as SVG inside the song sandbox — no DOM needed, and
+  non-ASCII (æøå) works.
+- Keep the visual track shorter than the music: pending steps on a concurrent
+  track are dropped when the main sequence returns.

--- a/examples/textoverlay/shaders/shader_textoverlay.glsl
+++ b/examples/textoverlay/shaders/shader_textoverlay.glsl
@@ -1,0 +1,112 @@
+// Text overlay demo — the song decides WHAT text to show (showText), WHEN
+// (song time) and HOW (setVisual('textTransition', n) picks the style below).
+//
+// Uniforms from the app:
+//   uText / uTextPrev  the current and outgoing text images (alpha = coverage)
+//   uTextMix           0..1 progress of the current text's fade
+//   textTransition     set by the song: 0 fade, 1 wipe, 2 rise, 3 dissolve
+//   textScale          set by the song: 1.0 = text image fills the height
+//
+// Headless check:
+//   node ../tools/shadertest/render.mjs ../examples/textoverlay/shaders/shader_textoverlay.glsl \
+//        --text "Første vers" --textmix 0.4 --visual textTransition=1
+precision highp float;
+
+uniform vec2 resolution;
+uniform float time;
+uniform float smoothedNoteStates[128];
+
+uniform sampler2D uText;
+uniform sampler2D uTextPrev;
+uniform float uTextMix;
+
+uniform float textTransition;
+uniform float textScale;
+
+const float TEXT_ASPECT = 16.0 / 9.0;   // showText's default image is 1280x720
+
+float noteEnergy() {
+    float e = 0.0;
+    for (int i = 0; i < 128; i++) {
+        e += max(0.0, smoothedNoteStates[i] * 0.5 + 0.5);
+    }
+    return clamp(e / 16.0, 0.0, 1.0);
+}
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Music-reactive backdrop, so the text has something to sit on top of.
+vec3 background(vec2 uv, float energy) {
+    float d = length(uv - 0.5);
+    float waves = sin(uv.x * 8.0 + time * 0.7) * 0.5 + sin(uv.y * 6.0 - time * 0.5) * 0.5;
+    vec3 deep = vec3(0.03, 0.05, 0.12);
+    vec3 glow = vec3(0.25, 0.12, 0.45) + vec3(0.35, 0.15, 0.0) * energy;
+    return mix(deep, glow, clamp(0.5 + 0.5 * waves - d * 1.2 + energy * 0.4, 0.0, 1.0));
+}
+
+// Fit the text image inside the viewport without stretching it ("contain").
+vec2 textUv(vec2 uv, float scale) {
+    float dstAspect = resolution.x / resolution.y;
+    vec2 fit = dstAspect > TEXT_ASPECT
+        ? vec2(dstAspect / TEXT_ASPECT, 1.0)
+        : vec2(1.0, TEXT_ASPECT / dstAspect);
+    vec2 tuv = (uv - 0.5) * fit / max(scale, 0.001) + 0.5;
+    return vec2(tuv.x, 1.0 - tuv.y);   // textures upload top-row-first
+}
+
+vec4 sampleText(sampler2D tex, vec2 tuv) {
+    // Outside the image: nothing. CLAMP_TO_EDGE would otherwise smear the
+    // border pixels across the letterbox area.
+    if (tuv.x < 0.0 || tuv.x > 1.0 || tuv.y < 0.0 || tuv.y > 1.0) {
+        return vec4(0.0);
+    }
+    return texture2D(tex, tuv);
+}
+
+// One text layer under a transition. `p` runs 0..1 as the layer comes IN;
+// pass 1.0 - uTextMix and `outgoing = true` for the layer going out.
+vec4 transitionedText(sampler2D tex, vec2 uv, float p, bool outgoing) {
+    float mode = floor(textTransition + 0.5);
+    vec2 offset = vec2(0.0);
+    float alpha = 1.0;
+
+    if (mode < 0.5) {                       // 0: crossfade
+        alpha = p;
+    } else if (mode < 1.5) {                // 1: wipe left→right
+        // Both layers share the same edge: the new text owns everything left
+        // of it, the old text everything right of it.
+        float edge = outgoing ? 1.0 - p : p;
+        float reveal = smoothstep(edge + 0.12, edge - 0.12, uv.x);
+        alpha = outgoing ? 1.0 - reveal : reveal;
+    } else if (mode < 2.5) {                // 2: rise into place
+        offset.y = (1.0 - p) * (outgoing ? -0.12 : 0.12);
+        alpha = smoothstep(0.0, 0.6, p);
+    } else {                                // 3: pixel dissolve
+        // Sequential, not simultaneous: the old text dissolves away over the
+        // first half of the fade, the new one materialises over the second.
+        // Two texts dissolving at once is unreadable mush.
+        float block = hash(floor(uv * vec2(90.0, 50.0)));
+        alpha = step(block, clamp(2.0 * p - 1.0, 0.0, 1.0));
+    }
+
+    vec4 texel = sampleText(tex, textUv(uv + offset, textScale > 0.0 ? textScale : 1.0));
+    texel.a *= clamp(alpha, 0.0, 1.0);
+    return texel;
+}
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / resolution;
+    float energy = noteEnergy();
+    vec3 col = background(uv, energy);
+
+    // Outgoing text first, incoming over it.
+    vec4 prev = transitionedText(uTextPrev, uv, 1.0 - uTextMix, true);
+    vec4 cur = transitionedText(uText, uv, uTextMix, false);
+
+    col = mix(col, prev.rgb, prev.a);
+    col = mix(col, cur.rgb, cur.a);
+
+    gl_FragColor = vec4(col, 1.0);
+}

--- a/examples/textoverlay/song.js
+++ b/examples/textoverlay/song.js
@@ -1,0 +1,42 @@
+// Text overlay demo — the song decides what text appears, when, and how.
+// Pair it with shaders/shader_textoverlay.glsl. See README.md.
+setBPM(96);
+
+// A plain setVisual param: the shader reads it as `uniform float textScale`.
+// Nothing about the name is built into the app — the song and the shader agree.
+setVisual('textScale', 1.0);
+
+// --- visuals ---------------------------------------------------------------
+// Channel 15 sounds nothing, so this track is purely a visual timeline. Each
+// showText supersedes the previous one; `transition` is the style the shader
+// branches on, `fade` is how long uTextMix takes to travel 0 -> 1.
+createTrack(15).steps(1, [
+    () => showText('Text from the sequencer', { transition: 0, fade: 1.5 }),
+    ,,,,
+    () => showText(['Fade, wipe, rise, dissolve', 'picked per line'],
+        { transition: 1, fade: 1.2, size: 80 }),
+    ,,,,
+    () => showText('…this one rises', { transition: 2, fade: 1.2 }),
+    ,,,,
+    () => showText('…and this one dissolves', { transition: 3, fade: 1.6, size: 84 }),
+    ,,,,
+    // Ramped param: the shader zooms the text out over 2 seconds.
+    () => setVisual('textScale', 1.6, 2.0),
+    ,,,,
+    () => hideText({ transition: 0, fade: 2.0 }),
+]);
+
+// --- music -----------------------------------------------------------------
+// A slow pad on channel 0 (whatever instrument the project has there), four
+// beats per chord, so the visuals have something to breathe with.
+const chords = [
+    [c3(4), ds3(4), g3(4)],
+    [as2(4), d3(4), f3(4)],
+    [gs2(4), c3(4), ds3(4)],
+    [as2(4), d3(4), g3(4)],
+];
+// 7 chords = 28 beats — the song must outlast the visual track above, or its
+// pending steps are dropped when the main sequence returns.
+for (let repeat = 0; repeat < 7; repeat++) {
+    await createTrack(0, 1, 80).steps(0.25, [chords[repeat % chords.length]]);
+}

--- a/tools/shadertest/render.mjs
+++ b/tools/shadertest/render.mjs
@@ -22,6 +22,11 @@
  *   --size <WxH>          framebuffer size (default 900x506)
  *   --out <file.png>      output path (single frame). Default: /tmp/<name>_t<time>.png
  *   --outdir <dir>        output dir for --frames (default /tmp)
+ *   --text <string>       render this text into the uText layer (\n for line breaks),
+ *                         exactly as showText() does in a song
+ *   --textprev <string>   text in uTextPrev (the outgoing text of a transition)
+ *   --textmix <0..1>      uTextMix, the text transition progress (default 1)
+ *   --visual <name=value> set a setVisual() uniform; repeat for several
  *   --compile-only        just compile-check; print OK/FAIL and exit
  *
  * Exit code is non-zero if the shader fails to compile, so it doubles as a
@@ -36,6 +41,10 @@
  *   uniform sampler2D uSampler;            // active image/video frame (image shaders)
  *   uniform sampler2D uSamplerPrev;        // previous frame (crossfade pair)
  *   uniform float uMix;                    // 0..1 crossfade; pinned to 1 outside transitions
+ *   uniform sampler2D uText;               // showText() layer (alpha = text coverage)
+ *   uniform sampler2D uTextPrev;           // previous text (transition pair)
+ *   uniform float uTextMix;                // 0..1 progress of the text transition
+ *   uniform float <name>;                  // anything the song set with setVisual()
  */
 
 import fs from 'fs';
@@ -59,7 +68,10 @@ try {
 }
 
 function parseArgs(argv) {
-  const a = { time: 4, energy: 0.5, size: '900x506', frames: null, out: null, outdir: '/tmp', compileOnly: false };
+  const a = {
+    time: 4, energy: 0.5, size: '900x506', frames: null, out: null, outdir: '/tmp',
+    compileOnly: false, text: null, textPrev: null, textMix: 1, visuals: {},
+  };
   const rest = [];
   for (let i = 0; i < argv.length; i++) {
     const k = argv[i];
@@ -69,6 +81,13 @@ function parseArgs(argv) {
     else if (k === '--frames') a.frames = argv[++i].split(',').map(Number);
     else if (k === '--out') a.out = argv[++i];
     else if (k === '--outdir') a.outdir = argv[++i];
+    else if (k === '--text') a.text = argv[++i].replace(/\\n/g, '\n');
+    else if (k === '--textprev') a.textPrev = argv[++i].replace(/\\n/g, '\n');
+    else if (k === '--textmix') a.textMix = parseFloat(argv[++i]);
+    else if (k === '--visual') {
+      const [name, value] = argv[++i].split('=');
+      a.visuals[name] = parseFloat(value);
+    }
     else if (k === '--compile-only') a.compileOnly = true;
     else rest.push(k);
   }
@@ -78,9 +97,11 @@ function parseArgs(argv) {
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.shader) {
-  console.error('usage: node ../tools/shadertest/render.mjs <shader.glsl> [--time s] [--frames t1,t2] [--energy 0..1] [--size WxH] [--out f.png] [--compile-only]');
+  console.error('usage: node ../tools/shadertest/render.mjs <shader.glsl> [--time s] [--frames t1,t2] [--energy 0..1] [--size WxH] [--text "hi"] [--textmix 0..1] [--visual name=value] [--out f.png] [--compile-only]');
   process.exit(2);
 }
+// Same text→image path the song API uses, so what renders here is what the app shows.
+const { textToSvgDataUrl } = await import(path.join(waw, 'midisequencer/textimage.js'));
 const src = fs.readFileSync(args.shader, 'utf8');
 const [W, H] = args.size.split('x').map(Number);
 const name = path.basename(args.shader).replace(/\.[^.]+$/, '');
@@ -105,7 +126,11 @@ console.log(`COMPILE OK  ${args.shader}`);
 if (args.compileOnly) { await browser.close(); process.exit(0); }
 
 async function render(time) {
-  const r = await page.evaluate(({ src, W, H, time, energy }) => {
+  const textUrls = [
+    args.text === null ? null : textToSvgDataUrl(args.text),
+    args.textPrev === null ? null : textToSvgDataUrl(args.textPrev),
+  ];
+  const r = await page.evaluate(async ({ src, W, H, time, energy, visuals, textUrls, textMix }) => {
     const cv = document.createElement('canvas'); cv.width = W; cv.height = H;
     const gl = cv.getContext('webgl', { preserveDrawingBuffer: true });
     const mk = (type, s) => { const o = gl.createShader(type); gl.shaderSource(o, s); gl.compileShader(o); return o; };
@@ -128,23 +153,48 @@ async function render(time) {
     for (let i = 20; i < 20 + Math.floor(energy * 60); i++) z[i] = 0.9;
     setv('targetNoteStates', z);
     setv('smoothedNoteStates', z);
+    // song-scheduled setVisual() uniforms
+    Object.entries(visuals).forEach(([n, v]) => set1(n, v));
     // bind a 1x1 texture for image shaders so uSampler/uSamplerPrev don't error.
+    // Transparent, like the app's placeholder — an opaque one would hide
+    // everything in a shader that composites the image layer by its alpha.
     for (let u = 0; u < 2; u++) {
       const name = u === 0 ? 'uSampler' : 'uSamplerPrev';
       const l = gl.getUniformLocation(p, name); if (!l) continue;
       const tex = gl.createTexture(); gl.activeTexture(gl.TEXTURE0 + u); gl.bindTexture(gl.TEXTURE_2D, tex);
-      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([90, 90, 90, 255]));
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
       gl.uniform1i(l, u);
+    }
+    // text layer (units 2/3): --text renders through the same SVG path as showText(),
+    // otherwise a transparent pixel so a text shader still draws its background.
+    set1('uTextMix', textMix);
+    for (let u = 0; u < 2; u++) {
+      const name = u === 0 ? 'uText' : 'uTextPrev';
+      const l = gl.getUniformLocation(p, name); if (!l) continue;
+      const tex = gl.createTexture(); gl.activeTexture(gl.TEXTURE2 + u); gl.bindTexture(gl.TEXTURE_2D, tex);
+      const url = textUrls[u];
+      if (url) {
+        const img = new Image();
+        img.src = url;
+        await img.decode();
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+      } else {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
+      }
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.uniform1i(l, 2 + u);
     }
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     // simple "did it draw anything" metric: fraction of non-near-black pixels.
     const px = new Uint8Array(W * H * 4); gl.readPixels(0, 0, W, H, gl.RGBA, gl.UNSIGNED_BYTE, px);
     let lit = 0; for (let i = 0; i < px.length; i += 4) if (px[i] + px[i + 1] + px[i + 2] > 24) lit++;
     return { url: cv.toDataURL('image/png'), litPct: Math.round((100 * lit) / (W * H)) };
-  }, { src, W, H, time, energy: args.energy });
+  }, { src, W, H, time, energy: args.energy, visuals: args.visuals, textUrls, textMix: args.textMix });
   return r;
 }
 

--- a/tools/studio-agent/README.md
+++ b/tools/studio-agent/README.md
@@ -56,9 +56,10 @@ errors, and starts playback — all in your browser.
 | `get_synth` / `set_synth` | read / replace the synth editor |
 | `edit_synth` / `edit_song` | surgical find-and-replace in place (like Edit) — change a large doc (e.g. the 14k-line DX7 bundle) without rewriting it |
 | `grep_synth` / `grep_song` | regex-search the current in-browser doc for anchors, without dumping the whole file into context |
+| `get_shader` / `set_shader` / `edit_shader` / `grep_shader` | read / replace / surgically edit / search the visualizer shader (GLSL). The song's visuals only reach the screen through uniforms this document declares, so `showText`/`setVisual` work is a shader job as much as a song job — the write tools report back anything the song schedules that the shader still cannot show |
 | `write_faust` / `read_faust` / `list_faust` | author instruments in **Faust** (`.dsp`) in OPFS `faust/` — `write_faust` also transpiles to AssemblyScript and reports the generated classes (needs `?gitrepo=` mode) |
-| `compile` | `window.compileSong()`, returns "compiled OK" or the compiler error |
-| `play` / `stop` | `window.startaudio()` / `window.stopaudio()` |
+| `compile` | `window.saveSong()` (save + compile + apply to a playing worklet), returns "compiled OK" or the compiler error |
+| `stop` | `window.stopaudio()` — there is deliberately no `play` tool; starting playback is the user's action |
 
 It also has read-only `Read`/`Glob`/`Grep` over this repo so it can learn from
 `examples/` (incl. the DX7 FM synth), `songs/`, and `wasmaudioworklet/docs/`.

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -70,6 +70,7 @@ if (process.env.ANTHROPIC_API_KEY) {
 const STUDIO_TOOLS = [
   'get_song', 'set_song', 'get_synth', 'set_synth',
   'edit_synth', 'edit_song', 'grep_synth', 'grep_song',
+  'get_shader', 'set_shader', 'edit_shader', 'grep_shader',
   'write_faust', 'read_faust', 'list_faust',
   'git_log', 'read_committed',
   'load_synth_from_file', 'load_song_from_file',
@@ -167,6 +168,10 @@ function makeStudioServer(ws) {
       proxy('edit_song', 'Surgically find-and-replace in the song document IN PLACE. old_string must match exactly and be unique unless replace_all is true.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
       proxy('grep_synth', 'Search the CURRENT in-browser synth document for a regex; returns matching line numbers + text (optionally with surrounding context lines). Use to find exact anchors for edit_synth in a large synth without dumping the whole file.', { pattern: z.string(), context: z.number().optional() }),
       proxy('grep_song', 'Search the CURRENT in-browser song document for a regex; returns matching line numbers + text.', { pattern: z.string(), context: z.number().optional() }),
+      proxy('get_shader', 'Return the current visualizer shader document (GLSL ES 1.00 fragment shader). This is what the song\'s visuals actually render through — read it before concluding anything about what is or is not on screen.', {}),
+      proxy('set_shader', 'Replace the entire visualizer shader document. Provide the full new GLSL source. Reports back any visuals the song schedules that the new shader still cannot show.', { source: z.string() }),
+      proxy('edit_shader', 'Surgically find-and-replace in the visualizer shader document IN PLACE. old_string must match exactly and be unique unless replace_all is true. Reports back any visuals the song schedules that the shader still cannot show.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
+      proxy('grep_shader', 'Search the CURRENT in-browser shader document for a regex; returns matching line numbers + text. Use it to check which uniforms the shader declares (e.g. "uText|uSampler|uniform float") before editing the song\'s visuals.', { pattern: z.string(), context: z.number().optional() }),
       proxy('write_faust', 'Author an INSTRUMENT in Faust: write faust/<path>.dsp AND transpile it to AssemblyScript in one step (persists faust/<name>.dsp + faust/<name>.ts in the browser OPFS). Returns the generated class names to import into synth.ts, or the exact transpile error. This is the primary way to create instrument DSP — do NOT hand-write DSP in AssemblyScript.', { path: z.string(), source: z.string() }),
       proxy('read_faust', 'Read a Faust .dsp instrument source from the browser OPFS faust/ folder.', { path: z.string() }),
       proxy('list_faust', 'List the .dsp Faust instruments in the browser OPFS faust/ folder.', {}),

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -20,6 +20,7 @@ import { dirname, resolve } from 'node:path';
 import { z } from 'zod';
 import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { SYSTEM_PROMPT } from './prompt.mjs';
+import { toolDefsFor, sdkToolNames } from '../../wasmaudioworklet/studio-agent-tools-def.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..'); // tools/studio-agent -> repo root
@@ -66,16 +67,11 @@ if (process.env.ANTHROPIC_API_KEY) {
   );
 }
 
-// Tools the agent may use: our browser-proxied studio tools + read-only repo access.
-const STUDIO_TOOLS = [
-  'get_song', 'set_song', 'get_synth', 'set_synth',
-  'edit_synth', 'edit_song', 'grep_synth', 'grep_song',
-  'get_shader', 'set_shader', 'edit_shader', 'grep_shader',
-  'write_faust', 'read_faust', 'list_faust',
-  'git_log', 'read_committed',
-  'load_synth_from_file', 'load_song_from_file',
-  'compile', 'stop',
-];
+// Tools the agent may use: our browser-proxied studio tools + read-only repo
+// access. The tool set itself is declared once in
+// wasmaudioworklet/studio-agent-tools-def.js and shared with the in-browser
+// NEAR AI provider, so adding a tool cannot reach only one of them.
+const STUDIO_TOOLS = sdkToolNames();
 const ALLOWED = new Set([
   ...STUDIO_TOOLS.map((n) => `mcp__studio__${n}`),
   'Read', 'Glob', 'Grep',
@@ -123,6 +119,24 @@ function callBrowser(ws, name, args) {
   });
 }
 
+// The shared tool defs carry JSON Schema (what the OpenAI-compatible NEAR AI
+// path sends); the Agent SDK wants a zod shape. Only the primitive types the
+// defs actually use are supported — anything else is a mistake worth throwing on.
+function zodShape(parameters) {
+  const required = new Set(parameters.required || []);
+  const shape = {};
+  for (const [name, spec] of Object.entries(parameters.properties || {})) {
+    let field;
+    if (spec.type === 'string') field = z.string();
+    else if (spec.type === 'number') field = z.number();
+    else if (spec.type === 'boolean') field = z.boolean();
+    else throw new Error(`studio tool schema: unsupported type "${spec.type}" for "${name}"`);
+    if (spec.description) field = field.describe(spec.description);
+    shape[name] = required.has(name) ? field : field.optional();
+  }
+  return shape;
+}
+
 // ---- Build the in-process MCP tools, bound to one browser socket -----------
 function makeStudioServer(ws) {
   const proxy = (name, description, shape) =>
@@ -141,16 +155,15 @@ function makeStudioServer(ws) {
 
   // Load a repo file straight into an editor: the bytes are read server-side and
   // pushed to the browser, so a huge bundle never has to pass through the model.
-  const loadInto = (toolName, browserOp, label) =>
-    tool(toolName,
-      `Load a repository file DIRECTLY into the ${label} editor without reading it into context. Use this for large bundles (e.g. examples/dx7/dx7-synth.ts) — pass a repo-relative path; the file content is sent to the browser for you.`,
-      { path: z.string() },
+  const loadInto = (def) =>
+    tool(def.name, `${def.description} The file content is read here and sent to the browser for you.`,
+      zodShape(def.parameters),
       async ({ path }) => {
         try {
           const content = await readFile(safeResolve(path), 'utf8');
-          const res = await callBrowser(ws, browserOp, { source: content });
+          const res = await callBrowser(ws, def.target === 'synth' ? 'set_synth' : 'set_song', { source: content });
           if (!res.ok) return { content: [{ type: 'text', text: `ERROR: ${res.result ?? 'load failed'}` }], isError: true };
-          return { content: [{ type: 'text', text: `loaded ${path} (${content.split('\n').length} lines) into the ${label} editor` }] };
+          return { content: [{ type: 'text', text: `loaded ${path} (${content.split('\n').length} lines) into the ${def.target} editor` }] };
         } catch (e) {
           return { content: [{ type: 'text', text: `ERROR: ${e?.message || e}` }], isError: true };
         }
@@ -160,27 +173,8 @@ function makeStudioServer(ws) {
     name: 'studio',
     version: '1.0.0',
     tools: [
-      proxy('get_song', 'Return the current song document (JavaScript sequencer DSL).', {}),
-      proxy('set_song', 'Replace the entire song document. Provide the full new source.', { source: z.string() }),
-      proxy('get_synth', 'Return the current synth document (AssemblyScript).', {}),
-      proxy('set_synth', 'Replace the entire synth document. Provide the full new source.', { source: z.string() }),
-      proxy('edit_synth', 'Surgically find-and-replace in the synth document IN PLACE (like the Edit tool). Use this to add a voice/channel to a large synth (e.g. the DX7 bundle) WITHOUT rewriting it. old_string must match exactly and be unique unless replace_all is true.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
-      proxy('edit_song', 'Surgically find-and-replace in the song document IN PLACE. old_string must match exactly and be unique unless replace_all is true.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
-      proxy('grep_synth', 'Search the CURRENT in-browser synth document for a regex; returns matching line numbers + text (optionally with surrounding context lines). Use to find exact anchors for edit_synth in a large synth without dumping the whole file.', { pattern: z.string(), context: z.number().optional() }),
-      proxy('grep_song', 'Search the CURRENT in-browser song document for a regex; returns matching line numbers + text.', { pattern: z.string(), context: z.number().optional() }),
-      proxy('get_shader', 'Return the current visualizer shader document (GLSL ES 1.00 fragment shader). This is what the song\'s visuals actually render through — read it before concluding anything about what is or is not on screen.', {}),
-      proxy('set_shader', 'Replace the entire visualizer shader document. Provide the full new GLSL source. Reports back any visuals the song schedules that the new shader still cannot show.', { source: z.string() }),
-      proxy('edit_shader', 'Surgically find-and-replace in the visualizer shader document IN PLACE. old_string must match exactly and be unique unless replace_all is true. Reports back any visuals the song schedules that the shader still cannot show.', { old_string: z.string(), new_string: z.string(), replace_all: z.boolean().optional() }),
-      proxy('grep_shader', 'Search the CURRENT in-browser shader document for a regex; returns matching line numbers + text. Use it to check which uniforms the shader declares (e.g. "uText|uSampler|uniform float") before editing the song\'s visuals.', { pattern: z.string(), context: z.number().optional() }),
-      proxy('write_faust', 'Author an INSTRUMENT in Faust: write faust/<path>.dsp AND transpile it to AssemblyScript in one step (persists faust/<name>.dsp + faust/<name>.ts in the browser OPFS). Returns the generated class names to import into synth.ts, or the exact transpile error. This is the primary way to create instrument DSP — do NOT hand-write DSP in AssemblyScript.', { path: z.string(), source: z.string() }),
-      proxy('read_faust', 'Read a Faust .dsp instrument source from the browser OPFS faust/ folder.', { path: z.string() }),
-      proxy('list_faust', 'List the .dsp Faust instruments in the browser OPFS faust/ folder.', {}),
-      proxy('git_log', 'Show the commit history of the in-browser OPFS repo (the user commits their work here). Use it to find a commit to restore a file from.', {}),
-      proxy('read_committed', 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use to restore something overwritten in the editor: read_committed then set_song/set_synth it back.', { path: z.string(), ref: z.string().optional() }),
-      loadInto('load_synth_from_file', 'set_synth', 'synth'),
-      loadInto('load_song_from_file', 'set_song', 'song'),
-      proxy('compile', 'SAVE + compile the current song+synth in the browser (same as the app\'s save button). If a track is already playing, the changes are applied and audible immediately. Returns "compiled OK" or the exact compiler error. Call after every edit. There is NO play tool — the user starts playback themselves.', {}),
-      proxy('stop', 'Stop live audio playback. Only on the user\'s request.', {}),
+      ...toolDefsFor('browser').map((d) => proxy(d.name, d.description, zodShape(d.parameters))),
+      ...toolDefsFor('loadfile').map((d) => loadInto(d)),
     ],
   });
 }

--- a/wasmaudioworklet/docs/animations.md
+++ b/wasmaudioworklet/docs/animations.md
@@ -141,7 +141,8 @@ uniform sampler2D uTextPrev;
 uniform float uTextMix;
 uniform float textTransition;   // showText's `transition` option (via setVisual)
 
-vec2 tuv = vec2(uv.x, 1.0 - uv.y);          // texture rows upload top-first
+vec2 tuv = gl_FragCoord.xy / resolution;    // must be 0..1, not a centered uv
+tuv.y = 1.0 - tuv.y;                        // texture rows upload top-first
 vec4 t = mix(texture2D(uTextPrev, tuv), texture2D(uText, tuv), uTextMix);
 col = mix(col, t.rgb, t.a);
 ```

--- a/wasmaudioworklet/docs/animations.md
+++ b/wasmaudioworklet/docs/animations.md
@@ -22,6 +22,11 @@ Key detail: the schedule is sorted so the **latest `startTime` ≤ now wins**. S
 you do **not** need to set a stop time — each `startVideo` simply supersedes the
 previous frame. Rapid successive calls = animation.
 
+Before the first `startVideo` — and in a song with no images at all — `uSampler`
+and `uSamplerPrev` hold a fully **transparent** pixel, so a shader that
+composites the image layer by its alpha (`mix(col, card.rgb, card.a)`) just
+shows its own output.
+
 ## Frame rate
 
 `startVideo` stamps the *current song time*, so frame spacing is driven by the
@@ -111,31 +116,54 @@ if (x >= margin && x < (1.0 - margin)) {
 
 ## Text overlays
 
-There's no text primitive — render text to a canvas and use it as an image
-frame. Build a data-URL once, register it with `addImage`, and `startVideo` it
-when you want it on screen:
+`showText(text, options)` puts text on screen at the current song time. It
+renders the text to an SVG image internally — pure string work, so it runs
+inside the song sandbox (there is **no** `document` or canvas at song-compile
+time).
 
 ```js
-function textImage(lines) {
-  const c = document.createElement('canvas');
-  c.width = 1152; c.height = 1280;
-  const ctx = c.getContext('2d');
-  ctx.font = '70px Arial';
-  ctx.fillStyle = '#fff';
-  lines.forEach((t, i) => {
-    const w = ctx.measureText(t).width;
-    ctx.fillText(t, (c.width - w) / 2, 400 + i * 100);
-  });
-  return c.toDataURL();
-}
-
-addImage('title', textImage(['My Song', 'by me']));
-// ...
-startVideo('title');   // show the title card
+showText('My Song', { transition: 0, fade: 1.5 });
+// ...later
+showText(['Second verse', 'starts here'], { size: 72, transition: 1 });
+// ...and away
+hideText({ fade: 2 });
 ```
 
-(Note: in the browser song editor, `document` is available at song-compile
-time, so building a canvas data-URL like this works.)
+Text goes on its **own layer** — `uText` / `uTextPrev` / `uTextMix` — not the
+image layer, so it composites over an image slideshow, a video or a purely
+generative shader. **The shader must declare and composite those uniforms** or
+the text never appears (the app warns at compile time if it doesn't).
+`uTextMix` runs 0 → 1 over `fade` seconds; the shader decides what to do with it:
+
+```glsl
+uniform sampler2D uText;
+uniform sampler2D uTextPrev;
+uniform float uTextMix;
+uniform float textTransition;   // showText's `transition` option (via setVisual)
+
+vec2 tuv = vec2(uv.x, 1.0 - uv.y);          // texture rows upload top-first
+vec4 t = mix(texture2D(uTextPrev, tuv), texture2D(uText, tuv), uTextMix);
+col = mix(col, t.rgb, t.a);
+```
+
+Style options: `size`, `color`, `font`, `weight`, `align`, `x`, `y`,
+`lineHeight`, `background`, `stroke`, `strokeWidth`, `width`, `height` — see
+[song-api.md](song-api.md#shader-text--parameter-functions).
+
+`examples/textoverlay` is a complete song + shader pair showing fade, wipe,
+rise and dissolve transitions selected from the sequence.
+
+## Anything else the song wants to control
+
+`setVisual(name, value, rampSeconds)` schedules any named float the shader
+declares as `uniform float <name>` — the transition style above, a zoom, a
+scene index, a colour. Values step by default, or ramp over `rampSeconds`:
+
+```js
+setVisual('bloom', 0.0);
+// ...at the drop
+setVisual('bloom', 1.0, 2);   // ramp up over two seconds
+```
 
 ## Fades
 

--- a/wasmaudioworklet/docs/shaders.md
+++ b/wasmaudioworklet/docs/shaders.md
@@ -28,7 +28,41 @@ uniform float smoothedNoteStates[128]; // JS-smoothed view of the above: FAST at
 uniform sampler2D uSampler;            // active image/video frame (image shaders)
 uniform sampler2D uSamplerPrev;        // previous frame (crossfade pair)
 uniform float uMix;                    // 0..1 crossfade; pinned to 1 outside transitions
+uniform sampler2D uText;               // showText() layer — alpha is the text coverage
+uniform sampler2D uTextPrev;           // the outgoing text of a transition
+uniform float uTextMix;                // 0..1 progress of the current text's fade
 ```
+
+## Text and parameters the song controls
+
+Two song API calls drive the shader from the sequence (full reference in
+[song-api.md](song-api.md)):
+
+- **`showText(text, { fade, transition, ...style })`** puts text on the text
+  layer — its own texture pair, independent of `uSampler`, so text composites
+  over a photo, a video or a purely generative shader. `uTextMix` runs 0 → 1
+  over `fade` seconds, timed from song time (so it's identical when seeking or
+  exporting video).
+- **`setVisual(name, value, rampSeconds)`** sets any `uniform float <name>` the
+  shader declares. The app assigns no meaning to the names — this is where the
+  song says *how* to show something (which transition, how bright, which scene).
+
+```glsl
+uniform sampler2D uText;
+uniform sampler2D uTextPrev;
+uniform float uTextMix;
+uniform float textTransition;   // set by the song via setVisual / showText's `transition`
+
+// crossfade the outgoing text out and the incoming text in
+vec4 t = mix(texture2D(uTextPrev, tuv), texture2D(uText, tuv), uTextMix);
+col = mix(col, t.rgb, t.a);
+```
+
+Note the text image uploads top-row-first, so flip the y coordinate when
+sampling: `vec2 tuv = vec2(uv.x, 1.0 - uv.y);`. A shader that never declares
+these uniforms is unaffected — the renderer skips locations it can't find.
+[`examples/textoverlay`](../../examples/textoverlay) is a complete song + shader
+pair with four transition styles.
 
 Common idioms:
 
@@ -70,11 +104,19 @@ node ../tools/shadertest/render.mjs path/to/shader.glsl --time 6 --energy 0.7
 node ../tools/shadertest/render.mjs path/to/shader.glsl --frames 3,18,30 --energy 0.8
 ```
 
+```sh
+# text layer + song params: mid-transition between two texts, wipe style
+node ../tools/shadertest/render.mjs path/to/shader.glsl \
+  --text "Refrenget" --textprev "Første vers" --textmix 0.45 --visual textTransition=1
+```
+
 Options: `--time <s>`, `--frames <t1,t2,..>`, `--energy <0..1>` (fills a band of
 note states so reactive shaders light up), `--size <WxH>`, `--out <file.png>`,
-`--outdir <dir>`, `--compile-only`. On a compile error it prints the GLSL info
-log and exits non-zero. Each rendered frame prints a `lit=NN%` metric (fraction
-of non-black pixels) — a quick "did anything draw" sanity check.
+`--outdir <dir>`, `--text <string>` / `--textprev <string>` / `--textmix <0..1>`
+(the showText layer — `\n` for line breaks), `--visual <name=value>` (repeatable,
+for setVisual params), `--compile-only`. On a compile error it prints the GLSL
+info log and exits non-zero. Each rendered frame prints a `lit=NN%` metric
+(fraction of non-black pixels) — a quick "did anything draw" sanity check.
 
 The loop that works well:
 

--- a/wasmaudioworklet/docs/shaders.md
+++ b/wasmaudioworklet/docs/shaders.md
@@ -53,14 +53,18 @@ uniform sampler2D uTextPrev;
 uniform float uTextMix;
 uniform float textTransition;   // set by the song via setVisual / showText's `transition`
 
+vec2 tuv = gl_FragCoord.xy / resolution;   // 0..1 — NOT the centered `uv` above
+tuv.y = 1.0 - tuv.y;                       // texture rows upload top-first
 // crossfade the outgoing text out and the incoming text in
 vec4 t = mix(texture2D(uTextPrev, tuv), texture2D(uText, tuv), uTextMix);
 col = mix(col, t.rgb, t.a);
 ```
 
-Note the text image uploads top-row-first, so flip the y coordinate when
-sampling: `vec2 tuv = vec2(uv.x, 1.0 - uv.y);`. A shader that never declares
-these uniforms is unaffected — the renderer skips locations it can't find.
+Two easy mistakes: sampling with the **centered** `uv` from the idiom above
+(texture coordinates must be 0..1, or the text ends up clipped in a corner),
+and declaring the uniforms without ever sampling them (GLSL drops unused
+uniforms, so nothing appears). A shader that never declares them at all is
+unaffected — the renderer skips locations it can't find.
 [`examples/textoverlay`](../../examples/textoverlay) is a complete song + shader
 pair with four transition styles.
 

--- a/wasmaudioworklet/docs/song-api.md
+++ b/wasmaudioworklet/docs/song-api.md
@@ -18,6 +18,7 @@ Never wrap sequencing in an async IIFE (`(async () => { ... })()`) or any other 
 - [Track Functions](#track-functions)
 - [Note Functions](#note-functions)
 - [Video/Audio Functions](#videoaudio-functions)
+- [Shader Text & Parameter Functions](#shader-text--parameter-functions)
 - [Recording Functions](#recording-functions)
 - [Song Structure Functions](#song-structure-functions)
 - [Channel Control Functions](#channel-control-functions)
@@ -224,6 +225,61 @@ Stops video playback.
 
 **Parameters:**
 - `name` (string): Video identifier
+
+---
+
+## Shader Text & Parameter Functions
+
+The sequence can drive the visualizer shader directly: **what** text is on
+screen, **when** it appears, and — through a parameter the shader branches on —
+**how** it appears. See [shaders.md](shaders.md) for the shader side and
+[animations.md](animations.md) for worked examples.
+
+### `showText(text, options = {})`
+Shows text at the current song time, on the shader's text layer
+(`uText` / `uTextPrev` / `uTextMix`). Each call supersedes the previous text.
+The text is rendered to an SVG image — no DOM needed, so it works inside the
+song sandbox.
+
+**Parameters:**
+- `text` (string | string[]): the text; `\n` or an array gives several lines
+- `options` (object):
+  - `fade` (number): seconds for `uTextMix` to travel 0 → 1 (default `1.0`; `0` snaps)
+  - `transition` (number): sets the `textTransition` visual param, which the
+    shader reads to pick a style. Only meaningful if your shader implements it.
+  - `size` (number), `color`, `font`, `weight`, `align` (`left`/`center`/`right`),
+    `x`, `y` (0..1 anchors), `lineHeight`, `background`, `stroke`, `strokeWidth`,
+    `width`, `height` — styling of the generated image (defaults: 1280x720,
+    96px bold white sans-serif, centered, transparent background)
+
+**Example:**
+```javascript
+showText('Første vers', { transition: 1, fade: 0.8 });
+showText(['Two lines', 'at once'], { size: 72, stroke: '#000', strokeWidth: 6 });
+```
+
+### `hideText(options = {})`
+Clears the text layer (an empty image, transitioned like any other text).
+Takes the same `fade` / `transition` options.
+
+### `setVisual(name, value, rampSeconds = 0)`
+Schedules a named float that the shader reads as `uniform float <name>`. The
+app assigns no meaning to the names — the song and its shader agree on them.
+
+**Parameters:**
+- `name` (string): must be a valid GLSL identifier (`[A-Za-z_][A-Za-z0-9_]*`)
+- `value` (number | boolean): booleans become 1 / 0
+- `rampSeconds` (number): interpolate from the previous value over this many
+  seconds instead of stepping (default `0`)
+
+Before its first scheduled value a parameter reads `0`. Values are resolved
+from song time, so seeking and video export give the same result as playback.
+
+**Example:**
+```javascript
+setVisual('sceneMode', 2);          // step
+setVisual('bloom', 1.0, 4);         // ramp up over 4 seconds
+```
 
 ---
 

--- a/wasmaudioworklet/e2e/studio-agent-mock.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-mock.spec.js
@@ -194,6 +194,50 @@ test.describe('studio-agent client with mocked agent server', () => {
         expect(await page.evaluate(() => !!window.audioworkletnode)).toBe(false);
     });
 
+    test('shader tools: the agent can see and fix a shader that cannot show the song visuals', async ({ page }) => {
+        await openAppWithMockAgent(page, mock);
+
+        // A song that shows text, and a shader with no text layer — the
+        // combination that silently renders nothing.
+        expect((await mock.callTool('set_song', {
+            source: `setBPM(120);\nshowText('hello', { fade: 1 });\nawait createTrack(0).steps(4, [c4,,,,]);\nloopHere();\n`,
+        })).ok).toBe(true);
+        const noTextLayer = `precision highp float;
+uniform vec2 resolution;
+uniform float time;
+void main() { gl_FragColor = vec4(gl_FragCoord.xy / resolution, abs(sin(time)), 1.0); }
+`;
+        const set = await mock.callTool('set_shader', { source: noTextLayer });
+        expect(set.ok).toBe(true);
+        // Every shader write reports what the song schedules but this shader can't show.
+        expect(String(set.result)).toContain('uText');
+
+        expect((await mock.callTool('compile', {})).result).toContain('compiled OK');
+        // ...and so does compile, so the agent cannot miss it.
+        expect(String((await mock.callTool('compile', {})).result)).toContain('showText');
+
+        // grep_shader is how the agent inspects what the shader supports.
+        const grep = await mock.callTool('grep_shader', { pattern: 'uniform' });
+        expect(grep.ok).toBe(true);
+        expect(String(grep.result)).toContain('uniform vec2 resolution');
+
+        // edit_shader adds the text layer in place; the warning then clears.
+        const edit = await mock.callTool('edit_shader', {
+            old_string: 'uniform float time;',
+            new_string: `uniform float time;
+uniform sampler2D uText;
+uniform sampler2D uTextPrev;
+uniform float uTextMix;`,
+        });
+        expect(edit.ok).toBe(true);
+        expect(String(edit.result)).toContain('applied 1 edit');
+        expect(String(edit.result)).not.toContain('uText;'); // no warning left
+
+        const shader = await mock.callTool('get_shader', {});
+        expect(String(shader.result)).toContain('uniform sampler2D uTextPrev;');
+        expect(String((await mock.callTool('compile', {})).result)).not.toContain('showText');
+    });
+
     test('there is no play tool — the agent cannot start playback', async ({ page }) => {
         await openAppWithMockAgent(page, mock);
         const res = await mock.callTool('play', {});

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -15,6 +15,9 @@ import { updateSong, updateSynth, exportToWav } from './synth1/audioworklet/midi
 import { compileWebAssemblySynth } from './synth1/browsersynthcompiler.js';
 
 import { exportVideo, setupWebGL } from './visualizer/fragmentshader.js';
+import { hasScheduledText } from './visualizer/videoscheduler.js';
+import { getVisualParamNames } from './visualizer/visualparams.js';
+import { visualWarnings } from './visualizer/visualwarnings.js';
 import { triggerDownload } from './common/filedownload.js';
 import { decodeBufferFromPNG, encodeBufferAsPNG } from './common/png.js';
 import { isSointuSong, getSointuWasm, getSointuYaml } from './sointu/playsointu.js';
@@ -363,6 +366,23 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
 
     componentRoot.getElementById('savesongbutton').onclick = () => compileAndPostSong();
 
+    // Visuals the song asks for that a shader source cannot show. Defaults to
+    // the shader EDITOR's current content so the studio agent can check a
+    // shader it just edited without compiling first — which is also why the
+    // song is scanned textually as well as through the compiled schedule: an
+    // edited-but-not-yet-compiled song must still produce the warning.
+    window.getVisualWarnings = (source = shadersourceeditor.doc.getValue()) => {
+        const songsource = songsourceeditor.doc.getValue();
+        const paramNames = new Set(getVisualParamNames());
+        for (const m of songsource.matchAll(/setVisual\s*\(\s*['"`]([A-Za-z_][A-Za-z0-9_]*)['"`]/g)) {
+            paramNames.add(m[1]);
+        }
+        return visualWarnings(source, {
+            hasText: hasScheduledText() || /\b(showText|hideText)\s*\(/.test(songsource),
+            paramNames: [...paramNames],
+        });
+    };
+
     window.compileSong = async function (exportProject = false) {
         const errorMessagesElement = componentRoot.querySelector('#errormessages');
         const errorMessagesContentElement = errorMessagesElement.querySelector('span');
@@ -456,6 +476,12 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
                 const eventlist = await compileMidiSong(songsource);
                 if (midiInstrumentNames.length > 0) {
                     setInstrumentNames(midiInstrumentNames);
+                }
+                // Non-fatal: the song compiled, but its visuals have no shader
+                // uniform to land on (a real error later overwrites this).
+                const warnings = window.getVisualWarnings();
+                if (warnings.length) {
+                    displayError(warnings.join('\n\n'));
                 }
                 if (synthSourceIsXML && exportProject) {
                     await exportWAMAudio(eventlist, synthsource);

--- a/wasmaudioworklet/midisequencer/quickjssandbox.js
+++ b/wasmaudioworklet/midisequencer/quickjssandbox.js
@@ -30,6 +30,7 @@ const SANDBOX_MEMORY_LIMIT = 64 * 1024 * 1024;
 const GUEST_SOURCE_FILES = [
     'sequenceconstants.js',
     'pattern.js',
+    'textimage.js',
     'trackerpattern.js',
     'songcompiler.js',
 ];
@@ -39,6 +40,8 @@ const GUEST_SOURCE_FILES = [
 const GUEST_PRELUDE = `
 globalThis.console = { log: print, warn: print, error: print };
 const setVideoSchedule = () => {};
+const setTextSchedule = () => {};
+const setVisualParamSchedule = () => {};
 `;
 
 // Appended in the same module scope as the stripped sources: replace the
@@ -80,14 +83,17 @@ export async function __runSong() {
         output: { startTime: p.output.startTime, midievents: p.output.midievents }
     }));
     result.audioUrls = __audioUrls;
+    result.visualParams = visualParams;
     result.visual = Object.fromEntries(Object.entries(addedVideo)
         .map(([name, v]) => [name, {
             url: v.url,
             isImage: !!v.isImage,
+            layer: v.layer,
             schedule: v.schedule.map(s => ({
                 startTime: s.startTime,
                 stopTime: s.stopTime,
-                clipStartTime: s.clipStartTime
+                clipStartTime: s.clipStartTime,
+                fade: s.fade
             }))
         }]));
     return JSON.stringify(result);

--- a/wasmaudioworklet/midisequencer/songcompiler.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.js
@@ -1,7 +1,9 @@
 import { resetTick, setBPM, nextTick, currentTime, waitForBeat, waitDuration } from './pattern.js';
 import { TrackerPattern, pitchbend, controlchange, createNoteFunctions, noteFunctionKeys } from './trackerpattern.js';
 import { SEQ_MSG_LOOP, SEQ_MSG_START_RECORDING, SEQ_MSG_STOP_RECORDING, SEQ_MSG_BROADCAST_SEND, SEQ_MSG_BROADCAST_WAIT } from './sequenceconstants.js';
-import { setVideoSchedule } from '../visualizer/videoscheduler.js';
+import { setVideoSchedule, setTextSchedule } from '../visualizer/videoscheduler.js';
+import { setVisualParamSchedule } from '../visualizer/visualparams.js';
+import { textToSvgDataUrl } from './textimage.js';
 
 // Map a URL to one suitable for assignment to <img>/<video>.src.
 // Repo-relative paths (no protocol, no leading slash) are read via the host-
@@ -55,6 +57,10 @@ export const addedVideo = {};
 
 let trackerPatterns = [];
 let songParts = {};
+// setVisual calls, stamped with song time: { time, name, value, ramp }.
+let visualParams = [];
+// showText registers each text as its own image entry — unique name per call.
+let textCounter = 0;
 
 const AsyncFunction = Object.getPrototypeOf(async function () { }).constructor;
 const output = {
@@ -97,6 +103,56 @@ function startVideo(name, clipStartTime = 0) {
 
 function stopVideo(name) {
     addedVideo[name].schedule[addedVideo[name].schedule.length - 1].stopTime = currentTime();
+}
+
+// --- Visuals driven from the sequence ---------------------------------------
+// setVisual schedules a named float that the shader reads as
+// `uniform float <name>`; showText schedules a text image on the shader's text
+// layer (uText/uTextPrev/uTextMix). Together they let the song decide what to
+// show, when, and — via a param the shader branches on — how.
+
+const VISUAL_PARAM_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const DEFAULT_TEXT_FADE_SECONDS = 1.0;
+
+function setVisual(name, value, rampSeconds = 0) {
+    if (!VISUAL_PARAM_NAME.test(name)) {
+        throw new Error(`setVisual: '${name}' is not a valid GLSL uniform name`);
+    }
+    const numeric = typeof value === 'boolean' ? (value ? 1 : 0) : Number(value);
+    if (!isFinite(numeric)) {
+        throw new Error(`setVisual('${name}', ...): value must be a finite number, got ${value}`);
+    }
+    visualParams.push({
+        time: currentTime(),
+        name,
+        value: numeric,
+        ramp: Math.max(0, Number(rampSeconds) || 0) * 1000,
+    });
+}
+
+function showText(text, options = {}) {
+    const name = `__text${textCounter++}`;
+    // cache: false — the generated names repeat between compiles, and the
+    // content behind them changes when the song is edited.
+    // Not awaited on purpose: addImage registers addedVideo[name] synchronously
+    // (both in the guest recorder and on the host) before it resolves the URL,
+    // so the schedule push below always finds the entry.
+    songargs.addImage(name, textToSvgDataUrl(text, options), false);
+    addedVideo[name].layer = 'text';
+    addedVideo[name].schedule.push({
+        startTime: currentTime(),
+        fade: options.fade === undefined
+            ? DEFAULT_TEXT_FADE_SECONDS
+            : Math.max(0, Number(options.fade) || 0),
+    });
+    if (options.transition !== undefined) {
+        setVisual('textTransition', options.transition);
+    }
+    return name;
+}
+
+function hideText(options = {}) {
+    return showText('', options);
 }
 
 // Emit a named signal on the BroadcastChannel at the current song time.
@@ -151,6 +207,9 @@ const songargs = {
     'stopRecording': stopRecording,
     'startVideo': startVideo,
     'stopVideo': stopVideo,
+    'setVisual': setVisual,
+    'showText': showText,
+    'hideText': hideText,
     'broadcastSend': broadcastSend,
     'broadcastWait': broadcastWait,
     'definePartStart': (partName) => songParts[partName] = { startTime: currentTime() },
@@ -223,21 +282,29 @@ export async function compileSong(songsource) {
     result.audioUrls.forEach(url => songargs.addAudio(url));
 
     const videoSchedule = [];
+    const textSchedule = [];
     Object.values(addedVideo).forEach(vid => vid.schedule = []);
     for (const [name, spec] of Object.entries(result.visual)) {
+        const isText = spec.layer === 'text';
         if (spec.isImage) {
-            await songargs.addImage(name, spec.url);
+            // Text entries reuse their names between compiles with new content,
+            // so they must replace rather than hit the name cache.
+            await songargs.addImage(name, spec.url, !isText);
         } else {
             await songargs.addVideo(name, spec.url);
         }
+        addedVideo[name].layer = spec.layer;
         addedVideo[name].schedule = spec.schedule;
         spec.schedule.forEach(sch => {
             sch.video = addedVideo[name];
-            videoSchedule.push(sch);
+            (isText ? textSchedule : videoSchedule).push(sch);
         });
     }
     videoSchedule.sort((a, b) => b.startTime - a.startTime);
+    textSchedule.sort((a, b) => b.startTime - a.startTime);
     setVideoSchedule(videoSchedule);
+    setTextSchedule(textSchedule);
+    setVisualParamSchedule(result.visualParams);
 
     return songmessages;
 }
@@ -253,7 +320,10 @@ export async function generateSong(songfunc) {
     songmessages = [];
     instrumentNames = [];
     trackerPatterns = [];
+    visualParams = [];
+    textCounter = 0;
     const videoSchedule = [];
+    const textSchedule = [];
     Object.values(addedVideo).forEach(vid => vid.schedule = []);
     muted = {};
     solo = {};
@@ -281,11 +351,14 @@ export async function generateSong(songfunc) {
     Object.values(addedVideo).forEach(vid =>
         vid.schedule.forEach(sch => {
             sch.video = vid;
-            videoSchedule.push(sch);
+            (vid.layer === 'text' ? textSchedule : videoSchedule).push(sch);
         })
     );
     videoSchedule.sort((a, b) => b.startTime - a.startTime);
+    textSchedule.sort((a, b) => b.startTime - a.startTime);
     setVideoSchedule(videoSchedule);
+    setTextSchedule(textSchedule);
+    setVisualParamSchedule(visualParams);
 
     const loopMessageIndex = songmessages.findIndex(evt => evt.message == SEQ_MSG_LOOP);
     if (loopMessageIndex > -1) {

--- a/wasmaudioworklet/midisequencer/songcompiler.spec.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.spec.js
@@ -1,4 +1,5 @@
-import { getActiveVideo } from '../visualizer/videoscheduler.js';
+import { getActiveVideo, getActiveText } from '../visualizer/videoscheduler.js';
+import { getActiveVisualParams } from '../visualizer/visualparams.js';
 import { compileSong, convertEventListToByteArraySequence, createMultipatternSequence, addedVideo, getSongParts, reassembleSongParts } from './songcompiler.js';
 
 describe('songcompiler', async function () {
@@ -466,6 +467,40 @@ loopHere();
         expect(getActiveVideo(500).src).to.equal(img2);
         expect(getActiveVideo(1000).src).to.equal(img3);
         expect(getActiveVideo(1500).src).to.equal(img4);
+    });
+    it('should schedule text and visual params from the song', async () => {
+        const songsource = `
+        setBPM(120);
+
+        setVisual('glow', 0.25);
+        showText('Hello', { fade: 0.5 });
+        await createTrack(0).steps(4, [c3,,,,]);
+        setVisual('glow', 1, 1);
+        showText('World', { transition: 2, fade: 0 });
+        await createTrack(0).steps(4, [c3,,,,]);
+        hideText();
+        loopHere();
+`;
+        await compileSong(songsource);
+
+        // one beat at 120bpm = 500ms
+        const first = getActiveText(0);
+        expect(first.fade).to.equal(0.5);
+        expect(decodeURIComponent(first.video.imageElement.src)).to.contain('>Hello<');
+        expect(decodeURIComponent(getActiveText(700).video.imageElement.src)).to.contain('>World<');
+        // hideText renders an image without any text element
+        expect(decodeURIComponent(getActiveText(1200).video.imageElement.src)).to.not.contain('<text');
+
+        // text goes on its own layer — the image/video schedule stays empty
+        expect(getActiveVideo(700)).to.equal(undefined);
+
+        expect(getActiveVisualParams(0).get('glow')).to.equal(0.25);
+        // ramped over 1s from 500ms
+        expect(getActiveVisualParams(1000).get('glow')).to.be.closeTo(0.625, 1e-9);
+        expect(getActiveVisualParams(1500).get('glow')).to.equal(1);
+        // showText's transition rides on the same channel
+        expect(getActiveVisualParams(0).get('textTransition')).to.equal(0);
+        expect(getActiveVisualParams(700).get('textTransition')).to.equal(2);
     });
 }
 );

--- a/wasmaudioworklet/midisequencer/textimage.js
+++ b/wasmaudioworklet/midisequencer/textimage.js
@@ -1,0 +1,81 @@
+// Render song text to an SVG data URL.
+//
+// The song script runs inside the QuickJS sandbox (see quickjssandbox.js), so
+// it has no DOM — no canvas, no document. Building an SVG document is pure
+// string work, which the sandbox allows, and the host turns the resulting
+// data: URL into an <img> exactly like any other image (see showText in
+// songcompiler.js). This module is part of the guest source bundle, so keep it
+// free of imports and browser APIs.
+
+export const DEFAULT_TEXT_OPTIONS = {
+    width: 1280,          // texture size; the shader maps it with its own uv
+    height: 720,
+    size: 96,             // font size in px, relative to width/height above
+    font: 'sans-serif',   // system fonts only — no webfont fetch from an <img>
+    weight: 'bold',
+    color: '#ffffff',
+    align: 'center',      // left | center | right
+    x: 0.5,               // horizontal anchor, 0..1 of width
+    y: 0.5,               // vertical centre of the text block, 0..1 of height
+    lineHeight: 1.25,
+    background: null,     // e.g. 'rgba(0,0,0,0.4)'; transparent when null
+    stroke: null,         // outline colour — legibility over busy visuals
+    strokeWidth: 0,
+};
+
+const TEXT_ANCHOR = { left: 'start', center: 'middle', right: 'end' };
+
+function escapeXml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
+export function textToLines(text) {
+    if (text === null || text === undefined) return [];
+    const lines = (Array.isArray(text) ? text : String(text).split('\n'))
+        .map(line => String(line));
+    // A single empty string means "no text" (hideText) — an empty, fully
+    // transparent image rather than a blank line.
+    return lines.length === 1 && lines[0] === '' ? [] : lines;
+}
+
+export function textToSvg(text, options = {}) {
+    const o = { ...DEFAULT_TEXT_OPTIONS, ...options };
+    const lines = textToLines(text);
+    const anchor = TEXT_ANCHOR[o.align] || 'middle';
+    const x = o.x * o.width;
+    const step = o.size * o.lineHeight;
+    // Centre the block on o.y, then offset to the first baseline (roughly the
+    // cap height of the first line).
+    const firstBaseline = o.y * o.height - (lines.length - 1) * step / 2 + o.size * 0.35;
+
+    const parts = [
+        `<svg xmlns="http://www.w3.org/2000/svg" width="${o.width}" height="${o.height}" viewBox="0 0 ${o.width} ${o.height}">`,
+    ];
+    if (o.background) {
+        parts.push(`<rect width="${o.width}" height="${o.height}" fill="${escapeXml(o.background)}"/>`);
+    }
+    const strokeAttrs = o.stroke && o.strokeWidth > 0
+        // paint-order puts the outline behind the fill so it doesn't eat the glyphs
+        ? ` stroke="${escapeXml(o.stroke)}" stroke-width="${o.strokeWidth}" stroke-linejoin="round" paint-order="stroke"`
+        : '';
+    lines.forEach((line, ndx) => {
+        parts.push(
+            `<text x="${x}" y="${firstBaseline + ndx * step}"` +
+            ` font-family="${escapeXml(o.font)}" font-size="${o.size}" font-weight="${escapeXml(o.weight)}"` +
+            ` fill="${escapeXml(o.color)}" text-anchor="${anchor}"${strokeAttrs}>${escapeXml(line)}</text>`
+        );
+    });
+    parts.push('</svg>');
+    return parts.join('');
+}
+
+export function textToSvgDataUrl(text, options = {}) {
+    // encodeURIComponent keeps this valid for characters an SVG data URL can't
+    // carry raw (#, %, non-ASCII like æøå).
+    return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(textToSvg(text, options));
+}

--- a/wasmaudioworklet/midisequencer/textimage.spec.js
+++ b/wasmaudioworklet/midisequencer/textimage.spec.js
@@ -1,0 +1,54 @@
+import { textToSvg, textToSvgDataUrl, textToLines } from './textimage.js';
+
+describe('textimage', function () {
+    it('should split lines from a string or an array', () => {
+        expect(textToLines('one\ntwo')).to.deep.equal(['one', 'two']);
+        expect(textToLines(['one', 'two'])).to.deep.equal(['one', 'two']);
+        // hideText() shows an empty image, not a blank line
+        expect(textToLines('')).to.deep.equal([]);
+        expect(textToLines(null)).to.deep.equal([]);
+    });
+
+    it('should render one text element per line', () => {
+        const svg = textToSvg(['first', 'second']);
+        expect(svg.match(/<text /g).length).to.equal(2);
+        expect(svg).to.contain('>first<');
+        expect(svg).to.contain('>second<');
+        expect(svg).to.contain('width="1280" height="720"');
+    });
+
+    it('should escape markup in the text', () => {
+        const svg = textToSvg('rock & <roll>');
+        expect(svg).to.contain('rock &amp; &lt;roll&gt;');
+    });
+
+    it('should apply style options', () => {
+        const svg = textToSvg('styled', {
+            size: 40, color: '#ff0000', align: 'left', font: 'monospace',
+            background: 'black', stroke: '#000', strokeWidth: 3,
+        });
+        expect(svg).to.contain('font-size="40"');
+        expect(svg).to.contain('fill="#ff0000"');
+        expect(svg).to.contain('text-anchor="start"');
+        expect(svg).to.contain('font-family="monospace"');
+        expect(svg).to.contain('<rect');
+        expect(svg).to.contain('stroke-width="3"');
+    });
+
+    it('should produce an image data url a browser can decode', async () => {
+        const url = textToSvgDataUrl('Første vers');
+        expect(url.startsWith('data:image/svg+xml;charset=utf-8,')).to.equal(true);
+        const image = new Image();
+        image.src = url;
+        await image.decode();
+        expect(image.naturalWidth).to.equal(1280);
+        expect(image.naturalHeight).to.equal(720);
+    });
+
+    it('should produce an empty but valid image for no text', async () => {
+        const image = new Image();
+        image.src = textToSvgDataUrl('');
+        await image.decode();
+        expect(image.naturalWidth).to.equal(1280);
+    });
+});

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -32,7 +32,7 @@
         "test-claude-bridge": "npx playwright test e2e/claude-bridge.spec.js",
         "near-sandbox": "docker run --rm -p 3030:8080 ghcr.io/petersalomonsen/near-git-storage/sandbox:main",
         "test-faust": "node ../tools/faust2as/generate-test-sources.js && npx playwright test e2e/faust2as-compilation.spec.js",
-        "test-agent-tools": "node --test studio-agent-tools-core.test.mjs studio-agent-nearai-core.test.mjs",
+        "test-agent-tools": "node --test studio-agent-tools-core.test.mjs studio-agent-nearai-core.test.mjs studio-agent-tools-def.test.mjs",
         "test-quickjs-sandbox": "node --test quickjs-sandbox-poc.test.mjs",
         "test-gitproxy": "node --test gitproxy.test.mjs nearai-proxy.test.mjs"
     },

--- a/wasmaudioworklet/quickjs-sandbox-poc.test.mjs
+++ b/wasmaudioworklet/quickjs-sandbox-poc.test.mjs
@@ -84,3 +84,38 @@ test('malicious song cannot reach the network', async () => {
 test('runaway song is interrupted instead of hanging', async () => {
     await assert.rejects(runSongInSandbox('while(true){}', 1000));
 });
+
+// showText builds its image as an SVG data URL, which is pure string work —
+// the guest has no canvas or document to render text with. The host only
+// receives the URL and turns it into an <img> (see compileSong).
+test('visuals: setVisual and showText cross the sandbox boundary', async () => {
+    const result = await runSongInSandbox(`
+        setBPM(120);
+        setVisual('glow', 0.25);
+        showText('Hei & hå', { fade: 0.5, transition: 2 });
+        await createTrack(0).steps(4, [c3,,,,]);
+        setVisual('glow', 1, 1.5);
+        hideText({ fade: 0 });
+        loopHere();
+    `);
+
+    assert.deepStrictEqual(result.visualParams, [
+        { time: 0, name: 'glow', value: 0.25, ramp: 0 },
+        { time: 0, name: 'textTransition', value: 2, ramp: 0 },
+        { time: 500, name: 'glow', value: 1, ramp: 1500 },
+    ]);
+
+    const texts = Object.values(result.visual).filter(spec => spec.layer === 'text');
+    assert.strictEqual(texts.length, 2);
+    assert.deepStrictEqual(texts[0].schedule, [{ startTime: 0, fade: 0.5 }]);
+    assert.match(decodeURIComponent(texts[0].url), /<text[^>]*>Hei &amp; hå<\/text>/);
+    assert.deepStrictEqual(texts[1].schedule, [{ startTime: 500, fade: 0 }]);
+    assert.doesNotMatch(decodeURIComponent(texts[1].url), /<text/);
+});
+
+test('setVisual rejects names that are not valid GLSL uniforms', async () => {
+    await assert.rejects(runSongInSandbox(`setVisual('not a name', 1); await createTrack(0).steps(4, [c3]);`),
+        /not a valid GLSL uniform name/);
+    await assert.rejects(runSongInSandbox(`setVisual('glow', 'bright'); await createTrack(0).steps(4, [c3]);`),
+        /must be a finite number/);
+});

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -5,7 +5,7 @@
 // editors, the compiler, the audio worklet) and send the result back. This is
 // the "full in-app" path: tool calls operate on the browser, not on disk.
 
-import { songsourceeditor, synthsourceeditor } from './editorcontroller.js';
+import { songsourceeditor, synthsourceeditor, shadersourceeditor } from './editorcontroller.js';
 import { transpileDspSource } from './faust/faust-rs-transpile.js';
 import { readfile, writefileandstage, listfiles, gitCommand, gitLog } from './wasmgit/wasmgitclient.js';
 import { applyEditToText, grepText, normDsp, faustRegistrationHint, songSourceWarnings } from './studio-agent-tools-core.js';
@@ -63,6 +63,14 @@ function grepDoc(editor, args) {
   return r;
 }
 
+// What the last compiled song schedules but the CURRENT shader document cannot
+// show (showText with no uText, setVisual names the shader never declares).
+// The app computes the same warnings for the human in the error panel; the
+// agent gets them straight in the tool result, where it can act on them.
+function shaderWarnings() {
+  return window.getVisualWarnings ? window.getVisualWarnings(shadersourceeditor.doc.getValue()) : [];
+}
+
 // ---- the tool registry: tool name -> async fn acting on the app -------------
 // Returning an object with `__error` marks a failed tool result.
 const registry = {
@@ -81,6 +89,22 @@ const registry = {
   },
   grep_synth: async (args) => grepDoc(synthsourceeditor, args),
   grep_song: async (args) => grepDoc(songsourceeditor, args),
+
+  // ---- the visualizer shader (GLSL) ----
+  // The song's visuals only reach the screen through uniforms this document
+  // declares, so shader edits and song edits belong to the same job. Every
+  // write reports back what the song schedules but the shader can't show.
+  get_shader: async () => shadersourceeditor.doc.getValue() || '(no shader — the shader editor is empty)',
+  set_shader: async ({ source }) => {
+    shadersourceeditor.doc.setValue(source);
+    return ['shader updated', ...shaderWarnings()].join('\n');
+  },
+  edit_shader: async (args) => {
+    const result = applyEdit(shadersourceeditor, args);
+    if (result && result.__error) return result;
+    return [result, ...shaderWarnings()].join('\n');
+  },
+  grep_shader: async (args) => grepDoc(shadersourceeditor, args),
 
   // ---- Faust instrument authoring (OPFS faust/ folder; needs ?gitrepo= mode) ----
   list_faust: async () => {
@@ -158,13 +182,19 @@ const registry = {
       return { __error: String(e?.message || e) };
     }
     const err = readErrorPanel();
-    if (!err) return 'compiled OK';
+    // Visuals the song scheduled that the shader can't show are read straight
+    // from the app rather than the panel — a later synth warning would
+    // otherwise overwrite them there.
+    const visual = shaderWarnings();
+    if (!err) return ['compiled OK', ...visual].join('\n');
     // The panel also surfaces NON-fatal AssemblyScript warnings (AS233/AS235…)
     // after a successful build — reporting those as an error makes models
     // "fix" working code. Only real ERROR lines fail the tool.
     const text = err.replace(/^Error:\s*/, '');
-    const onlyWarnings = /^WARNING/.test(text) && !/(^|\n)\s*ERROR/.test(text);
-    if (onlyWarnings) return 'compiled OK (non-fatal AssemblyScript warnings in the panel — ignore them)';
+    const onlyWarnings = /^WARNING/i.test(text) && !/(^|\n)\s*ERROR/.test(text);
+    if (onlyWarnings) {
+      return ['compiled OK (non-fatal AssemblyScript warnings in the panel — ignore them)', ...visual].join('\n');
+    }
     return { __error: err };
   },
   // NOTE: intentionally NO `play` tool — starting playback is the user's

--- a/wasmaudioworklet/studio-agent-client.js
+++ b/wasmaudioworklet/studio-agent-client.js
@@ -376,9 +376,12 @@ function nearaiConfig() {
   const enabled = apiKey || localStorage.getItem('nearai-enabled');
   if (!enabled) return null;
   const baseUrl = localStorage.getItem('nearai-base-url') || resolveDefaultBaseUrl(location.hostname);
-  // A relative base URL = the same-origin Pages Function proxy, which holds
-  // the API key AND injects the system prompt + tools server-side.
-  const proxy = baseUrl.startsWith('/');
+  // The Pages Function proxy holds the API key AND injects the system prompt +
+  // tools server-side. Normally it is same-origin (a relative base URL), but an
+  // absolute .../nearai/v1 also counts — that lets a locally served app drive a
+  // deployed proxy (it origin-allowlists localhost), which is how the NEAR AI
+  // path gets exercised without handing a key to the browser.
+  const proxy = baseUrl.startsWith('/') || (!apiKey && /\/nearai\/v1\/?$/.test(baseUrl));
   if (!proxy && !apiKey) return null; // direct upstream needs the user's key
   return {
     apiKey: proxy ? null : apiKey,

--- a/wasmaudioworklet/studio-agent-nearai-core.js
+++ b/wasmaudioworklet/studio-agent-nearai-core.js
@@ -19,35 +19,14 @@ export function resolveDefaultBaseUrl(hostname) {
     : '/nearai/v1';
 }
 
-// Tool definitions in OpenAI function-calling format. Descriptions mirror
-// tools/studio-agent/server.mjs — keep them in sync when tools change.
-const str = (description) => ({ type: 'string', description });
-const opt = (props, required) => ({ type: 'object', properties: props, required });
+// The tool set is declared once in studio-agent-tools-def.js and shared with
+// the local Agent SDK path; here it is only reshaped into OpenAI
+// function-calling format. Serverless mode gets every tool including the
+// repo-file readers (there is no built-in Read here).
+export { TOOL_DEFS } from './studio-agent-tools-def.js';
+import { TOOL_DEFS as SHARED_TOOL_DEFS } from './studio-agent-tools-def.js';
 
-export const TOOL_DEFS = [
-  { name: 'get_song', description: 'Return the current song document (JavaScript sequencer DSL).', parameters: opt({}, []) },
-  { name: 'set_song', description: 'Replace the entire song document. Provide the full new source.', parameters: opt({ source: str('full new song source') }, ['source']) },
-  { name: 'get_synth', description: 'Return the current synth document (AssemblyScript).', parameters: opt({}, []) },
-  { name: 'set_synth', description: 'Replace the entire synth document. Provide the full new source.', parameters: opt({ source: str('full new synth source') }, ['source']) },
-  { name: 'edit_synth', description: 'Surgically find-and-replace in the synth document IN PLACE. old_string must match exactly and be unique unless replace_all is true.', parameters: opt({ old_string: str('exact text to find'), new_string: str('replacement text'), replace_all: { type: 'boolean' } }, ['old_string', 'new_string']) },
-  { name: 'edit_song', description: 'Surgically find-and-replace in the song document IN PLACE. old_string must match exactly and be unique unless replace_all is true.', parameters: opt({ old_string: str('exact text to find'), new_string: str('replacement text'), replace_all: { type: 'boolean' } }, ['old_string', 'new_string']) },
-  { name: 'grep_synth', description: 'Regex-search the CURRENT synth document; returns matching line numbers + text.', parameters: opt({ pattern: str('regex pattern'), context: { type: 'number' } }, ['pattern']) },
-  { name: 'grep_song', description: 'Regex-search the CURRENT song document; returns matching line numbers + text.', parameters: opt({ pattern: str('regex pattern'), context: { type: 'number' } }, ['pattern']) },
-  { name: 'write_faust', description: 'Author an INSTRUMENT in Faust: write faust/<path>.dsp AND transpile it to AssemblyScript in one step. Returns the generated class names to import into synth.ts, or the exact transpile error.', parameters: opt({ path: str('faust file basename'), source: str('faust dsp source') }, ['path', 'source']) },
-  { name: 'read_faust', description: 'Read a Faust .dsp instrument source from the browser OPFS faust/ folder.', parameters: opt({ path: str('faust file basename') }, ['path']) },
-  { name: 'list_faust', description: 'List the .dsp Faust instruments in the browser OPFS faust/ folder.', parameters: opt({}, []) },
-  { name: 'git_log', description: 'Show the commit history of the in-browser OPFS repo.', parameters: opt({}, []) },
-  { name: 'read_committed', description: 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD).', parameters: opt({ path: str('repo-relative path'), ref: str('git ref, default HEAD') }, ['path']) },
-  { name: 'compile', description: "SAVE + compile the current song+synth in the browser (same as the app's save button). If a track is already playing, the changes are applied and audible immediately. Returns 'compiled OK' or the exact compiler error. Call after every edit. There is NO play tool — the user starts playback themselves.", parameters: opt({}, []) },
-  { name: 'stop', description: "Stop live audio playback. Only on the user's request.", parameters: opt({}, []) },
-  // Serverless replacements for the local agent's repo-file access (fetched
-  // from the public GitHub repo via jsDelivr instead of local disk):
-  { name: 'read_repo_file', description: 'Read a reference file from the javascriptmusic repository (examples, docs). Path is repo-relative, e.g. "wasmaudioworklet/docs/song-api.md" or "examples/beachdrive/song.js". Do NOT use for huge bundles — use load_synth_from_file for those.', parameters: opt({ path: str('repo-relative path') }, ['path']) },
-  { name: 'load_synth_from_file', description: 'Load a repository file DIRECTLY into the synth editor without reading it into context. Use this for large bundles (e.g. examples/dx7/dx7-synth.ts).', parameters: opt({ path: str('repo-relative path') }, ['path']) },
-  { name: 'load_song_from_file', description: 'Load a repository file DIRECTLY into the song editor without reading it into context.', parameters: opt({ path: str('repo-relative path') }, ['path']) },
-];
-
-export function toOpenAiTools(defs = TOOL_DEFS) {
+export function toOpenAiTools(defs = SHARED_TOOL_DEFS) {
   return defs.map((d) => ({ type: 'function', function: { name: d.name, description: d.description, parameters: d.parameters } }));
 }
 

--- a/wasmaudioworklet/studio-agent-prompt.js
+++ b/wasmaudioworklet/studio-agent-prompt.js
@@ -2,6 +2,8 @@
 // song/synth formats, the tools the agent drives, and where to find examples.
 export const SYSTEM_PROMPT = `You are the Studio Agent for "WebAssembly Music" — a browser-based DAW where music is made by editing two source documents and compiling them to WebAssembly that runs live in the user's browser. You do NOT edit files on disk. You drive the running app through tools, and you READ example/reference files from the repository to learn how things are done.
 
+Your studio tools are namespaced: when looking one up by exact name, use \`mcp__studio__<name>\` (e.g. \`mcp__studio__get_shader\`) — bare names do not resolve.
+
 ## The pieces you work with (all in the browser, via tools)
 1. FAUST INSTRUMENTS — each instrument's DSP is authored as a Faust \`.dsp\` file in the OPFS \`faust/\` folder. This is where you DESIGN sounds. (Faust is a concise functional DSP language.)
 2. SYNTH (synth.ts, AssemblyScript) — the multitimbral COMBINER only. It imports the Faust-generated voice classes and assigns them to MIDI channels. It should contain almost no DSP of its own.
@@ -40,6 +42,7 @@ The song is JavaScript run by the sequencer. The full DSL is below — if a capa
 - **Channel control:** \`mute(ch)\`, \`solo(ch)\`.
 - **Recording (capture live MIDI input INTO the song):** \`startRecording()\` … \`stopRecording()\` wrap the section during which the player's live MIDI input is recorded into the song. To "record the piano while the beat plays", put \`startRecording()\` right before the played/looped section and \`stopRecording()\` right after it (see examples/dx7/dx7-sequence.js lines 1134 & 1193). These do NOT start/stop audio — they bracket what gets captured.
 - **Media:** \`addAudio(url)\`, \`addImage(name,url)\`, \`addVideo(name,url)\`, \`startVideo(name, t?)\`, \`stopVideo(name)\`.
+- **Shader text & params:** \`showText(text, {fade, transition, size, color, align, y, stroke, ...})\` shows text (string or array of lines) on the shader's own text layer at the current song time — each call supersedes the previous; \`hideText({fade})\` clears it; \`setVisual(name, value, rampSeconds?)\` sets any \`uniform float <name>\` the shader declares (ramped when rampSeconds > 0). The shader side is \`uText\`/\`uTextPrev\`/\`uTextMix\` plus whatever names the song and shader agree on — see wasmaudioworklet/docs/song-api.md and docs/shaders.md, and examples/textoverlay for a worked song+shader pair. Songs run sandboxed: there is NO \`document\`/canvas at song-compile time, so never hand-roll text images. **showText draws NOTHING unless the CURRENT shader declares \`uText\`** — see the shader section below; fix the shader, don't re-edit the song.
 - **Multi-window sync (midi path):** \`broadcastSend('name')\`, \`await broadcastWait('name')\`.
 - **Array helpers:** \`.repeat(n)\`, \`.quantize(stepsPerBeat, pct?)\`, \`.fixVelocity(v)\`.
 
@@ -50,6 +53,30 @@ A song plays through ONE synth document. To add a different instrument (say a wa
 3. edit_synth to (a) add any needed import line, (b) insert the new voice class (anchor on a unique line just before initializeMidiSynth), and (c) add or replace the \`midichannels[N] = new MidiChannel(maxVoices, (ch) => new YourVoice(ch));\` registration. Keep all existing DX7 channels intact.
 4. Make sure the song's addInstrument() count covers channel N, then write that channel's part. A non-FM voice (waveguide/subtractive) does NOT need NRPN patch data — only DX7/FM channels do.
 5. compile; if an import or symbol doesn't resolve, grep_synth/Read to find the right path and fix with edit_synth. Repeat until "compiled OK".
+
+## The visualizer shader (get_shader / grep_shader / edit_shader / set_shader)
+The song and the shader are ONE job: anything the song schedules visually only reaches the screen through a uniform the shader declares. **The song is never the whole story — when something visual is wrong or missing, get_shader/grep_shader FIRST, before editing the song at all.**
+
+The renderer binds (declare only what you use; undeclared ones are simply skipped):
+\`resolution\`, \`time\` (seconds ≈ song time), \`targetNoteStates[128]\` / \`smoothedNoteStates[128]\` (per MIDI note, **-1 = no note**, sounding ≈ velocity/127*2-1; the smoothed one has instant attack, slow release), \`synthState[]\` (raw f32 the synth writes in postprocess), \`uSampler\`/\`uSamplerPrev\`/\`uMix\` (addImage/startVideo layer), \`uText\`/\`uTextPrev\`/\`uTextMix\` (showText layer, alpha = glyph coverage), and any \`uniform float <name>\` the song sets with setVisual. GLSL ES 1.00 (WebGL1): no \`switch\`, loops need constant bounds, always \`precision highp float;\`. Texture rows upload top-first, so sample with \`vec2(uv.x, 1.0 - uv.y)\`.
+
+Typical text-layer block to add to an existing shader (keep whatever it already draws as the background):
+\`\`\`glsl
+uniform sampler2D uText;
+uniform sampler2D uTextPrev;
+uniform float uTextMix;
+// ... at the end of main(), over the colour the shader already computed:
+vec2 tuv = vec2(uv.x, 1.0 - uv.y);
+vec4 t = mix(texture2D(uTextPrev, tuv), texture2D(uText, tuv), uTextMix);
+col = mix(col, t.rgb, clamp(t.a, 0.0, 1.0));
+\`\`\`
+Rules of thumb:
+- \`edit_shader\` for surgical changes (same semantics as edit_synth); \`set_shader\` only for a shader you are writing from scratch. \`grep_shader('uText|uSampler|uniform float')\` tells you what the current shader supports.
+- set_shader/edit_shader/compile report back visuals the song schedules that the shader still can't show — treat those warnings as work to finish, not noise.
+- \`compile\` also applies the shader and returns GLSL compile errors verbatim.
+- A shader that composites the image layer over its own output (\`col = mix(col, card.rgb, card.a)\`) shows nothing from that layer when the song has no images — the layer is transparent. If the user reports a flat/blank screen, read the shader before suspecting the song.
+- You cannot SEE the canvas. Say what you changed and ask the user what appears; never claim a visual result you can't verify.
+- Reference: wasmaudioworklet/docs/shaders.md (uniform contract + the headless render harness), docs/animations.md, examples/textoverlay (worked song+shader pair), examples/beachdrive.
 
 ## Authoring an instrument in FAUST (the primary way to make a sound)
 Use \`write_faust(path, source)\` — it writes \`faust/<path>.dsp\` AND transpiles it to \`faust/<path>.ts\`, returning the generated class names (or the exact transpile error to fix). Requires the app opened with \`?gitrepo=…\` (OPFS). Then synth.ts imports those classes.

--- a/wasmaudioworklet/studio-agent-prompt.js
+++ b/wasmaudioworklet/studio-agent-prompt.js
@@ -66,11 +66,14 @@ uniform sampler2D uText;
 uniform sampler2D uTextPrev;
 uniform float uTextMix;
 // ... at the end of main(), over the colour the shader already computed:
-vec2 tuv = vec2(uv.x, 1.0 - uv.y);
+vec2 tuv = gl_FragCoord.xy / resolution;   // texture coords MUST be 0..1
+tuv.y = 1.0 - tuv.y;                       // texture rows upload top-first
 vec4 t = mix(texture2D(uTextPrev, tuv), texture2D(uText, tuv), uTextMix);
 col = mix(col, t.rgb, clamp(t.a, 0.0, 1.0));
 \`\`\`
+**Compute those coordinates fresh — do NOT reuse the host shader's \`uv\`.** Most shaders here define \`uv\` as centered and aspect-corrected (\`(gl_FragCoord.xy - 0.5*resolution)/resolution.y\`, roughly -0.9..0.9), and sampling a texture with that puts the text in a corner, clipped. Only reuse an existing variable if you have read its definition and it really is 0..1.
 Rules of thumb:
+- **Add a layer ALONGSIDE what is already there — never delete another layer to make room.** Removing the image-card block (\`uSampler\`/\`uSamplerPrev\`/\`uMix\` and its aspect-fit maths) breaks the song's images/slides the moment the user brings them back; the text layer is independent and costs nothing to add next to it.
 - \`edit_shader\` for surgical changes (same semantics as edit_synth); \`set_shader\` only for a shader you are writing from scratch. \`grep_shader('uText|uSampler|uniform float')\` tells you what the current shader supports.
 - set_shader/edit_shader/compile report back visuals the song schedules that the shader still can't show — treat those warnings as work to finish, not noise.
 - \`compile\` also applies the shader and returns GLSL compile errors verbatim.

--- a/wasmaudioworklet/studio-agent-tools-def.js
+++ b/wasmaudioworklet/studio-agent-tools-def.js
@@ -1,0 +1,82 @@
+// The studio agent's tool set — declared ONCE, for every provider.
+//
+// Two provider paths consume this:
+//   • the local Agent SDK process (tools/studio-agent/server.mjs) turns each
+//     def into an in-process MCP tool (JSON Schema -> zod there);
+//   • the in-browser NEAR AI loop (studio-agent-nearai-core.js) sends them as
+//     OpenAI function-calling definitions — and the Pages Function proxy
+//     (functions/nearai/[[path]].js) injects that same list server-side.
+//
+// It used to be two hand-maintained lists with a "keep them in sync" comment;
+// they drifted the first time a tool was added (the shader tools reached the
+// SDK path only). Pure data, no imports, so both Node and the browser can read
+// it, and studio-agent-tools-def.test.mjs checks it stays coherent.
+//
+// `where` says who executes the call:
+//   'browser'  — proxied to the browser tool registry (studio-agent-client.js)
+//   'loadfile' — reads a repo file and pushes it into an editor: server-side
+//                from disk in the SDK path, via the jsDelivr CDN in the browser
+//   'repofile' — reads a repo reference file for the model. Serverless ONLY;
+//                the local SDK agent has its own Read/Glob/Grep instead.
+
+const str = (description) => ({ type: 'string', description });
+const num = (description) => ({ type: 'number', description });
+const bool = (description) => ({ type: 'boolean', description });
+const obj = (properties, required = []) => ({ type: 'object', properties, required });
+
+const editParams = obj({
+    old_string: str('exact text to find'),
+    new_string: str('replacement text'),
+    replace_all: bool('replace every occurrence instead of requiring a unique match'),
+}, ['old_string', 'new_string']);
+
+const grepParams = obj({
+    pattern: str('regular expression'),
+    context: num('lines of surrounding context to include'),
+}, ['pattern']);
+
+export const TOOL_DEFS = [
+    // ---- song ----
+    { name: 'get_song', where: 'browser', description: 'Return the current song document (JavaScript sequencer DSL).', parameters: obj({}) },
+    { name: 'set_song', where: 'browser', description: 'Replace the entire song document. Provide the full new source.', parameters: obj({ source: str('full new song source') }, ['source']) },
+    { name: 'edit_song', where: 'browser', description: 'Surgically find-and-replace in the song document IN PLACE. old_string must match exactly and be unique unless replace_all is true.', parameters: editParams },
+    { name: 'grep_song', where: 'browser', description: 'Search the CURRENT in-browser song document for a regex; returns matching line numbers + text.', parameters: grepParams },
+
+    // ---- synth ----
+    { name: 'get_synth', where: 'browser', description: 'Return the current synth document (AssemblyScript).', parameters: obj({}) },
+    { name: 'set_synth', where: 'browser', description: 'Replace the entire synth document. Provide the full new source.', parameters: obj({ source: str('full new synth source') }, ['source']) },
+    { name: 'edit_synth', where: 'browser', description: 'Surgically find-and-replace in the synth document IN PLACE (like the Edit tool). Use this to add a voice/channel to a large synth (e.g. the DX7 bundle) WITHOUT rewriting it. old_string must match exactly and be unique unless replace_all is true.', parameters: editParams },
+    { name: 'grep_synth', where: 'browser', description: 'Search the CURRENT in-browser synth document for a regex; returns matching line numbers + text (optionally with surrounding context lines). Use to find exact anchors for edit_synth in a large synth without dumping the whole file.', parameters: grepParams },
+
+    // ---- visualizer shader ----
+    { name: 'get_shader', where: 'browser', description: "Return the current visualizer shader document (GLSL ES 1.00 fragment shader). This is what the song's visuals actually render through — read it before concluding anything about what is or is not on screen.", parameters: obj({}) },
+    { name: 'set_shader', where: 'browser', description: 'Replace the entire visualizer shader document. Provide the full new GLSL source. Reports back any visuals the song schedules that the new shader still cannot show.', parameters: obj({ source: str('full new GLSL fragment shader source') }, ['source']) },
+    { name: 'edit_shader', where: 'browser', description: 'Surgically find-and-replace in the visualizer shader document IN PLACE. old_string must match exactly and be unique unless replace_all is true. Reports back any visuals the song schedules that the shader still cannot show.', parameters: editParams },
+    { name: 'grep_shader', where: 'browser', description: 'Search the CURRENT in-browser shader document for a regex; returns matching line numbers + text. Use it to check which uniforms the shader declares (e.g. "uText|uSampler|uniform float") before editing the song\'s visuals.', parameters: grepParams },
+
+    // ---- Faust instruments (OPFS faust/ folder; needs ?gitrepo= mode) ----
+    { name: 'write_faust', where: 'browser', description: 'Author an INSTRUMENT in Faust: write faust/<path>.dsp AND transpile it to AssemblyScript in one step (persists faust/<name>.dsp + faust/<name>.ts in the browser OPFS). Returns the generated class names to import into synth.ts, or the exact transpile error. This is the primary way to create instrument DSP — do NOT hand-write DSP in AssemblyScript.', parameters: obj({ path: str('faust file basename, e.g. "bass"'), source: str('faust dsp source') }, ['path', 'source']) },
+    { name: 'read_faust', where: 'browser', description: 'Read a Faust .dsp instrument source from the browser OPFS faust/ folder.', parameters: obj({ path: str('faust file basename') }, ['path']) },
+    { name: 'list_faust', where: 'browser', description: 'List the .dsp Faust instruments in the browser OPFS faust/ folder.', parameters: obj({}) },
+
+    // ---- git history of the in-browser OPFS repo ----
+    { name: 'git_log', where: 'browser', description: 'Show the commit history of the in-browser OPFS repo (the user commits their work here). Use it to find a commit to restore a file from.', parameters: obj({}) },
+    { name: 'read_committed', where: 'browser', description: 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use to restore something overwritten in the editor: read_committed then set_song/set_synth it back.', parameters: obj({ path: str('repo-relative path'), ref: str('git ref, default HEAD') }, ['path']) },
+
+    // ---- build / transport ----
+    { name: 'compile', where: 'browser', description: "SAVE + compile the current song+synth in the browser (same as the app's save button). If a track is already playing, the changes are applied and audible immediately. Returns \"compiled OK\" or the exact compiler error. Call after every edit. There is NO play tool — the user starts playback themselves.", parameters: obj({}) },
+    { name: 'stop', where: 'browser', description: "Stop live audio playback. Only on the user's request.", parameters: obj({}) },
+
+    // ---- repository files ----
+    { name: 'load_synth_from_file', where: 'loadfile', target: 'synth', description: 'Load a repository file DIRECTLY into the synth editor without reading it into context. Use this for large bundles (e.g. examples/dx7/dx7-synth.ts) — pass a repo-relative path.', parameters: obj({ path: str('repo-relative path') }, ['path']) },
+    { name: 'load_song_from_file', where: 'loadfile', target: 'song', description: 'Load a repository file DIRECTLY into the song editor without reading it into context — pass a repo-relative path.', parameters: obj({ path: str('repo-relative path') }, ['path']) },
+    { name: 'read_repo_file', where: 'repofile', description: 'Read a reference file from the javascriptmusic repository (examples, docs). Path is repo-relative, e.g. "wasmaudioworklet/docs/song-api.md" or "examples/beachdrive/song.js". Do NOT use for huge bundles — use load_synth_from_file for those.', parameters: obj({ path: str('repo-relative path') }, ['path']) },
+];
+
+export const browserToolNames = () => TOOL_DEFS.filter((d) => d.where === 'browser').map((d) => d.name);
+export const toolDefsFor = (where) => TOOL_DEFS.filter((d) => d.where === where);
+
+// Every tool the SDK path exposes: browser-proxied + the server-side file
+// loaders. read_repo_file is excluded — that path has built-in Read/Glob/Grep.
+export const sdkToolNames = () =>
+    TOOL_DEFS.filter((d) => d.where === 'browser' || d.where === 'loadfile').map((d) => d.name);

--- a/wasmaudioworklet/studio-agent-tools-def.test.mjs
+++ b/wasmaudioworklet/studio-agent-tools-def.test.mjs
@@ -1,0 +1,71 @@
+// The tool set is shared by both provider paths (local Agent SDK + in-browser
+// NEAR AI). These tests pin the properties both depend on — the previous
+// arrangement was two hand-maintained lists, and the first tool added after
+// that comment reached only one of them.
+//
+// Run with: npm run test-agent-tools
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { TOOL_DEFS, browserToolNames, sdkToolNames, toolDefsFor } from './studio-agent-tools-def.js';
+import { toOpenAiTools } from './studio-agent-nearai-core.js';
+
+test('every tool is declared once, with a description and an object schema', () => {
+    const names = TOOL_DEFS.map((d) => d.name);
+    assert.deepStrictEqual(names, [...new Set(names)], 'duplicate tool name');
+    for (const def of TOOL_DEFS) {
+        assert.match(def.name, /^[a-z][a-z0-9_]*$/, `bad tool name ${def.name}`);
+        assert.ok(def.description && def.description.length > 20, `${def.name}: needs a real description`);
+        assert.strictEqual(def.parameters.type, 'object', `${def.name}: schema must be an object`);
+        for (const [prop, spec] of Object.entries(def.parameters.properties || {})) {
+            assert.ok(['string', 'number', 'boolean'].includes(spec.type),
+                `${def.name}.${prop}: unsupported type ${spec.type} (the SDK path converts these to zod)`);
+        }
+        for (const req of def.parameters.required || []) {
+            assert.ok(def.parameters.properties?.[req], `${def.name}: required "${req}" is not a property`);
+        }
+        assert.ok(['browser', 'loadfile', 'repofile'].includes(def.where), `${def.name}: unknown where "${def.where}"`);
+    }
+});
+
+test('the shader tools reach BOTH providers', () => {
+    // The regression that motivated sharing the list: these existed only in the
+    // Agent SDK path, so the in-browser NEAR AI agent (and the Pages Function
+    // proxy, which injects this same list server-side) could not fix a shader.
+    const shaderTools = ['get_shader', 'set_shader', 'edit_shader', 'grep_shader'];
+    const openai = toOpenAiTools().map((t) => t.function.name);
+    for (const name of shaderTools) {
+        assert.ok(browserToolNames().includes(name), `${name} missing from the browser tool set`);
+        assert.ok(sdkToolNames().includes(name), `${name} missing from the SDK tool list`);
+        assert.ok(openai.includes(name), `${name} missing from the OpenAI/NEAR AI definitions`);
+    }
+});
+
+test('serverless mode gets the repo-file readers, the SDK path does not', () => {
+    // The local agent has built-in Read/Glob/Grep instead.
+    assert.deepStrictEqual(toolDefsFor('repofile').map((d) => d.name), ['read_repo_file']);
+    assert.ok(!sdkToolNames().includes('read_repo_file'));
+    assert.ok(toOpenAiTools().some((t) => t.function.name === 'read_repo_file'));
+    // ...but the file loaders exist in both (different implementations).
+    for (const name of ['load_synth_from_file', 'load_song_from_file']) {
+        assert.ok(sdkToolNames().includes(name));
+        assert.ok(toOpenAiTools().some((t) => t.function.name === name));
+    }
+});
+
+test('there is no play tool — starting playback stays the user\'s action', () => {
+    assert.ok(!TOOL_DEFS.some((d) => d.name === 'play'));
+    assert.ok(TOOL_DEFS.some((d) => d.name === 'stop'));
+});
+
+test('OpenAI conversion keeps names, descriptions and schemas intact', () => {
+    const tools = toOpenAiTools();
+    assert.strictEqual(tools.length, TOOL_DEFS.length);
+    for (const tool of tools) {
+        assert.strictEqual(tool.type, 'function');
+        const def = TOOL_DEFS.find((d) => d.name === tool.function.name);
+        assert.ok(def, `unexpected tool ${tool.function.name}`);
+        assert.strictEqual(tool.function.description, def.description);
+        assert.deepStrictEqual(tool.function.parameters, def.parameters);
+    }
+});

--- a/wasmaudioworklet/visualizer/fragmentshader.js
+++ b/wasmaudioworklet/visualizer/fragmentshader.js
@@ -1,7 +1,8 @@
 import { setProgressbarValue } from '../common/ui/progress-bar.js';
 import { getCurrentTimeSeconds, setUseDefaultVisualizer, getUseDefaultVisualizer, getTargetNoteStates, getSynthState, clearPositions } from './defaultvisualizer.js';
 import { setGetCurrentTimeFunction, visualizeSong } from './midieventlistvisualizer.js';
-import { getActiveVideo } from './videoscheduler.js';
+import { getActiveVideo, getActiveText } from './videoscheduler.js';
+import { getActiveVisualParams } from './visualparams.js';
 
 const vertexShaderSrc = `            
 attribute vec2 a_position;
@@ -33,14 +34,18 @@ function computeSmoothedNoteStates() {
     return smoothedNoteStates;
 }
 
-function initTexture(gl) {
+function initTexture(gl, fillPixel = [0, 0, 0, 0]) {
     const texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
 
     // Because video has to be download over the internet
     // they might take a moment until it's ready so
     // put a single pixel in the texture so we can
-    // use it immediately.
+    // use it immediately. It is fully TRANSPARENT: shaders composite these
+    // layers by alpha, so "nothing scheduled yet" (or a song with no images
+    // at all) must paint nothing. An opaque placeholder here covers the whole
+    // frame in shaders that mix by card.a — a flat screen of placeholder
+    // colour hiding everything the shader draws.
     const level = 0;
     const internalFormat = gl.RGBA;
     const width = 1;
@@ -48,7 +53,7 @@ function initTexture(gl) {
     const border = 0;
     const srcFormat = gl.RGBA;
     const srcType = gl.UNSIGNED_BYTE;
-    const pixel = new Uint8Array([0, 0, 255, 255]);  // opaque blue
+    const pixel = new Uint8Array(fillPixel);
     gl.texImage2D(gl.TEXTURE_2D, level, internalFormat,
         width, height, border, srcFormat, srcType,
         pixel);
@@ -133,6 +138,79 @@ function bindMediaTextures(gl, state, samplerLoc, samplerPrevLoc, mixLoc, mix) {
     if (mixLoc) gl.uniform1f(mixLoc, mix);
 }
 
+// --- Text layer -------------------------------------------------------------
+// showText() in the song schedules text images on their own texture pair
+// (units 2 and 3), so text composites over whatever the shader draws instead
+// of competing for uSampler. Unlike the media crossfade, the fade is timed
+// from the scheduled song time and its duration comes from the song — which
+// makes it deterministic when seeking or exporting video.
+
+function createTextState(gl) {
+    return {
+        textures: [initTexture(gl), initTexture(gl)],
+        lastImage: null,
+        shownEntry: null,
+    };
+}
+
+function updateTextStateAndGetMix(gl, state, currentTimeSeconds) {
+    const entry = getActiveText(currentTimeSeconds * 1000);
+    const image = entry && entry.video ? entry.video.imageElement : null;
+    // Skip until decoded — the previous text stays on screen rather than
+    // flashing away while the new one loads.
+    const ready = image && image.complete && image.naturalWidth > 0 ? image : null;
+
+    if (ready && ready !== state.lastImage) {
+        // Ping-pong: the outgoing text becomes textures[1] (uTextPrev).
+        state.textures.reverse();
+        updateTexture(gl, state.textures[0], ready);
+        state.lastImage = ready;
+        state.shownEntry = entry;
+    } else if (!entry && state.lastImage) {
+        // Seeked (or looped) back past the first showText — clear the layer
+        // instead of leaving the last text of the previous pass on screen.
+        gl.bindTexture(gl.TEXTURE_2D, state.textures[0]);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE,
+            new Uint8Array([0, 0, 0, 0]));
+        state.lastImage = null;
+        state.shownEntry = null;
+    }
+
+    const shown = state.shownEntry;
+    if (!shown || !(shown.fade > 0)) {
+        return 1.0;
+    }
+    const elapsed = currentTimeSeconds - shown.startTime / 1000;
+    return Math.min(1, Math.max(0, elapsed / shown.fade));
+}
+
+function bindTextTextures(gl, state, textLoc, textPrevLoc, textMixLoc, mix) {
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(gl.TEXTURE_2D, state.textures[0]);
+    gl.activeTexture(gl.TEXTURE3);
+    gl.bindTexture(gl.TEXTURE_2D, state.textures[1]);
+    if (textLoc) gl.uniform1i(textLoc, 2);
+    if (textPrevLoc) gl.uniform1i(textPrevLoc, 3);
+    if (textMixLoc) gl.uniform1f(textMixLoc, mix);
+}
+
+// Named floats the song scheduled with setVisual(). Locations are resolved
+// lazily and cached per program — a name the shader doesn't declare resolves
+// to null once and is skipped from then on.
+function applyVisualParams(ctx, currentTimeSeconds) {
+    const gl = ctx.glContext;
+    getActiveVisualParams(currentTimeSeconds * 1000).forEach((value, name) => {
+        let location = ctx.visualParamLocations.get(name);
+        if (location === undefined) {
+            location = gl.getUniformLocation(ctx.program, name);
+            ctx.visualParamLocations.set(name, location);
+        }
+        if (location) {
+            gl.uniform1f(location, value);
+        }
+    });
+}
+
 function configureGLContext(source) {
     const glContext = canvas.getContext("webgl");
 
@@ -210,6 +288,14 @@ function configureGLContext(source) {
     bindMediaTextures(glContext, mediaState,
         samplerUniformLocation, samplerPrevUniformLocation, mixUniformLocation, 1.0);
 
+    // uText / uTextPrev / uTextMix — the showText() layer, same null-safe deal.
+    const textState = createTextState(glContext);
+    const textUniformLocation = glContext.getUniformLocation(program, "uText");
+    const textPrevUniformLocation = glContext.getUniformLocation(program, "uTextPrev");
+    const textMixUniformLocation = glContext.getUniformLocation(program, "uTextMix");
+    bindTextTextures(glContext, textState,
+        textUniformLocation, textPrevUniformLocation, textMixUniformLocation, 1.0);
+
     const positionLocation = glContext.getAttribLocation(program, "a_position");
     glContext.enableVertexAttribArray(positionLocation);
     glContext.vertexAttribPointer(positionLocation, 2, glContext.FLOAT, false, 0, 0);
@@ -227,7 +313,34 @@ function configureGLContext(source) {
         samplerPrevUniformLocation,
         mixUniformLocation,
         mediaState,
+        textUniformLocation,
+        textPrevUniformLocation,
+        textMixUniformLocation,
+        textState,
+        // name -> uniform location (or null), filled in by applyVisualParams
+        visualParamLocations: new Map(),
     };
+}
+
+// One frame with every uniform the app provides — shared by the live render
+// loop and the video export so the two can't drift apart.
+function drawFrame(ctx, currentTimeSeconds) {
+    const gl = ctx.glContext;
+
+    const mix = updateMediaStateAndGetMix(gl, ctx.mediaState, currentTimeSeconds);
+    const textMix = updateTextStateAndGetMix(gl, ctx.textState, currentTimeSeconds);
+    bindMediaTextures(gl, ctx.mediaState,
+        ctx.samplerUniformLocation, ctx.samplerPrevUniformLocation, ctx.mixUniformLocation, mix);
+    bindTextTextures(gl, ctx.textState,
+        ctx.textUniformLocation, ctx.textPrevUniformLocation, ctx.textMixUniformLocation, textMix);
+
+    gl.uniform1f(ctx.timeUniformLocation, currentTimeSeconds);
+    gl.uniform1fv(ctx.targetNoteStatesUniformLocation, getTargetNoteStates());
+    gl.uniform1fv(ctx.smoothedNoteStatesUniformLocation, computeSmoothedNoteStates());
+    gl.uniform1fv(ctx.synthStateUniformLocation, getSynthState());
+    applyVisualParams(ctx, currentTimeSeconds);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
 }
 
 export function setupWebGL(source, targetCanvas, customGetTimeSeconds = null) {
@@ -243,37 +356,18 @@ export function setupWebGL(source, targetCanvas, customGetTimeSeconds = null) {
     canvas.width = canvas.clientWidth;
     canvas.height = canvas.clientHeight;
 
-    const {
-        program,
-        glContext,
-        timeUniformLocation,
-        targetNoteStatesUniformLocation,
-        smoothedNoteStatesUniformLocation,
-        synthStateUniformLocation,
-        samplerUniformLocation,
-        samplerPrevUniformLocation,
-        mixUniformLocation,
-        mediaState,
-    } = configureGLContext(source);
+    const ctx = configureGLContext(source);
 
     const render = () => {
         if (exporting || getUseDefaultVisualizer()) {
             return;
         }
-        if (glContext.getParameter(glContext.CURRENT_PROGRAM) != program) {
+        if (ctx.glContext.getParameter(ctx.glContext.CURRENT_PROGRAM) != ctx.program) {
             return;
         }
         const currentTimeSeconds = customGetTimeSeconds ? customGetTimeSeconds() : getCurrentTimeSeconds();
 
-        const mix = updateMediaStateAndGetMix(glContext, mediaState, currentTimeSeconds);
-        bindMediaTextures(glContext, mediaState,
-            samplerUniformLocation, samplerPrevUniformLocation, mixUniformLocation, mix);
-
-        glContext.uniform1f(timeUniformLocation, currentTimeSeconds);
-        glContext.uniform1fv(targetNoteStatesUniformLocation, getTargetNoteStates());
-        glContext.uniform1fv(smoothedNoteStatesUniformLocation, computeSmoothedNoteStates());
-        glContext.uniform1fv(synthStateUniformLocation, getSynthState());
-        glContext.drawArrays(glContext.TRIANGLES, 0, 6);
+        drawFrame(ctx, currentTimeSeconds);
 
         window.requestAnimationFrame(render);
     }
@@ -308,17 +402,7 @@ export async function exportVideo(source, eventlist) {
     canvas.width = width;
     canvas.height = height;
 
-    const {
-        glContext,
-        timeUniformLocation,
-        targetNoteStatesUniformLocation,
-        smoothedNoteStatesUniformLocation,
-        synthStateUniformLocation,
-        samplerUniformLocation,
-        samplerPrevUniformLocation,
-        mixUniformLocation,
-        mediaState,
-    } = configureGLContext(source);
+    const ctx = configureGLContext(source);
 
     const framerate = 30;
 
@@ -354,15 +438,7 @@ export async function exportVideo(source, eventlist) {
         const currentTimeMillis = await currentTimeMillisFunc();
         const currentTimeSeconds = currentTimeMillis / 1000;
 
-        const mix = updateMediaStateAndGetMix(glContext, mediaState, currentTimeSeconds);
-        bindMediaTextures(glContext, mediaState,
-            samplerUniformLocation, samplerPrevUniformLocation, mixUniformLocation, mix);
-
-        glContext.uniform1f(timeUniformLocation, currentTimeSeconds);
-        glContext.uniform1fv(targetNoteStatesUniformLocation, getTargetNoteStates());
-        glContext.uniform1fv(smoothedNoteStatesUniformLocation, computeSmoothedNoteStates());
-        glContext.uniform1fv(synthStateUniformLocation, getSynthState());
-        glContext.drawArrays(glContext.TRIANGLES, 0, 6);
+        drawFrame(ctx, currentTimeSeconds);
 
         const frame = new VideoFrame(canvas, { timestamp: currentTimeMillis * 1000 });
         const keyFrame = (frame_counter % framerate) == 0;

--- a/wasmaudioworklet/visualizer/fragmentshader.spec.js
+++ b/wasmaudioworklet/visualizer/fragmentshader.spec.js
@@ -1,6 +1,11 @@
 import { exportVideo, setupWebGL } from './fragmentshader.js';
 import { setVisualParamSchedule } from './visualparams.js';
-import { compileSong, addedVideo } from '../midisequencer/songcompiler.js';
+import { setTextSchedule } from './videoscheduler.js';
+// textimage.js is pure string work with no imports — deliberately NOT going
+// through the song compiler here: that would pull the QuickJS sandbox (and its
+// CDN wasm download) into this page, which pushed Firefox past its 30s page
+// start budget in CI.
+import { textToSvgDataUrl } from '../midisequencer/textimage.js';
 
 describe('fragmentshader', function() {
     this.timeout(20000);
@@ -36,9 +41,10 @@ describe('fragmentshader', function() {
                 gl_FragColor = vec4(textTransition, zoom, uTextMix * texture2D(uText, vec2(0.5)).a, 1.0);
             }
         `;
-        // song time 1.5s — halfway into the zoom ramp
+        // song time 1.5s — halfway into the zoom ramp. setupWebGL renders one
+        // frame synchronously before scheduling the rAF loop, so there is no
+        // need to wait for a frame (rAF is unreliable in headless CI).
         setupWebGL(shadersource, canvaselement, () => 1.5);
-        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
         const gl = canvaselement.getContext('webgl');
         const program = gl.getParameter(gl.CURRENT_PROGRAM);
@@ -58,16 +64,12 @@ describe('fragmentshader', function() {
         canvaselement.height = 90;
         document.documentElement.appendChild(canvaselement);
 
-        await compileSong(`
-            setBPM(120);
-            showText('IIIIIIII', { fade: 2 });
-            await createTrack(0).steps(4, [c3,,,,]);
-            loopHere();
-        `);
-        // the text image is an SVG data url — wait for the browser to decode it
-        await Promise.all(Object.values(addedVideo)
-            .filter(vid => vid.layer === 'text')
-            .map(vid => vid.imageElement.decode()));
+        // what showText() schedules: a text image on the text layer at song
+        // time 0, fading over 2s (see songcompiler.spec.js for the song path)
+        const image = new Image();
+        image.src = textToSvgDataUrl('IIIIIIII');
+        await image.decode();
+        setTextSchedule([{ startTime: 0, fade: 2, video: { imageElement: image } }]);
 
         const shadersource = `
             precision highp float;
@@ -82,9 +84,8 @@ describe('fragmentshader', function() {
                 gl_FragColor = vec4(vec3(a * uTextMix), 1.0);
             }
         `;
-        // 1s into a 2s fade
+        // 1s into a 2s fade; the first frame is drawn synchronously
         setupWebGL(shadersource, canvaselement, () => 1.0);
-        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
         const gl = canvaselement.getContext('webgl');
         const program = gl.getParameter(gl.CURRENT_PROGRAM);

--- a/wasmaudioworklet/visualizer/fragmentshader.spec.js
+++ b/wasmaudioworklet/visualizer/fragmentshader.spec.js
@@ -1,4 +1,6 @@
 import { exportVideo, setupWebGL } from './fragmentshader.js';
+import { setVisualParamSchedule } from './visualparams.js';
+import { compileSong, addedVideo } from '../midisequencer/songcompiler.js';
 
 describe('fragmentshader', function() {
     this.timeout(20000);
@@ -9,6 +11,98 @@ describe('fragmentshader', function() {
     });
     this.afterAll(async () => {
         document.documentElement.removeChild(document.getElementById('glCanvas'));
+    });
+    // Must run before the export test: exportVideo leaves the module in
+    // "exporting" mode, which stops all render loops.
+    it('should set song-scheduled visual params as shader uniforms', async () => {
+        const canvaselement = document.createElement('canvas');
+        canvaselement.width = 64;
+        canvaselement.height = 64;
+        document.documentElement.appendChild(canvaselement);
+
+        setVisualParamSchedule([
+            { time: 0, name: 'textTransition', value: 2 },
+            { time: 0, name: 'zoom', value: 1 },
+            { time: 1000, name: 'zoom', value: 3, ramp: 1000 },
+        ]);
+
+        const shadersource = `
+            precision highp float;
+            uniform float textTransition;
+            uniform float zoom;
+            uniform sampler2D uText;
+            uniform float uTextMix;
+            void main() {
+                gl_FragColor = vec4(textTransition, zoom, uTextMix * texture2D(uText, vec2(0.5)).a, 1.0);
+            }
+        `;
+        // song time 1.5s — halfway into the zoom ramp
+        setupWebGL(shadersource, canvaselement, () => 1.5);
+        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const gl = canvaselement.getContext('webgl');
+        const program = gl.getParameter(gl.CURRENT_PROGRAM);
+        const uniform = name => gl.getUniform(program, gl.getUniformLocation(program, name));
+        expect(uniform('textTransition')).to.equal(2);
+        expect(uniform('zoom')).to.be.closeTo(2, 1e-6);
+        // the text layer binds even with no text scheduled
+        expect(uniform('uText')).to.equal(2);
+        expect(uniform('uTextMix')).to.equal(1);
+
+        setVisualParamSchedule([]);
+        document.documentElement.removeChild(canvaselement);
+    });
+    it('should render text scheduled by showText into the uText layer', async () => {
+        const canvaselement = document.createElement('canvas');
+        canvaselement.width = 160;
+        canvaselement.height = 90;
+        document.documentElement.appendChild(canvaselement);
+
+        await compileSong(`
+            setBPM(120);
+            showText('IIIIIIII', { fade: 2 });
+            await createTrack(0).steps(4, [c3,,,,]);
+            loopHere();
+        `);
+        // the text image is an SVG data url — wait for the browser to decode it
+        await Promise.all(Object.values(addedVideo)
+            .filter(vid => vid.layer === 'text')
+            .map(vid => vid.imageElement.decode()));
+
+        const shadersource = `
+            precision highp float;
+            uniform vec2 resolution;
+            uniform sampler2D uText;
+            uniform sampler2D uTextPrev;
+            uniform float uTextMix;
+            void main() {
+                vec2 uv = gl_FragCoord.xy / resolution;
+                float a = texture2D(uText, vec2(uv.x, 1.0 - uv.y)).a
+                        + 0.0 * texture2D(uTextPrev, uv).a;
+                gl_FragColor = vec4(vec3(a * uTextMix), 1.0);
+            }
+        `;
+        // 1s into a 2s fade
+        setupWebGL(shadersource, canvaselement, () => 1.0);
+        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const gl = canvaselement.getContext('webgl');
+        const program = gl.getParameter(gl.CURRENT_PROGRAM);
+        expect(gl.getUniform(program, gl.getUniformLocation(program, 'uTextMix'))).to.be.closeTo(0.5, 1e-6);
+
+        // draw once more and read it back before the compositor clears
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+        const pixels = new Uint8Array(160 * 90 * 4);
+        gl.readPixels(0, 0, 160, 90, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        let lit = 0;
+        for (let ndx = 0; ndx < pixels.length; ndx += 4) {
+            if (pixels[ndx] > 0) lit++;
+        }
+        // the glyphs cover a small part of the frame, at half opacity
+        expect(lit).to.be.greaterThan(20);
+        expect(lit).to.be.lessThan(160 * 90 * 0.5);
+
+        document.documentElement.removeChild(canvaselement);
     });
     it('should export a video from the fragment shader', async () => {
         if (!('VideoEncoder' in window) || /\bHeadlessChrome\//.test(navigator.userAgent)) {

--- a/wasmaudioworklet/visualizer/videoscheduler.js
+++ b/wasmaudioworklet/visualizer/videoscheduler.js
@@ -1,7 +1,29 @@
 let videoSchedule = [];
+// The text layer is a second, independent image schedule (showText in the song
+// API). It renders to its own texture pair so a song can put text over a photo,
+// a video or a purely generative shader without fighting for uSampler.
+let textSchedule = [];
 
 export function setVideoSchedule(schedule) {
     videoSchedule = schedule;
+}
+
+export function setTextSchedule(schedule) {
+    textSchedule = schedule;
+}
+
+// Did the song schedule any showText? Used to warn when the shader has no
+// text layer to show it on.
+export function hasScheduledText() {
+    return textSchedule.length > 0;
+}
+
+// The text entry active at the given time — the latest one started, since
+// each showText supersedes the previous (schedules are sorted descending).
+// Returns the schedule entry itself ({ startTime, fade, video }) so the
+// renderer can time the fade from song time.
+export function getActiveText(milliseconds) {
+    return textSchedule.find(sch => sch.startTime <= milliseconds) ?? null;
 }
 
 export function exportVideoSchedule() {

--- a/wasmaudioworklet/visualizer/visualparams.js
+++ b/wasmaudioworklet/visualizer/visualparams.js
@@ -1,0 +1,81 @@
+// Scheduled named float uniforms — the song's control channel into the shader.
+//
+// A song calls setVisual(name, value, rampSeconds) at a point in the sequence.
+// The calls are collected at compile time into a schedule stamped with song
+// time (milliseconds), and the renderer sets `uniform float <name>` to the
+// value active at the current playback time each frame (see fragmentshader.js).
+// A shader that doesn't declare a name simply never sees it —
+// getUniformLocation returns null and the write is skipped.
+//
+// Pure logic (no DOM, no WebGL) so it can be scheduled from the song compiler
+// and unit tested on its own.
+
+let paramsByName = new Map();
+// Reused across frames — getActiveVisualParams is called on every render tick.
+const active = new Map();
+
+export function setVisualParamSchedule(entries) {
+    paramsByName = new Map();
+    for (const entry of entries || []) {
+        if (!paramsByName.has(entry.name)) {
+            paramsByName.set(entry.name, []);
+        }
+        paramsByName.get(entry.name).push({
+            time: entry.time,
+            value: entry.value,
+            ramp: entry.ramp > 0 ? entry.ramp : 0,
+        });
+    }
+    paramsByName.forEach(list => list.sort((a, b) => a.time - b.time));
+}
+
+export function getVisualParamNames() {
+    return [...paramsByName.keys()];
+}
+
+export function clearVisualParams() {
+    paramsByName = new Map();
+}
+
+// Index of the last entry with time <= milliseconds, or -1 if none.
+function lastIndexBefore(list, milliseconds) {
+    let lo = 0;
+    let hi = list.length - 1;
+    let found = -1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (list[mid].time <= milliseconds) {
+            found = mid;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return found;
+}
+
+// Values active at the given song time, as a name -> value Map. The Map
+// instance is reused between calls — read it before the next call.
+export function getActiveVisualParams(milliseconds) {
+    active.clear();
+    paramsByName.forEach((list, name) => {
+        const ndx = lastIndexBefore(list, milliseconds);
+        if (ndx < 0) {
+            // Before its first scheduled value a param reads 0 (the GL
+            // default), so seeking backwards is deterministic.
+            active.set(name, 0);
+            return;
+        }
+        const entry = list[ndx];
+        let value = entry.value;
+        if (entry.ramp > 0 && milliseconds < entry.time + entry.ramp) {
+            // Ramp from the previous scheduled value (0 before the first one).
+            // Overlapping ramps start from the previous target, not from the
+            // half-ramped value — songs rarely stack ramps on one name.
+            const from = ndx > 0 ? list[ndx - 1].value : 0;
+            value = from + (value - from) * ((milliseconds - entry.time) / entry.ramp);
+        }
+        active.set(name, value);
+    });
+    return active;
+}

--- a/wasmaudioworklet/visualizer/visualparams.spec.js
+++ b/wasmaudioworklet/visualizer/visualparams.spec.js
@@ -1,0 +1,54 @@
+import { setVisualParamSchedule, getActiveVisualParams, getVisualParamNames, clearVisualParams } from './visualparams.js';
+
+describe('visualparams', function () {
+    this.afterEach(() => clearVisualParams());
+
+    it('should hold the value scheduled at or before the given song time', () => {
+        setVisualParamSchedule([
+            { time: 0, name: 'mode', value: 1 },
+            { time: 2000, name: 'mode', value: 3 },
+            { time: 1000, name: 'mode', value: 2 },
+        ]);
+        expect(getActiveVisualParams(0).get('mode')).to.equal(1);
+        expect(getActiveVisualParams(999).get('mode')).to.equal(1);
+        expect(getActiveVisualParams(1000).get('mode')).to.equal(2);
+        expect(getActiveVisualParams(5000).get('mode')).to.equal(3);
+        // seeking backwards must give the same answer as playing forwards
+        expect(getActiveVisualParams(1000).get('mode')).to.equal(2);
+    });
+
+    it('should read 0 before the first scheduled value', () => {
+        setVisualParamSchedule([{ time: 4000, name: 'glow', value: 1 }]);
+        expect(getActiveVisualParams(0).get('glow')).to.equal(0);
+        expect(getActiveVisualParams(4000).get('glow')).to.equal(1);
+    });
+
+    it('should interpolate over a ramp and hold the target afterwards', () => {
+        setVisualParamSchedule([
+            { time: 0, name: 'zoom', value: 1 },
+            { time: 1000, name: 'zoom', value: 2, ramp: 1000 },
+        ]);
+        expect(getActiveVisualParams(1000).get('zoom')).to.equal(1);
+        expect(getActiveVisualParams(1500).get('zoom')).to.be.closeTo(1.5, 1e-9);
+        expect(getActiveVisualParams(2000).get('zoom')).to.equal(2);
+        expect(getActiveVisualParams(9000).get('zoom')).to.equal(2);
+    });
+
+    it('should ramp from 0 when there is no previous value', () => {
+        setVisualParamSchedule([{ time: 0, name: 'fadein', value: 1, ramp: 2000 }]);
+        expect(getActiveVisualParams(0).get('fadein')).to.equal(0);
+        expect(getActiveVisualParams(1000).get('fadein')).to.be.closeTo(0.5, 1e-9);
+        expect(getActiveVisualParams(2000).get('fadein')).to.equal(1);
+    });
+
+    it('should keep parameters independent', () => {
+        setVisualParamSchedule([
+            { time: 0, name: 'a', value: 1 },
+            { time: 500, name: 'b', value: 7 },
+        ]);
+        expect(getVisualParamNames()).to.deep.equal(['a', 'b']);
+        const params = getActiveVisualParams(600);
+        expect(params.get('a')).to.equal(1);
+        expect(params.get('b')).to.equal(7);
+    });
+});

--- a/wasmaudioworklet/visualizer/visualwarnings.js
+++ b/wasmaudioworklet/visualizer/visualwarnings.js
@@ -12,12 +12,21 @@ export function visualWarnings(shaderSource, { hasText = false, paramNames = [] 
     const source = shaderSource || '';
     const warnings = [];
 
-    if (hasText && !/\buText\b/.test(source)) {
+    // Declaring the uniforms is not enough: GLSL drops uniforms that are never
+    // read, so a shader that declares uText without sampling it renders nothing
+    // and reports no error. Check for a reference OUTSIDE the declarations.
+    const body = source.replace(/uniform[^;]*;/g, '');
+    if (hasText && !/\buText\b/.test(body)) {
         warnings.push(source.trim().length === 0
             ? `Warning: the song calls showText(), but there is no fragment shader to show it on. ${TEXT_DOC_HINT}`
-            : 'Warning: the song calls showText(), but the shader never uses `uText` — ' +
-            'declare `uniform sampler2D uText; uniform sampler2D uTextPrev; uniform float uTextMix;` ' +
-            `and composite them, or the text stays invisible. ${TEXT_DOC_HINT}`);
+            : /\buText\b/.test(source)
+                ? 'Warning: the shader declares `uText` but never samples it, so the song\'s text still renders ' +
+                'nothing (GLSL drops unused uniforms). Composite it in main() with 0..1 coordinates: ' +
+                '`vec2 tuv = gl_FragCoord.xy / resolution; tuv.y = 1.0 - tuv.y;` then mix ' +
+                `texture2D(uText, tuv) over your colour by its alpha. ${TEXT_DOC_HINT}`
+                : 'Warning: the song calls showText(), but the shader never uses `uText` — ' +
+                'declare `uniform sampler2D uText; uniform sampler2D uTextPrev; uniform float uTextMix;` ' +
+                `and composite them, or the text stays invisible. ${TEXT_DOC_HINT}`);
     }
 
     // Names are validated as GLSL identifiers when scheduled, so they are safe

--- a/wasmaudioworklet/visualizer/visualwarnings.js
+++ b/wasmaudioworklet/visualizer/visualwarnings.js
@@ -1,0 +1,34 @@
+// Warn when a song schedules visuals its shader cannot show.
+//
+// showText() and setVisual() only reach the screen through uniforms the
+// fragment shader declares; a shader that never mentions `uText` silently
+// drops every word the song shows, which looks exactly like a broken feature.
+// Checked at compile time in editorcontroller.js — pure string work, so it can
+// be tested on its own.
+
+const TEXT_DOC_HINT = 'See wasmaudioworklet/docs/shaders.md (uniform contract) or examples/textoverlay.';
+
+export function visualWarnings(shaderSource, { hasText = false, paramNames = [] } = {}) {
+    const source = shaderSource || '';
+    const warnings = [];
+
+    if (hasText && !/\buText\b/.test(source)) {
+        warnings.push(source.trim().length === 0
+            ? `Warning: the song calls showText(), but there is no fragment shader to show it on. ${TEXT_DOC_HINT}`
+            : 'Warning: the song calls showText(), but the shader never uses `uText` — ' +
+            'declare `uniform sampler2D uText; uniform sampler2D uTextPrev; uniform float uTextMix;` ' +
+            `and composite them, or the text stays invisible. ${TEXT_DOC_HINT}`);
+    }
+
+    // Names are validated as GLSL identifiers when scheduled, so they are safe
+    // to put in a pattern.
+    const missing = paramNames.filter(name =>
+        !new RegExp(`uniform\\s+(?:lowp\\s+|mediump\\s+|highp\\s+)?float\\s+${name}\\s*;`).test(source));
+    if (missing.length) {
+        warnings.push(`Warning: setVisual(${missing.map(n => `'${n}'`).join(', ')}) ` +
+            `${missing.length === 1 ? 'has' : 'have'} no effect — the shader does not declare ` +
+            `${missing.map(n => `\`uniform float ${n};\``).join(', ')}.`);
+    }
+
+    return warnings;
+}

--- a/wasmaudioworklet/visualizer/visualwarnings.spec.js
+++ b/wasmaudioworklet/visualizer/visualwarnings.spec.js
@@ -1,0 +1,44 @@
+import { visualWarnings } from './visualwarnings.js';
+
+const TEXT_SHADER = `
+    precision highp float;
+    uniform sampler2D uText;
+    uniform sampler2D uTextPrev;
+    uniform float uTextMix;
+    uniform float textTransition;
+    void main() { gl_FragColor = texture2D(uText, vec2(0.5)) * uTextMix * textTransition; }
+`;
+
+describe('visualwarnings', function () {
+    it('should warn when the song shows text but the shader has no text layer', () => {
+        const warnings = visualWarnings('precision highp float; void main(){}', { hasText: true });
+        expect(warnings.length).to.equal(1);
+        expect(warnings[0]).to.contain('uText');
+    });
+
+    it('should point out a missing shader entirely', () => {
+        expect(visualWarnings('', { hasText: true })[0]).to.contain('no fragment shader');
+    });
+
+    it('should stay quiet when the shader uses the text layer', () => {
+        expect(visualWarnings(TEXT_SHADER, { hasText: true, paramNames: ['textTransition'] }))
+            .to.deep.equal([]);
+    });
+
+    it('should stay quiet when the song shows no text', () => {
+        expect(visualWarnings('void main(){}', { hasText: false })).to.deep.equal([]);
+    });
+
+    it('should warn about visual params the shader does not declare', () => {
+        const warnings = visualWarnings(TEXT_SHADER, { hasText: true, paramNames: ['textTransition', 'zoom'] });
+        expect(warnings.length).to.equal(1);
+        expect(warnings[0]).to.contain('zoom');
+        expect(warnings[0]).to.not.contain('textTransition');
+    });
+
+    it('should accept precision qualifiers on the declaration', () => {
+        expect(visualWarnings('uniform mediump float zoom;', { paramNames: ['zoom'] })).to.deep.equal([]);
+        // a name that only appears in the body is not a declaration
+        expect(visualWarnings('void main(){ float x = zoom; }', { paramNames: ['zoom'] }).length).to.equal(1);
+    });
+});

--- a/wasmaudioworklet/visualizer/visualwarnings.spec.js
+++ b/wasmaudioworklet/visualizer/visualwarnings.spec.js
@@ -29,6 +29,23 @@ describe('visualwarnings', function () {
         expect(visualWarnings('void main(){}', { hasText: false })).to.deep.equal([]);
     });
 
+    it('should warn when uText is declared but never sampled', () => {
+        // A real NEAR AI model produced exactly this: uniforms added, no
+        // compositing. GLSL drops the unused uniform, so nothing renders and
+        // nothing errors.
+        const declaredOnly = `
+            precision highp float;
+            uniform vec2 resolution;
+            uniform sampler2D uText;
+            uniform sampler2D uTextPrev;
+            uniform float uTextMix;
+            void main() { gl_FragColor = vec4(gl_FragCoord.xy / resolution, 0.0, 1.0); }
+        `;
+        const warnings = visualWarnings(declaredOnly, { hasText: true });
+        expect(warnings.length).to.equal(1);
+        expect(warnings[0]).to.contain('never samples it');
+    });
+
     it('should warn about visual params the shader does not declare', () => {
         const warnings = visualWarnings(TEXT_SHADER, { hasText: true, paramNames: ['textTransition', 'zoom'] });
         expect(warnings.length).to.equal(1);

--- a/wasmaudioworklet/web-test-runner.config.js
+++ b/wasmaudioworklet/web-test-runner.config.js
@@ -13,6 +13,12 @@ export default {
   // on slower CI runners 60s had no headroom and the file timed out while all
   // of its tests were passing.
   testsFinishTimeout: 180000,
+  // Firefox on CI has failed to open a test page inside the default 30s
+  // ("unable to create and start a test page", page.goto NS_BINDING_ABORTED)
+  // while other files were still pulling wasm over the network. Local runs open
+  // a page in well under a second, so a larger budget costs nothing and only
+  // stops a slow runner from being reported as a test failure.
+  browserStartTimeout: 90000,
   testRunnerHtml: testRunnerImport =>
     `<html>
       <body>


### PR DESCRIPTION
Lets the sequencer decide **what** the shader shows, **when**, and **how** — and gives the studio agent the tools to hold up its end of that.

## Song API

- **`setVisual(name, value, rampSeconds)`** — schedules a named float the shader reads as `uniform float <name>`. The app assigns no meaning to names; the song and its shader agree on them. Values step or ramp, and are resolved from song time so seeking, looping and video export match playback.
- **`showText(text, {fade, transition, ...style})` / `hideText()`** — text on a **dedicated texture pair** (`uText`/`uTextPrev`/`uTextMix`), independent of the image layer, so text composites over a photo, a video or a purely generative shader. `transition` rides the `setVisual` channel as `textTransition` for the shader to branch on.

Text is built as an **SVG data URL** — pure string work, so it runs inside the QuickJS song sandbox, which has no DOM. `docs/animations.md` still documented a canvas/`document` recipe that the sandbox had already made impossible; that is corrected.

```js
showText('Første vers', { transition: 1, fade: 0.8 });
setVisual('bloom', 1.0, 4);   // ramp over four seconds
```

## Renderer

- Text layer on texture units 2/3, faded from **scheduled song time** (deterministic on seek/export), plus one shared `drawFrame()` for the live loop and the video export, which previously duplicated the uniform block.
- **The media placeholder texture is now transparent instead of opaque blue.** A shader that composites the image layer by alpha painted the entire frame with that placeholder as soon as a song had no images — a flat blue screen hiding everything the shader drew. `tools/shadertest` had the same flaw with an opaque grey pixel.
- Compile-time **warning** when a song shows text or sets params the shader can't receive — in the error panel for the human, and via `window.getVisualWarnings()` for the agent.

## Studio agent

`get_shader` / `set_shader` / `edit_shader` / `grep_shader`. The song's visuals only reach the screen through uniforms the shader declares, so shader and song edits are one job. Without them the agent could only rewrite the song and never see why nothing appeared — which is exactly what happened in a real session: it removed a song's images for `showText`, the screen went blue, and it edited the song twice more on a wrong theory. The write tools and `compile` now report back what the song schedules that the shader still cannot show.

Verified by driving the **real agent** (second server instance + Playwright, real app) against that same failing project: `get_shader → get_song → 2× edit_shader → compile OK`, 8 turns, ~82s. Its opening line was *"I'll look at the current shader first — visual issues are almost always in the shader, not the song."*

Prompt also notes that studio tools resolve only as `mcp__studio__<name>` — the agent's first `ToolSearch` for bare names failed and cost a round trip.

## Tests

- Scheduler + SVG builder unit specs; song→schedule through the sandbox (browser and node).
- Real-browser check that decodes the SVG, uploads it as a texture and reads glyph pixels back with `uTextMix` at the expected value.
- Mock-agent e2e covering the shader tool loop (warning appears → `edit_shader` → warning clears).
- Harness gains `--text` / `--textprev` / `--textmix` / `--visual name=value`.
- `examples/textoverlay/` — worked song + shader with fade, wipe, rise and dissolve.

All green: 72 browser tests (Chromium + Firefox), 4/4 studio-agent e2e, node sandbox suite.

Draft: the in-app behaviour has been tried by hand, but a second pair of eyes on the placeholder change (it affects every existing image shader) is worth having before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)