### PR TITLE
Fix "Delete local" for `?remote=` repos: key the OPFS directory on `?gitrepo=`

### DIFF
--- a/wasmaudioworklet/e2e/delete-local.spec.js
+++ b/wasmaudioworklet/e2e/delete-local.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-// Regression for issue #183: with `?gitrepo=A&remote=…/B.git` the local OPFS
+// Regression for PR #183: with `?gitrepo=A&remote=…/B.git` the local OPFS
 // directory used to be named after the REMOTE (B.git) while synclocal and
 // "Delete local" both looked for the `?gitrepo=` name (A.git). The result was a
 // delete that removed nothing yet reported "Local clone deleted", plus a doomed

--- a/wasmaudioworklet/e2e/delete-local.spec.js
+++ b/wasmaudioworklet/e2e/delete-local.spec.js
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+
+// Regression for issue #183: with `?gitrepo=A&remote=…/B.git` the local OPFS
+// directory used to be named after the REMOTE (B.git) while synclocal and
+// "Delete local" both looked for the `?gitrepo=` name (A.git). The result was a
+// delete that removed nothing yet reported "Local clone deleted", plus a doomed
+// re-clone on every boot whose failure was masked by the existing directory.
+//
+// No remote server needed: the OPFS directory name is decided before any
+// network traffic, and `initlocal` takes the same repoName path as `clone`.
+
+const GITREPO = 'july26song';                       // ?gitrepo=
+const NEAR_URL = `http://localhost:8080/near-repo/${GITREPO}.git`;
+// A remote whose basename deliberately differs from the ?gitrepo= name.
+const REMOTE_URL = 'http://localhost:8080/gitproxy/github.com/petersalomonsen/wasm-music-2026.git';
+const CANONICAL_DIR = `${GITREPO}.git`;
+const LEGACY_DIR = 'wasm-music-2026.git';
+
+// Drive the git worker directly with the same messages wasmgitclient sends.
+async function driveWorker(page, steps) {
+    return await page.evaluate(async ({ steps }) => {
+        const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
+        const pending = [];
+        let resolveNext;
+        worker.onmessage = (msg) => {
+            if (resolveNext) { const r = resolveNext; resolveNext = null; r(msg.data); }
+            else pending.push(msg.data);
+        };
+        const nextRaw = () => pending.length ? Promise.resolve(pending.shift()) : new Promise(r => (resolveNext = r));
+        const next = (ms) => Promise.race([nextRaw(), new Promise(res => setTimeout(() => res({ __timeout: true }), ms))]);
+
+        const out = {};
+        try {
+            for (const step of steps) {
+                worker.postMessage(step.msg);
+                out[step.name] = await next(step.ms || 20000);
+            }
+        } finally {
+            worker.terminate();
+        }
+        return out;
+    }, { steps });
+}
+
+const listOPFS = (page) => page.evaluate(async () => {
+    const names = [];
+    for await (const [name] of (await navigator.storage.getDirectory()).entries()) names.push(name);
+    return names.sort();
+});
+
+const clearOPFS = (page) => page.evaluate(async () => {
+    const root = await navigator.storage.getDirectory();
+    for await (const [name] of root.entries()) {
+        try { await root.removeEntry(name, { recursive: true }); } catch (e) { /* ignore */ }
+    }
+});
+
+// What deletelocal() ultimately does, given the directory name it resolved.
+const removeOPFSEntry = (page, repoName) => page.evaluate(async (name) => {
+    try {
+        await (await navigator.storage.getDirectory()).removeEntry(name, { recursive: true });
+        return { ok: true };
+    } catch (e) {
+        return { ok: false, error: `${e.name}: ${e.message}` };
+    }
+}, repoName);
+
+test.describe('local repo directory naming with ?remote=', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('http://localhost:8080/');
+        await clearOPFS(page);
+    });
+
+    test.afterEach(async ({ page }) => await clearOPFS(page));
+
+    test('the OPFS directory is named after ?gitrepo=, not the remote url', async ({ page }) => {
+        const out = await driveWorker(page, [
+            { name: 'synclocal', msg: { command: 'synclocal', url: NEAR_URL, repoName: CANONICAL_DIR }, ms: 8000 },
+            // The client passes the REMOTE url to clone from, but the canonical
+            // repoName for where it lands. initlocal takes the same path and
+            // needs no reachable server.
+            { name: 'initlocal', msg: { command: 'initlocal', url: NEAR_URL, repoName: CANONICAL_DIR, remoteUrl: REMOTE_URL } },
+        ]);
+
+        expect(out.synclocal.dircontents).toBeNull();
+        expect(out.initlocal.dircontents).toContain('.git');
+        expect(out.initlocal.repoName).toBe(CANONICAL_DIR);
+
+        expect(await listOPFS(page)).toEqual([CANONICAL_DIR]);
+        expect(await listOPFS(page)).not.toContain(LEGACY_DIR);
+    });
+
+    test('a clone lands in the ?gitrepo= directory even when cloning from another url', async ({ page }) => {
+        // The remote 404s, so the clone fails — but the failure message names
+        // the target directory, which is what this test is about.
+        const messages = [];
+        page.on('console', m => messages.push(m.text()));
+
+        await driveWorker(page, [
+            { name: 'clone', msg: { command: 'clone', url: REMOTE_URL, repoName: CANONICAL_DIR }, ms: 20000 },
+        ]);
+
+        expect(messages.some(m => m.includes(`/opfs/${CANONICAL_DIR}`))).toBe(true);
+        expect(messages.some(m => m.includes(`/opfs/${LEGACY_DIR}`))).toBe(false);
+    });
+
+    test('synclocal finds the repo again on the next boot, so no re-clone is attempted', async ({ page }) => {
+        await driveWorker(page, [
+            { name: 'initlocal', msg: { command: 'initlocal', url: NEAR_URL, repoName: CANONICAL_DIR, remoteUrl: REMOTE_URL } },
+            { name: 'write', msg: { command: 'writefileandstage', filename: 'song.js', contents: '// my work\n' } },
+        ]);
+
+        // Fresh worker == reload. Before the fix this returned null (it looked
+        // for the ?gitrepo= name while the clone sat under the remote name),
+        // sending every boot into a clone that only "succeeded" by adopting the
+        // directory already in the way.
+        const out = await driveWorker(page, [
+            { name: 'synclocal', msg: { command: 'synclocal', url: NEAR_URL, repoName: CANONICAL_DIR, legacyRepoName: LEGACY_DIR }, ms: 8000 },
+        ]);
+
+        expect(out.synclocal.dircontents).not.toBeNull();
+        expect(out.synclocal.dircontents).toContain('song.js');
+        expect(out.synclocal.repoName).toBe(CANONICAL_DIR);
+    });
+
+    test('delete local removes the directory the worker actually used', async ({ page }) => {
+        const out = await driveWorker(page, [
+            { name: 'initlocal', msg: { command: 'initlocal', url: NEAR_URL, repoName: CANONICAL_DIR, remoteUrl: REMOTE_URL } },
+        ]);
+
+        // deletelocal() targets the name the worker reported, NOT a name
+        // re-derived from a url — that mismatch is the bug.
+        expect(await removeOPFSEntry(page, out.initlocal.repoName)).toEqual({ ok: true });
+        expect(await listOPFS(page)).toEqual([]);
+    });
+
+    test('LEGACY: a pre-fix clone under the remote-derived name is adopted, and deletable', async ({ page }) => {
+        // Recreate the old on-disk state: repo sitting in the remote-derived
+        // directory, because that is where pre-#183 builds put it.
+        await driveWorker(page, [
+            { name: 'initlocal', msg: { command: 'initlocal', url: REMOTE_URL, remoteUrl: REMOTE_URL } },
+            { name: 'write', msg: { command: 'writefileandstage', filename: 'song.js', contents: '// work from before the fix\n' } },
+        ]);
+        expect(await listOPFS(page)).toEqual([LEGACY_DIR]);
+
+        // Boot with the fix: the canonical directory is absent, so the legacy
+        // one must be adopted rather than left orphaned beside a fresh clone.
+        const out = await driveWorker(page, [
+            { name: 'synclocal', msg: { command: 'synclocal', url: NEAR_URL, repoName: CANONICAL_DIR, legacyRepoName: LEGACY_DIR }, ms: 8000 },
+            { name: 'read', msg: { command: 'readfile', filename: 'song.js' } },
+        ]);
+
+        expect(out.synclocal.dircontents).toContain('song.js');
+        expect(out.synclocal.repoName).toBe(LEGACY_DIR);     // reported honestly
+        const read = out.read.filecontents;
+        const contents = typeof read === 'string' ? read : new TextDecoder().decode(read);
+        expect(contents).toBe('// work from before the fix\n');
+
+        // …and "Delete local" must then remove THAT directory.
+        expect(await removeOPFSEntry(page, out.synclocal.repoName)).toEqual({ ok: true });
+        expect(await listOPFS(page)).toEqual([]);
+    });
+});

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -221,7 +221,7 @@ export function addRemoteSyncListener(remoteSyncListener) {
 // while `repoName` is where it lands in OPFS. These must stay decoupled: the
 // local directory is keyed on `?gitrepo=` so that synclocal and "Delete local"
 // can find the repo again on the next boot, regardless of what the remote
-// happens to be called. See issue #183.
+// happens to be called. See PR #183.
 export async function clone(url = gitrepourl) {
     worker.postMessage({
         command: 'clone',
@@ -290,7 +290,7 @@ export async function setremote(url) {
 export async function deletelocal() {
     // The directory the worker reported working in — NOT a name re-derived from
     // a url. With `?…&remote=`, those differ, and deleting the re-derived name
-    // silently removed nothing while reporting success (issue #183).
+    // silently removed nothing while reporting success (PR #183).
     const repoName = localRepoName || repoNameFromUrl(gitrepourl);
 
     // Terminate the worker so it releases the OPFS lock

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -15,9 +15,22 @@ async function registerNearGitServiceWorker() {
 
 export const CONFIG_FILE = 'wasmmusic.config.json';
 
+// The OPFS directory a git url maps to — the last path segment, e.g.
+// `…/near-repo/mysong.git` -> `mysong.git`.
+export function repoNameFromUrl(url) {
+    return url.substring(url.lastIndexOf('/') + 1);
+}
+
 export let worker;
 
 let gitrepourl;
+// The `?…&remote=<url>` override, if any. Kept so the OPFS directory name can
+// stay tied to `?gitrepo=` while the clone still happens FROM the remote.
+let gitremoteurl;
+// Name of the OPFS directory actually holding the repo, as reported by the
+// worker. Normally repoNameFromUrl(gitrepourl), but an older clone (see
+// LEGACY note below) may live under the remote-derived name instead.
+let localRepoName;
 let commitAndPushButton;
 let discardChangesButton;
 let deleteLocalButton;
@@ -141,6 +154,8 @@ export async function initWASMGitClient(gitrepo, remoteUrl) {
     }
 
     gitrepourl = `${location.origin}/near-repo/${gitrepo}.git`;
+    gitremoteurl = remoteUrl;
+    localRepoName = repoNameFromUrl(gitrepourl);
 
     let dircontents = await synclocal();
 
@@ -202,10 +217,16 @@ export function addRemoteSyncListener(remoteSyncListener) {
     remoteSyncListeners.push(remoteSyncListener);
 }
 
+// `url` is where we clone FROM (the `?…&remote=` target when there is one),
+// while `repoName` is where it lands in OPFS. These must stay decoupled: the
+// local directory is keyed on `?gitrepo=` so that synclocal and "Delete local"
+// can find the repo again on the next boot, regardless of what the remote
+// happens to be called. See issue #183.
 export async function clone(url = gitrepourl) {
     worker.postMessage({
         command: 'clone',
-        url
+        url,
+        repoName: repoNameFromUrl(gitrepourl)
     });
     return await awaitDirContents();
 }
@@ -222,6 +243,11 @@ async function awaitDirContents(timeoutMs = 30000) {
         workerMessageListeners.push((msg) => {
             if (msg.data.dircontents !== undefined) {
                 clearTimeout(timer);
+                // Track where the repo actually lives, so "Delete local"
+                // targets the real directory even when it's a legacy one.
+                if (msg.data.repoName) {
+                    localRepoName = msg.data.repoName;
+                }
                 resolve(msg.data.dircontents);
             } else {
                 return true;
@@ -232,7 +258,13 @@ async function awaitDirContents(timeoutMs = 30000) {
 export async function synclocal() {
     worker.postMessage({
         command: 'synclocal',
-        url: gitrepourl
+        url: gitrepourl,
+        repoName: repoNameFromUrl(gitrepourl),
+        // LEGACY: before the fix for #183, a `?…&remote=` clone landed in a
+        // directory named after the REMOTE url instead of `?gitrepo=`. Existing
+        // users still have their work there, so adopt it when the canonical
+        // directory is absent.
+        legacyRepoName: gitremoteurl ? repoNameFromUrl(gitremoteurl) : undefined
     });
     return await awaitDirContents();
 }
@@ -244,6 +276,7 @@ export async function initlocal(remoteUrl) {
     worker.postMessage({
         command: 'initlocal',
         url: gitrepourl,
+        repoName: repoNameFromUrl(gitrepourl),
         remoteUrl: remoteUrl || gitrepourl,
     });
     return await awaitDirContents();
@@ -255,22 +288,35 @@ export async function setremote(url) {
 }
 
 export async function deletelocal() {
-    // Extract repo name from URL
-    const repoName = gitrepourl.substring(gitrepourl.lastIndexOf('/') + 1);
+    // The directory the worker reported working in — NOT a name re-derived from
+    // a url. With `?…&remote=`, those differ, and deleting the re-derived name
+    // silently removed nothing while reporting success (issue #183).
+    const repoName = localRepoName || repoNameFromUrl(gitrepourl);
 
     // Terminate the worker so it releases the OPFS lock
     worker.terminate();
 
     // Clear OPFS from the main thread (worker no longer holds the lock)
+    let error = null;
     try {
         const opfsRoot = await navigator.storage.getDirectory();
         await opfsRoot.removeEntry(repoName, { recursive: true });
         console.log('Deleted OPFS entry', repoName);
     } catch (e) {
+        error = e;
         console.error('Error deleting from OPFS', repoName, e);
     }
 
-    if (await modal(`<p>Local clone deleted</p>
+    // Report honestly: a failed delete used to still say "Local clone deleted",
+    // which is what hid #183 for weeks. repoName comes from the `?gitrepo=`
+    // param, so escape it like modalAlert does rather than injecting raw HTML.
+    const escape = (s) => String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+    const message = error
+        ? `<p>Could not delete the local clone <code>${escape(repoName)}</code></p>
+           <p>${escape(error.name)}: ${escape(error.message)}</p>`
+        : `<p>Local clone deleted</p>`;
+
+    if (await modal(`${message}
             <button onclick="getRootNode().result(null)">Dismiss</button>
             <button onclick="getRootNode().result(true)">Reload</button>
     `)) {

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -6,6 +6,16 @@ const CONFIG_FILE = 'wasmmusic.config.json';
 const WASM_GIT_BASE_URL = '/wasm-git/';
 const OPFS_MOUNT = '/opfs';
 
+// Which OPFS directory a command operates on. The client sends `repoName`
+// explicitly so the local directory stays keyed on `?gitrepo=` even when the
+// clone url points somewhere else entirely (`?…&remote=`); deriving it from
+// the url instead made clones land where synclocal and "Delete local" could
+// never find them again. See issue #183. The url fallback keeps older callers
+// (and the e2e worker drivers) working.
+function repoDirName(data) {
+  return data.repoName || data.url.substring(data.url.lastIndexOf('/') + 1);
+}
+
 globalThis.wasmGitModuleOverrides = {
   locateFile: function (s) {
     return WASM_GIT_BASE_URL + s;
@@ -218,66 +228,50 @@ onmessage = async (msg) => {
     console.log(currentRepoDir, 'persisted via OPFS');
     postMessage({ id: msg.data.id, error: err ? err : undefined, dircontents: readdir() });
   } else if (msg.data.command === 'synclocal') {
-    const repoName = msg.data.url.substring(msg.data.url.lastIndexOf('/') + 1);
-    currentRepoDir = OPFS_MOUNT + '/' + repoName;
-    console.log('synclocal', currentRepoDir);
+    // Candidates in priority order: the canonical `?gitrepo=`-derived name
+    // first, then the LEGACY remote-derived name a pre-#183 `?…&remote=` clone
+    // landed in. Adopting the legacy directory keeps existing local work
+    // reachable instead of silently re-cloning next to it.
+    const candidates = [repoDirName(msg.data)];
+    if (msg.data.legacyRepoName && candidates.indexOf(msg.data.legacyRepoName) === -1) {
+      candidates.push(msg.data.legacyRepoName);
+    }
 
-    try {
-      const entries = FS.readdir(currentRepoDir);
-      if (entries.find(file => file === '.git')) {
-        // Create symlink workaround for WASMFS getcwd() bug
-        try { FS.symlink(currentRepoDir, '/' + repoName); } catch (e) { }
-        ensureChdir(currentRepoDir);
-        // WASMFS+OPFS has no real Unix mode bits — every file stat's as
-        // 0o755, so git would otherwise flag every file as a mode change
-        // (100644 → 100755) on every diff. Idempotent re-set is fine.
-        try { callMainInDir(['config', 'core.fileMode', 'false']); } catch (_) {}
-        postMessage({ dircontents: readdir() });
-        console.log(currentRepoDir, 'restored from OPFS');
-      } else {
-        console.log('no git repo in', currentRepoDir);
-        postMessage({ dircontents: null });
+    let restored = false;
+    for (const repoName of candidates) {
+      currentRepoDir = OPFS_MOUNT + '/' + repoName;
+      console.log('synclocal', currentRepoDir);
+
+      try {
+        const entries = FS.readdir(currentRepoDir);
+        if (entries.find(file => file === '.git')) {
+          // Create symlink workaround for WASMFS getcwd() bug
+          try { FS.symlink(currentRepoDir, '/' + repoName); } catch (e) { }
+          ensureChdir(currentRepoDir);
+          // WASMFS+OPFS has no real Unix mode bits — every file stat's as
+          // 0o755, so git would otherwise flag every file as a mode change
+          // (100644 → 100755) on every diff. Idempotent re-set is fine.
+          try { callMainInDir(['config', 'core.fileMode', 'false']); } catch (_) {}
+          postMessage({ dircontents: readdir(), repoName });
+          console.log(currentRepoDir, 'restored from OPFS');
+          restored = true;
+          break;
+        } else {
+          console.log('no git repo in', currentRepoDir);
+        }
+      } catch (e) {
+        console.log('no directory', currentRepoDir);
       }
-    } catch (e) {
-      console.log('no directory', currentRepoDir);
+    }
+
+    if (!restored) {
+      // Leave currentRepoDir at the canonical name so a following clone /
+      // initlocal lands where the next synclocal will look for it.
+      currentRepoDir = OPFS_MOUNT + '/' + candidates[0];
       postMessage({ dircontents: null });
     }
-  } else if (msg.data.command === 'deletelocal') {
-    // Recursively remove the repo directory from WASMFS
-    function rmdirRecursive(path) {
-      const entries = FS.readdir(path);
-      for (const entry of entries) {
-        if (entry === '.' || entry === '..') continue;
-        const fullPath = path + '/' + entry;
-        const stat = FS.stat(fullPath);
-        if (FS.isDir(stat.mode)) {
-          rmdirRecursive(fullPath);
-        } else {
-          FS.unlink(fullPath);
-        }
-      }
-      FS.rmdir(path);
-    }
-    const repoName = currentRepoDir.substring(currentRepoDir.lastIndexOf('/') + 1);
-    try {
-      FS.chdir(OPFS_MOUNT);
-      rmdirRecursive(currentRepoDir);
-    } catch (e) {
-      console.error('Error deleting from WASMFS', currentRepoDir, e);
-    }
-    // Also clear the underlying OPFS storage
-    try {
-      const opfsRoot = await navigator.storage.getDirectory();
-      await opfsRoot.removeEntry(repoName, { recursive: true });
-      console.log('Deleted OPFS entry', repoName);
-    } catch (e) {
-      console.error('Error deleting from OPFS', repoName, e);
-    }
-    try { FS.unlink('/' + repoName); } catch (e) { }
-    currentRepoDir = undefined;
-    postMessage({ id: msg.data.id, deleted: repoName });
   } else if (msg.data.command === 'clone') {
-    const repoName = msg.data.url.substring(msg.data.url.lastIndexOf('/') + 1);
+    const repoName = repoDirName(msg.data);
     currentRepoDir = OPFS_MOUNT + '/' + repoName;
 
     callMainInDir(['clone', msg.data.url, currentRepoDir]);
@@ -308,14 +302,14 @@ onmessage = async (msg) => {
     try { callMainInDir(['config', 'core.fileMode', 'false']); } catch (_) {}
 
     console.log(currentRepoDir, 'persisted via OPFS');
-    postMessage({ dircontents: readdir() });
+    postMessage({ dircontents: readdir(), repoName });
   } else if (msg.data.command === 'initlocal') {
     // Establish a persistent local OPFS repo when there's nothing to clone
     // (unregistered/unreachable remote). Mkdir UNDER the OPFS mount so the
     // working tree survives reload, then `git init` in place. origin is set to
     // the requested URL so "Commit & Sync" can push once the remote exists.
     // See issue #151.
-    const repoName = msg.data.url.substring(msg.data.url.lastIndexOf('/') + 1);
+    const repoName = repoDirName(msg.data);
     currentRepoDir = OPFS_MOUNT + '/' + repoName;
     console.log('initlocal', currentRepoDir);
 
@@ -330,7 +324,7 @@ onmessage = async (msg) => {
     try { callMainInDir(['remote', 'add', 'origin', originUrl]); } catch (_) {}
 
     console.log(currentRepoDir, 'initialized local repo, persisted via OPFS');
-    postMessage({ dircontents: readdir() });
+    postMessage({ dircontents: readdir(), repoName });
   } else if (msg.data.command === 'setremote') {
     // Point origin at an arbitrary URL (the `?…&remote=<url>` param). The URL
     // is written to .git/config, which lives in OPFS and so persists across

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -10,7 +10,7 @@ const OPFS_MOUNT = '/opfs';
 // explicitly so the local directory stays keyed on `?gitrepo=` even when the
 // clone url points somewhere else entirely (`?…&remote=`); deriving it from
 // the url instead made clones land where synclocal and "Delete local" could
-// never find them again. See issue #183. The url fallback keeps older callers
+// never find them again. See PR #183. The url fallback keeps older callers
 // (and the e2e worker drivers) working.
 function repoDirName(data) {
   return data.repoName || data.url.substring(data.url.lastIndexOf('/') + 1);


### PR DESCRIPTION
## The bug

On a repo opened as `?gitrepo=A&remote=…/B.git`, pressing **Delete local** reported success but deleted nothing:

```
wasmgitclient.js:270 Error deleting from OPFS july26song.git
  NotFoundError: A requested file or directory could not be found…
```

The OPFS directory was named after the **remote** (`wasm-music-2026.git`), not the `?gitrepo=` name (`july26song.git`). The worker derived the directory from whatever url each command received — and `clone` receives the remote url — while `synclocal` and `deletelocal` both looked for the `?gitrepo=` name.

Two consequences:

1. **Delete removed nothing.** `removeEntry` threw `NotFoundError`, the `catch` only logged, and the modal still said "Local clone deleted".
2. **Every boot ran a doomed clone.** `synclocal` never found the repo, so it fell through to clone, which failed with `'/opfs/wasm-music-2026.git' exists and is not an empty directory` — masked because the `.git`-presence check then adopted the directory already in the way. These repos have been working by accident.

Regression from a9579de (#156), which introduced cloning *from* the `?remote=` target. Before that, `clone` always used the NEAR url, so the directory name matched what delete looked for. NEAR repos and the default workspace were never affected — only `?remote=` ones.

## The fix

Decouple the two concepts: **`url` is where we clone FROM, `repoName` is where it lands in OPFS.** The client sends the `?gitrepo=`-derived name explicitly on `clone` / `synclocal` / `initlocal`, and the worker resolves it through one helper:

```js
function repoDirName(data) {
  return data.repoName || data.url.substring(data.url.lastIndexOf('/') + 1);
}
```

`deletelocal()` now targets the directory **the worker reported working in** — tracked from the `repoName` returned alongside `dircontents` — rather than re-deriving a name that may never have existed.

**Migration.** `synclocal` tries the canonical name, then the legacy remote-derived one, and adopts whichever exists. Work saved by earlier builds stays reachable and deletable; nothing is moved on disk.

Also in this PR:

- Delete failures are reported in the modal instead of claiming success. The silent `NotFoundError` is what hid this.
- The repo name and error text interpolated into that modal are escaped — the name comes from a url query param.
- Removed the unreachable `deletelocal` worker handler. Nothing has posted that command since deletion moved to the main thread (the worker must be terminated first to release the OPFS lock).

## Tests

New `e2e/delete-local.spec.js`, 5 cases, no network needed — the directory name is decided before any traffic:

| | |
|---|---|
| naming | OPFS directory follows `?gitrepo=`, not the remote url |
| clone target | a clone lands in the `?gitrepo=` directory even when cloning elsewhere |
| boot | `synclocal` finds the repo again — no more doomed re-clone per reload |
| delete | removes the directory the worker actually used |
| **legacy** | a pre-fix clone under the remote-derived name is adopted, readable, deletable |

**All 5 fail on the current `master` code and pass with this change** (verified by stashing the source fix and re-running).

Full wasm-git e2e suite green with the NEAR sandbox running: **18 passed** across `delete-local`, `local-repo-persistence`, `commit-empty-diff-hang`, `commit-stages-unstaged`, `anonymous-clone-auth`, `default-workspace`, `near-git`.

## Upgrade note

Users who already have a repo under the old remote-derived directory keep their work — it is adopted on the next load. No action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)