### PR TITLE
Don't let a comment about uText silence the text-layer warning

### DIFF
--- a/wasmaudioworklet/visualizer/visualwarnings.js
+++ b/wasmaudioworklet/visualizer/visualwarnings.js
@@ -12,14 +12,21 @@ export function visualWarnings(shaderSource, { hasText = false, paramNames = [] 
     const source = shaderSource || '';
     const warnings = [];
 
-    // Declaring the uniforms is not enough: GLSL drops uniforms that are never
-    // read, so a shader that declares uText without sampling it renders nothing
-    // and reports no error. Check for a reference OUTSIDE the declarations.
-    const body = source.replace(/uniform[^;]*;/g, '');
-    if (hasText && !/\buText\b/.test(body)) {
+    // Shaders here tend to document their uniform contract in a header
+    // comment, so comments are stripped before anything is concluded from a
+    // mention of uText — otherwise the docs mask the warning.
+    const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/[^\n]*/g, '');
+    // Declaring the uniform is not enough either: GLSL drops uniforms that are
+    // never read, so a shader that declares uText without sampling it renders
+    // nothing and reports no error. Look for a reference outside declarations.
+    const declaresText = /uniform\s+sampler2D\s+uText\b/.test(code);
+    const usesText = /\buText\b/.test(code.replace(/uniform[^;]*;/g, ''));
+    if (hasText && !usesText) {
         warnings.push(source.trim().length === 0
             ? `Warning: the song calls showText(), but there is no fragment shader to show it on. ${TEXT_DOC_HINT}`
-            : /\buText\b/.test(source)
+            : declaresText
                 ? 'Warning: the shader declares `uText` but never samples it, so the song\'s text still renders ' +
                 'nothing (GLSL drops unused uniforms). Composite it in main() with 0..1 coordinates: ' +
                 '`vec2 tuv = gl_FragCoord.xy / resolution; tuv.y = 1.0 - tuv.y;` then mix ' +

--- a/wasmaudioworklet/visualizer/visualwarnings.spec.js
+++ b/wasmaudioworklet/visualizer/visualwarnings.spec.js
@@ -46,6 +46,21 @@ describe('visualwarnings', function () {
         expect(warnings[0]).to.contain('never samples it');
     });
 
+    it('should not let comments about uText silence the warning', () => {
+        // Shaders here often document the uniform contract in a header block;
+        // a production run seeded exactly this shape and got no warning.
+        const commentOnly = `
+            precision highp float;
+            // uText / uTextPrev — the current and outgoing text images
+            /* uTextMix runs 0..1 over each showText's fade */
+            uniform vec2 resolution;
+            void main() { gl_FragColor = vec4(gl_FragCoord.xy / resolution, 0.0, 1.0); }
+        `;
+        const warnings = visualWarnings(commentOnly, { hasText: true });
+        expect(warnings.length).to.equal(1);
+        expect(warnings[0]).to.contain('never uses');
+    });
+
     it('should warn about visual params the shader does not declare', () => {
         const warnings = visualWarnings(TEXT_SHADER, { hasText: true, paramNames: ['textTransition', 'zoom'] });
         expect(warnings.length).to.equal(1);


### PR DESCRIPTION
Follow-up to #181, found while testing it in production.

The compile-time warning ("the song calls `showText()` but the shader can't show it") stayed **quiet** for a shader whose only mention of `uText` was the header comment documenting the uniform contract:

```glsl
// uText / uTextPrev — the current and outgoing text images
/* uTextMix runs 0..1 over each showText's fade */
```

That is exactly how the shaders in this repo are written, so the check was liable to go silent on the very shaders it exists for.

- Comments are stripped before anything is concluded from a mention of `uText`.
- "declares it but never samples it" is now distinguished from "never mentions it" by looking for the real `uniform sampler2D uText` declaration, rather than the bare name appearing anywhere — otherwise the first case reported the wrong message.

Spec added for the comment case; 74 browser tests green in both browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)