### PR TITLE
Teach chords: a step slot that is an array

### DIFF
--- a/wasmaudioworklet/docs/song-api.md
+++ b/wasmaudioworklet/docs/song-api.md
@@ -103,6 +103,12 @@ part longer than it keeps running into whatever comes next, and anything past
 `Promise.all([...])` also works and is equivalent when the parts are the same
 length, but it is noisier — prefer awaiting the beat-keeper.
 
+The same rule applies *within* one track: notes that must sound together are
+notes placed at the same position, so a chord is a nested array in one
+`steps()` slot (or several notes in one `play()` row) — never one awaited call
+per chord tone, which arpeggiates them. See
+[Chords](#chords--a-step-slot-that-is-an-array).
+
 ### If nothing is awaited, the song is empty
 
 The playhead never moves, so `loopHere()` marks the end of the song at beat 0
@@ -556,7 +562,8 @@ Plays a sequence of events at regular intervals.
 
 **Parameters:**
 - `stepsperbeat` (number): Number of steps per beat
-- `events` (array): Array of note functions or arrays of note functions
+- `events` (array): Array of note functions, or arrays of note functions
+  (a nested array = a chord, see below). An empty slot is a rest.
 
 **Example:**
 ```javascript
@@ -572,6 +579,43 @@ the clock to the end of the pattern. Omit the `await` to have this part play
 alongside another one — see
 [Playing tracks at the same time](#playing-tracks-at-the-same-time).
 
+#### Chords — a step slot that is an array
+
+Everything inside a nested array fires **together** on that step. This is the
+normal way to write chords on a grid; you do not need `play()` for it, and you
+must not give each chord tone its own awaited call (that would advance the
+playhead between tones and arpeggiate the chord).
+
+```javascript
+const piano = createTrack(0, 4, 100);
+
+// Dm (twice), then A#maj / first inversion — three tones per hit, struck staccato
+await piano.steps(2, [
+    [d5(0.25), f5(0.25), a5(0.25)],
+    [d5(0.25), f5(0.25), a5(0.25)],
+    [d5(0.25), f5(0.25), as5(0.25)],
+    ,                                  // rest
+]);
+```
+
+Durations and velocities work per note, empty slots are still rests, and
+`.repeat(n)` applies to the whole grid as usual. A step array may also carry
+automation alongside the notes:
+
+```javascript
+rhodes.steps(2, [
+    [c5(2), e5(2), controlchange(7, 110)],   // chord + volume CC on the same step
+    , , ,
+    [d5(2), fs5(2)],
+]);
+```
+
+(see `songs/upbeat.js` for this in a real song).
+
+To check a chord part landed as chords rather than as an arpeggio, compile and
+read the note count from the compiled MIDI events: it should be
+*number of hits × tones per chord* (e.g. 16 hits of a triad = 48 notes).
+
 ### `play(rows, rowbeatcolumnmode)`
 Plays events with custom timing.
 
@@ -584,9 +628,14 @@ Plays events with custom timing.
 await track.play([
     [0, c4],
     [0.5, e4],
-    [1, g4, c5]  // Multiple notes at beat 1
+    [1, g4, c5]  // Multiple notes at beat 1 — a chord
 ]);
 ```
+
+Several notes in one row form a chord at that beat, same as a nested array in
+`steps()`. Use `play()` when the timing is off-grid; prefer
+[`steps()` with chord arrays](#chords--a-step-slot-that-is-an-array) for
+anything on a regular grid.
 
 ---
 

--- a/wasmaudioworklet/midisequencer/songcompiler.spec.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.spec.js
@@ -84,6 +84,38 @@ loopHere();
             [1, beatTime(3.5)]
         ]);
     });
+    // Documents the chord form in docs/song-api.md ("Chords - a step slot that is
+    // an array"): every note inside one step slot starts on that step, so a chord
+    // is written as a nested array - not as one awaited call per tone, which would
+    // arpeggiate it.
+    it('should start every note of a nested step array at the same time', async () => {
+        const bpm = 120;
+        const beatTime = beatNo => Math.floor((beatNo / bpm) * 60 * 1000);
+
+        const eventlist = await compileSong(`
+setBPM(${bpm});
+
+await createTrack(0).steps(2, [
+    [d5(0.25), f5(0.25), a5(0.25)],
+    [d5(0.25), f5(0.25), a5(0.25)],
+    [d5(0.25), f5(0.25), as5(0.25)],
+    ,
+]);
+
+loopHere();
+`);
+        const chordsByTime = {};
+        eventlist.filter(evt => (evt.message[0] & 0xf0) === 0x90 && evt.message[2] > 0)
+            .forEach(evt => (chordsByTime[evt.time] = chordsByTime[evt.time] ?? []).push(evt.message[1]));
+        Object.values(chordsByTime).forEach(notes => notes.sort((a, b) => a - b));
+
+        // three hits of three tones each - Dm twice, then d5/f5/as5 - none arpeggiated
+        assert.deepEqual(chordsByTime, {
+            [beatTime(0)]: [62, 65, 69],
+            [beatTime(0.5)]: [62, 65, 69],
+            [beatTime(1)]: [62, 65, 70]
+        });
+    });
     // `.repeat(n)` appends n FURTHER copies, so the result is n+1 — unlike
     // String.prototype.repeat. Pinned here with the exact numbers the docs and
     // the studio-agent prompt quote, because getting it backwards makes a part

--- a/wasmaudioworklet/studio-agent/prompt.js
+++ b/wasmaudioworklet/studio-agent/prompt.js
@@ -58,7 +58,12 @@ Musically: every statement starts a part; \`await\` means "wait for that part to
 - **Instruments / structure:** \`addInstrument('name')\` — the Nth call is channel N (0-based); order MUST match the synth's midichannels[]. \`definePartStart('name')\` / \`definePartEnd('name')\`.
 - **Tracks:** \`const t = createTrack(channel, stepsPerBeat?, defaultVelocity?)\`. Then:
   - \`t.steps(stepsPerBeat, [ ...notes ])\` — step grid; empty slot = rest; \`[...].repeat(n)\` (see the repeat rule below).
-  - \`t.play([ [beat, note(...), ...], ... ])\` — absolute-beat placement; append \`.quantize(stepsPerBeat, pct?)\` to snap timing.
+  - **CHORDS in a step grid: a step slot that is an ARRAY fires everything in it TOGETHER on that step.** This is the normal way to write chords — do NOT switch to \`play()\` and do NOT give each chord tone its own awaited call (that arpeggiates them, the #1 "my chords play one note at a time" bug):
+    \`\`\`javascript
+    piano.steps(4, [ [d5,f5,a5], , [d5,f5,a5], , [d5,f5,as5], , , ]);  // Dm hits, then A#/D-F-A#
+    \`\`\`
+    Empty slots are still rests, \`.repeat(n)\` still applies, and durations/velocities work per note (\`[c5(2), e5(2), g5(2)]\`). A step-array may also carry automation alongside the notes — \`[c5(2), e5(2), controlchange(7, 110)]\` (see songs/upbeat.js). Chord count is checkable: song_summary's note count = hits × tones per chord.
+  - \`t.play([ [beat, note(...), ...], ... ])\` — absolute-beat placement, several notes in one row = a chord at that beat; append \`.quantize(stepsPerBeat, pct?)\` to snap timing. Prefer \`steps()\` with chord-arrays for anything on a grid.
   - \`t.setChannel(ch)\`, \`t.waitForBeat(b)\`, \`t.waitForStep(s)\`, \`t.waitDuration(d)\`, \`t.note(midiNo, dur)\`, \`t.playNote('c4', dur)\`.
 
 - **A HELD note must END BEFORE the next note of the SAME pitch on that channel starts.** If a note-off lands at exactly the next note-on, the synth gets attack-then-release for one sounding note and the NEW note is CUT — audible as a chord tone dropping out. This bites when a chord is held into the next chord that shares a pitch (e.g. A#maj7 → F both contain f5 and a5). So when chords change on beats 0 / 2.5 / 3.5, do NOT write durations 2.5 / 1 that meet the next chord exactly — **trim each by a hair** (2.45 / 0.95; ~0.05 beat). Applies to sustained/chordal parts; short percussive steps in a grid retrigger normally and need no gap. compile reports these as "notes CUT by the previous note's note-off".


### PR DESCRIPTION
The step sequencer has always supported chords — [`trackerpattern.js`](https://github.com/petersalomonsen/javascriptmusic/blob/master/wasmaudioworklet/midisequencer/trackerpattern.js#L97-L105) iterates an array slot and fires every event at the same beat, and `songs/upbeat.js` uses it in anger (`[c5(2), e5(2), controlchange(7, 110)]`). But nothing actually said so: `song-api.md` only hinted at it in a parameter line ("arrays of note functions") with no example and no use of the word *chord*, and the studio-agent prompt described `steps()` as "step grid; empty slot = rest".

That gap has a cost. In a studio-agent session, asked how to sound chord notes simultaneously, the agent could only offer `play()` and cross-track layering — the user had to supply `.steps(4, [[d5,f5,a5],,[d5,f5,a5]])` themselves, and the agent's reply was "that's not in my instructions".

## Changes

- **`studio-agent/prompt.js`** — chord bullet under the `steps()` line: a nested array is one step with all tones together; do not switch to `play()` and do not give each tone its own awaited call (that arpeggiates them). Rests, `.repeat(n)` and per-note durations/velocities still apply; a slot may carry `controlchange` alongside the notes. Includes the check the agent can actually run: `song_summary` note count = hits × tones per chord. The `play()` bullet now notes that several notes in one row is the same thing, off-grid.
- **`docs/song-api.md`** — a `Chords — a step slot that is an array` subsection under `steps()`, cross-referenced from `play()` and from the playhead model, where the same "only `await` moves the playhead" rule explains *why* per-tone awaits arpeggiate.
- **`midisequencer/songcompiler.spec.js`** — pins the rule the way the concurrency and `.repeat(n)` rules are pinned: compiles the documented example and asserts the note-ons group into three simultaneous triads.

## Verification

- `npx wtr midisequencer/songcompiler.spec.js` — 14 passed on Chromium and Firefox.
- `npm run test-agent-tools` — 52 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)