### PR TITLE
Build and publish the Faust compiler module from CI

### DIFF
--- a/.github/workflows/publish-faust-compiler-module.yml
+++ b/.github/workflows/publish-faust-compiler-module.yml
@@ -13,7 +13,8 @@
 # Publishing: npm trusted publishing (OIDC), no token
 # ---------------------------------------------------------------------------
 # This workflow authenticates to npm with a short-lived OIDC token from GitHub,
-# so there is no NPM_TOKEN secret to leak or rotate. It requires, once:
+# so there is no NPM_TOKEN secret to leak or rotate. Already configured for this
+# package; what it took, should it ever need redoing:
 #
 #   1. The package must already exist on npm — a trusted publisher cannot be
 #      configured for a name that has never been published. Bootstrap it by
@@ -26,6 +27,10 @@
 #        Workflow filename:     publish-faust-compiler-module.yml
 #      All fields are case-sensitive, and npm does not validate them on save —
 #      a typo only surfaces as a failed publish.
+#
+# The publisher is not restricted to a branch (no environment is configured),
+# so a run started from any ref publishes — which is how 0.1.1 was released
+# from the PR branch, before this workflow was on master.
 #
 # A package may have exactly ONE trusted publisher, which is why this publishes
 # its own package rather than reusing the @psalomo/faustwasm fork: that name's
@@ -74,24 +79,6 @@ on:
         default: ''
         type: string
 
-  # -------------------------------------------------------------------------
-  # TEMPORARY — bootstrap trigger, remove before merging.
-  #
-  # A workflow_dispatch workflow can only be run from the default branch, so
-  # until this file is on master there is no way to exercise it — including the
-  # OIDC publish, the one step a dry run cannot cover. Pushing to the branch
-  # below with a marker in the commit message runs it with the fallback
-  # parameters in the job's env block:
-  #
-  #   [build-module]    build, validate, pack, upload the tarball — no publish
-  #   [publish-module]  the same, then actually publish via trusted publishing
-  #
-  # Anything without a marker is ignored: the compiler build is far too
-  # expensive to fire on every push.
-  # -------------------------------------------------------------------------
-  push:
-    branches: [faust-compiler-module-publish]
-
 permissions:
   contents: read
   id-token: write   # npm trusted publishing (OIDC)
@@ -103,24 +90,19 @@ concurrency:
 
 jobs:
   build-and-publish:
-    # Push-triggered runs are opt-in per commit; the compiler build is far too
-    # expensive to fire on every push to the bootstrap branch.
-    if: ${{ github.event_name != 'push' || contains(github.event.head_commit.message, '[build-module]') || contains(github.event.head_commit.message, '[publish-module]') }}
     runs-on: ubuntu-latest
     # The faust-rs workspace is a compiler: a cold cargo build is the long pole.
     timeout-minutes: 120
+    # Free-text inputs reach the shell as environment variables, never
+    # interpolated into a script body.
     env:
       PACKAGE: '@psalomo/wasm-music-faust'
-      # Inputs are empty on push events; the fallbacks are the bootstrap
-      # parameters and go away with the push trigger above.
-      VERSION: ${{ inputs.version || '0.1.1' }}
-      FAUST_RS_REF: ${{ inputs.faust_compiler_ref || 'main' }}
-      FAUSTLIBRARIES_REF: ${{ inputs.faustlibraries_ref || 'master' }}
-      E2E_REF: ${{ inputs.e2e_ref || 'faust-rich-diagnostics' }}
-      RUN_E2E: ${{ github.event_name == 'push' && 'true' || inputs.run_e2e }}
-      # On push, only a `[publish-module]` commit publishes; on dispatch this is
-      # the input, including an explicit false.
-      DRY_RUN: ${{ github.event_name == 'push' && (contains(github.event.head_commit.message, '[publish-module]') && 'false' || 'true') || inputs.dry_run }}
+      VERSION: ${{ inputs.version }}
+      FAUST_RS_REF: ${{ inputs.faust_compiler_ref }}
+      FAUSTLIBRARIES_REF: ${{ inputs.faustlibraries_ref }}
+      E2E_REF: ${{ inputs.e2e_ref }}
+      RUN_E2E: ${{ inputs.run_e2e }}
+      DRY_RUN: ${{ inputs.dry_run }}
 
     steps:
       # ---------------------------------------------------------------------
@@ -152,7 +134,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: grame-cncm/faust-rs
-          ref: ${{ inputs.faust_compiler_ref || 'main' }}
+          ref: ${{ inputs.faust_compiler_ref }}
           path: faust-rs
 
       # Note: faust-rs's own CI does not track faustlibraries@master — it pins
@@ -166,7 +148,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: grame-cncm/faustlibraries
-          ref: ${{ inputs.faustlibraries_ref || 'master' }}
+          ref: ${{ inputs.faustlibraries_ref }}
           path: faustlibraries
 
       - name: Use Node.js 20.x

--- a/.github/workflows/publish-faust-compiler-module.yml
+++ b/.github/workflows/publish-faust-compiler-module.yml
@@ -1,0 +1,393 @@
+# Build the Faust compiler module from source and publish it as
+# `@psalomo/wasm-music-faust` — so a compiler release no longer depends on one
+# developer's laptop.
+#
+# The package holds exactly one artifact: `faust-compiler-module.wasm`, the
+# faust-rs (Rust) Faust compiler built for wasm32-unknown-unknown with the
+# AssemblyScript backend and the Faust standard libraries embedded. The app
+# loads it with a bare `WebAssembly.instantiate(bytes, {})`
+# (wasmaudioworklet/faust/faust-rs-transpile.js, tools/faust2as/faust2asc.js),
+# and jsDelivr serves it straight out of the published package.
+#
+# ---------------------------------------------------------------------------
+# Publishing: npm trusted publishing (OIDC), no token
+# ---------------------------------------------------------------------------
+# This workflow authenticates to npm with a short-lived OIDC token from GitHub,
+# so there is no NPM_TOKEN secret to leak or rotate. It requires, once:
+#
+#   1. The package must already exist on npm — a trusted publisher cannot be
+#      configured for a name that has never been published. Bootstrap it by
+#      running this workflow with dry_run, downloading the tarball artifact,
+#      and publishing that exact file by hand:
+#        npm publish <tarball> --access public
+#   2. npmjs.com → the package → Settings → Trusted Publisher → GitHub Actions:
+#        Organization or user:  petersalomonsen
+#        Repository:            javascriptmusic
+#        Workflow filename:     publish-faust-compiler-module.yml
+#      All fields are case-sensitive, and npm does not validate them on save —
+#      a typo only surfaces as a failed publish.
+#
+# A package may have exactly ONE trusted publisher, which is why this publishes
+# its own package rather than reusing the @psalomo/faustwasm fork: that name's
+# publisher slot belongs to petersalomonsen/faustwasm's own workflow.
+#
+# Provenance is generated automatically for trusted publishes, and requires
+# package.json's `repository` field to match this repository exactly — which is
+# why build-package.mjs sets it to petersalomonsen/javascriptmusic and
+# verify-package.mjs asserts it.
+#
+# Trusted publishing needs npm >= 11.5.1 on Node >= 22, newer than the runner
+# default, so the publish step sets that up for itself.
+
+name: Publish faust compiler module
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New package version, e.g. 0.1.1'
+        required: true
+        type: string
+      faust_compiler_ref:
+        description: 'git ref of grame-cncm/faust-rs to build'
+        required: true
+        default: 'main'
+        type: string
+      faustlibraries_ref:
+        description: 'git ref of grame-cncm/faustlibraries to embed (faust-rs CI pins an exact SHA — see the note below)'
+        required: true
+        default: 'master'
+        type: string
+      dry_run:
+        description: 'Do everything except npm publish (the tarball is uploaded as an artifact either way)'
+        required: true
+        default: true
+        type: boolean
+      run_e2e:
+        description: 'Also run the in-browser Playwright transpile spec against the fresh module'
+        required: true
+        default: true
+        type: boolean
+      e2e_ref:
+        description: 'Branch of THIS repo to run that spec from (blank = the ref this run was started from). Point it at the PR that consumes the new module.'
+        required: false
+        default: ''
+        type: string
+
+  # -------------------------------------------------------------------------
+  # TEMPORARY — bootstrap trigger, remove before merging.
+  #
+  # A workflow_dispatch workflow can only be run from the default branch, so
+  # until this file is on master there is no way to exercise it. Pushing a
+  # commit whose message contains `[build-module]` to the branch below runs it
+  # with the fallback parameters in the job's env block. Push-triggered runs are
+  # forced to dry_run: they build, validate and upload the tarball, and can
+  # never publish.
+  # -------------------------------------------------------------------------
+  push:
+    branches: [faust-compiler-module-publish]
+
+permissions:
+  contents: read
+  id-token: write   # npm trusted publishing (OIDC)
+
+# Two runs must never race to publish.
+concurrency:
+  group: publish-faust-compiler-module
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    # Push-triggered runs are opt-in per commit; the compiler build is far too
+    # expensive to fire on every push to the bootstrap branch.
+    if: ${{ github.event_name != 'push' || contains(github.event.head_commit.message, '[build-module]') }}
+    runs-on: ubuntu-latest
+    # The faust-rs workspace is a compiler: a cold cargo build is the long pole.
+    timeout-minutes: 120
+    env:
+      PACKAGE: '@psalomo/wasm-music-faust'
+      # Inputs are empty on push events; the fallbacks are the bootstrap
+      # parameters and go away with the push trigger above.
+      VERSION: ${{ inputs.version || '0.1.0' }}
+      FAUST_RS_REF: ${{ inputs.faust_compiler_ref || 'main' }}
+      FAUSTLIBRARIES_REF: ${{ inputs.faustlibraries_ref || 'master' }}
+      E2E_REF: ${{ inputs.e2e_ref || 'faust-rich-diagnostics' }}
+      RUN_E2E: ${{ github.event_name == 'push' && 'true' || inputs.run_e2e }}
+      # `A && B || C`: on push this is 'true'; on dispatch it is the input,
+      # including an explicit false.
+      DRY_RUN: ${{ github.event_name == 'push' && 'true' || inputs.dry_run }}
+
+    steps:
+      # ---------------------------------------------------------------------
+      # Cheap gates first — never spend an hour of compiler build on a version
+      # string that was going to be rejected at the end.
+      # ---------------------------------------------------------------------
+      - name: Validate the requested version
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$VERSION' is not a semver version."
+            exit 1
+          fi
+
+          if npm view "$PACKAGE@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$PACKAGE@$VERSION is already published — pick a new version."
+            exit 1
+          fi
+
+          # Absent on the very first release; that is expected, not an error.
+          PREVIOUS="$(npm view "$PACKAGE" version 2>/dev/null || true)"
+          echo "PREVIOUS=${PREVIOUS:-none}" >> "$GITHUB_ENV"
+          echo "Building $PACKAGE $VERSION (previous: ${PREVIOUS:-none}, dry run: $DRY_RUN)"
+
+      - name: Checkout javascriptmusic
+        uses: actions/checkout@v4
+
+      - name: Checkout faust-rs (compiler source)
+        uses: actions/checkout@v4
+        with:
+          repository: grame-cncm/faust-rs
+          ref: ${{ inputs.faust_compiler_ref || 'main' }}
+          path: faust-rs
+
+      # Note: faust-rs's own CI does not track faustlibraries@master — it pins
+      # an exact revision (ecf2fdc238148c44c18352102333a1229ca7a8d3 as of
+      # 2026-07-30), after a lagging standard library broke its dx7_alg5
+      # compile-budget job by not providing `dx.algorithm`. `master` is the
+      # default here; pass the pinned SHA when you want exactly the standard
+      # library the compiler was tested against. Either way the resolved SHA is
+      # recorded in the published package and in the run summary.
+      - name: Checkout faustlibraries (embedded .lib files)
+        uses: actions/checkout@v4
+        with:
+          repository: grame-cncm/faustlibraries
+          ref: ${{ inputs.faustlibraries_ref || 'master' }}
+          path: faustlibraries
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Record the source revisions
+        run: |
+          set -euo pipefail
+          echo "FAUST_RS_SHA=$(git -C faust-rs rev-parse HEAD)" >> "$GITHUB_ENV"
+          echo "FAUSTLIBRARIES_SHA=$(git -C faustlibraries rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Set up the Rust wasm32 target
+        working-directory: faust-rs
+        run: |
+          set -euo pipefail
+          # Run from the workspace so faust-rs's rust-toolchain.toml (channel =
+          # stable) selects the toolchain the target gets added to.
+          rustup show active-toolchain || rustup toolchain install stable --profile minimal --no-self-update
+          rustup target add wasm32-unknown-unknown
+          rustc --version
+          cargo --version
+
+      # A cold build of the compiler workspace is the long pole of this run.
+      # The target dir is large — if these entries start crowding the
+      # repository's 10 GB cache budget, drop `faust-rs/target` from the list
+      # and keep only the registry.
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            faust-rs/target
+          key: faust-rs-cargo-${{ runner.os }}-${{ hashFiles('faust-rs/Cargo.lock') }}
+          restore-keys: |
+            faust-rs-cargo-${{ runner.os }}-
+
+      # ---------------------------------------------------------------------
+      # Build
+      # ---------------------------------------------------------------------
+      - name: Build the compiler module
+        working-directory: faust-rs
+        env:
+          # Without this the module still builds, but the Faust standard
+          # libraries are not embedded and `import("stdfaust.lib")` fails at
+          # runtime. Validation check 2 below is what catches that.
+          FAUST_RS_EMBEDDED_LIB_ROOT: ${{ github.workspace }}/faustlibraries
+        run: |
+          set -euo pipefail
+          # crates/wasm-ffi/build.rs embeds the .lib files but only declares
+          # `rerun-if-env-changed` for the root — never `rerun-if-changed` on
+          # the files themselves. With a restored target dir and an unchanged
+          # root *path*, cargo would consider the build script fresh and keep a
+          # module embedding a stale copy of the standard libraries, even
+          # though the faustlibraries checkout moved. Clean that one crate so
+          # the embed is always regenerated; every dependency stays cached.
+          cargo clean -p wasm-ffi
+          cargo run --release -p xtask -- build-faustwasm-compiler-module
+
+      - name: Locate the built module
+        run: |
+          set -euo pipefail
+          RELEASE_DIR="faust-rs/target/wasm32-unknown-unknown/release"
+          MODULE=""
+          # xtask renames cargo's crate-derived `faust_wasm_ffi.wasm` to the
+          # distribution name `libfaust-rs.wasm`; accept either, newest
+          # spelling first, so a change on that side does not break the run.
+          for candidate in "$RELEASE_DIR/libfaust-rs.wasm" "$RELEASE_DIR/faust_wasm_ffi.wasm"; do
+            if [ -f "$candidate" ]; then MODULE="$candidate"; break; fi
+          done
+          if [ -z "$MODULE" ]; then
+            # Exactly one .wasm in the release dir is still unambiguous.
+            mapfile -t found < <(find "$RELEASE_DIR" -maxdepth 1 -name '*.wasm' 2>/dev/null)
+            if [ "${#found[@]}" -eq 1 ]; then MODULE="${found[0]}"; fi
+          fi
+          if [ -z "$MODULE" ]; then
+            echo "::error::No compiler module found in $RELEASE_DIR"
+            ls -la "$RELEASE_DIR" || true
+            exit 1
+          fi
+          echo "MODULE_PATH=${{ github.workspace }}/$MODULE" >> "$GITHUB_ENV"
+          echo "MODULE_SHA256=$(sha256sum "$MODULE" | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          echo "MODULE_BYTES=$(stat -c%s "$MODULE")" >> "$GITHUB_ENV"
+          ls -la "$MODULE"
+
+      # ---------------------------------------------------------------------
+      # Mandatory validation — runs in dry runs too. See the script header for
+      # what each check protects against.
+      # ---------------------------------------------------------------------
+      - name: Validate the module
+        run: node tools/faust-compiler-module/validate-module.mjs "$MODULE_PATH"
+
+      # A branch that is waiting on this module can be validated against it
+      # before it is published: the spec runs from `e2e_ref`, against the build
+      # from above. The local module drop outranks the CDN, so the version that
+      # branch pins does not have to exist on npm yet.
+      - name: Check out the branch to run the e2e from
+        if: ${{ env.RUN_E2E == 'true' && env.E2E_REF != '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.E2E_REF }}
+          path: e2e-repo
+
+      - name: Repo e2e against the fresh module
+        if: ${{ env.RUN_E2E == 'true' }}
+        run: |
+          set -euo pipefail
+          APP_DIR="wasmaudioworklet"
+          if [ -n "$E2E_REF" ]; then APP_DIR="e2e-repo/wasmaudioworklet"; fi
+          echo "Running the transpile spec from ${E2E_REF:-the ref this run started from} in $APP_DIR"
+          # The gitignored local drop takes precedence over the CDN fallback,
+          # so the app under test loads exactly the module built above.
+          cp "$MODULE_PATH" "$APP_DIR/faust/faust_wasm_ffi.wasm"
+          cd "$APP_DIR"
+          yarn install
+          yarn playwright install --with-deps chromium
+          npx playwright test e2e/faust-rs-transpile.spec.js
+
+      - name: Upload Playwright artifacts on failure
+        if: ${{ failure() && env.RUN_E2E == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: |
+            wasmaudioworklet/test-results/
+            e2e-repo/wasmaudioworklet/test-results/
+          if-no-files-found: ignore
+
+      # ---------------------------------------------------------------------
+      # Package
+      # ---------------------------------------------------------------------
+      - name: Build the package
+        run: |
+          set -euo pipefail
+          node tools/faust-compiler-module/build-package.mjs \
+            --module "$MODULE_PATH" \
+            --license faust-rs/LICENSE \
+            --out staging/package \
+            --version "$VERSION" \
+            --faust-rs-commit "$FAUST_RS_SHA" \
+            --faustlibraries-commit "$FAUSTLIBRARIES_SHA"
+
+          # Pack, then verify the *tarball* — what ships is what gets checked,
+          # not the directory it was built from.
+          mkdir -p staging/out staging/repacked
+          (cd staging/package && npm pack --ignore-scripts --pack-destination ../out >/dev/null)
+          TARBALL="$(ls staging/out/*.tgz)"
+          tar -xzf "$TARBALL" -C staging/repacked
+          echo "TARBALL=${{ github.workspace }}/$TARBALL" >> "$GITHUB_ENV"
+          ls -la "$TARBALL"
+
+      - name: Verify the tarball
+        run: |
+          node tools/faust-compiler-module/verify-package.mjs \
+            staging/repacked/package "$VERSION" "$MODULE_PATH"
+
+      - name: Upload the tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-music-faust-${{ env.VERSION }}-tarball
+          path: ${{ env.TARBALL }}
+
+      # ---------------------------------------------------------------------
+      # Publish
+      # ---------------------------------------------------------------------
+      - name: Set up Node.js 22 and npm for trusted publishing
+        if: ${{ env.DRY_RUN != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        if: ${{ env.DRY_RUN != 'true' }}
+        run: |
+          set -euo pipefail
+          # Trusted publishing needs npm >= 11.5.1; Node 22 still ships npm 10.
+          npm install -g npm@latest
+          npm --version
+          # No NODE_AUTH_TOKEN: auth is the OIDC token from `id-token: write`.
+          # Provenance is automatic for trusted publishes; --provenance makes
+          # the intent explicit and fails loudly if OIDC did not take effect.
+          npm publish "$TARBALL" --access public --provenance
+
+      - name: Report the dry run
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: |
+          set -euo pipefail
+          echo "Dry run: nothing published. The tarball is attached to this run as an artifact."
+          echo "To publish it by hand (this is how the first release is bootstrapped):"
+          echo "  npm publish <downloaded tarball> --access public"
+
+      - name: Summary
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## $PACKAGE $VERSION"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "| mode | dry run — tarball attached, nothing published |"
+            else
+              echo "| mode | published to npm (trusted publishing, with provenance) |"
+            fi
+            echo "| previous | \`${PREVIOUS:-none}\` |"
+            echo "| faust-rs | \`$FAUST_RS_REF\` @ \`${FAUST_RS_SHA:-unknown}\` |"
+            echo "| faustlibraries | \`$FAUSTLIBRARIES_REF\` @ \`${FAUSTLIBRARIES_SHA:-unknown}\` |"
+            echo "| module | ${MODULE_BYTES:-?} bytes, sha256 \`${MODULE_SHA256:-unknown}\` |"
+            if [ "$RUN_E2E" = "true" ]; then
+              echo "| e2e | ran from \`${E2E_REF:-the ref this run started from}\` |"
+            else
+              echo "| e2e | skipped |"
+            fi
+            echo ""
+            if [ "$DRY_RUN" != "true" ] && [ "${{ job.status }}" = "success" ]; then
+              echo "### Manual follow-ups"
+              echo ""
+              echo "1. Bump \`COMPILER_MODULE_VERSION\` to \`$VERSION\` in"
+              echo "   \`wasmaudioworklet/faust/faust-rs-transpile.js\` (the CDN fallback URL is derived from it)."
+              echo "2. Bump the \`$PACKAGE\` dependency in \`tools/faust2as/package.json\`."
+              echo "3. Verify the CDN serves the new file (jsDelivr lags the publish by a few minutes):"
+              echo "   \`https://cdn.jsdelivr.net/npm/$PACKAGE@$VERSION/faust-compiler-module.wasm\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-faust-compiler-module.yml
+++ b/.github/workflows/publish-faust-compiler-module.yml
@@ -78,11 +78,16 @@ on:
   # TEMPORARY — bootstrap trigger, remove before merging.
   #
   # A workflow_dispatch workflow can only be run from the default branch, so
-  # until this file is on master there is no way to exercise it. Pushing a
-  # commit whose message contains `[build-module]` to the branch below runs it
-  # with the fallback parameters in the job's env block. Push-triggered runs are
-  # forced to dry_run: they build, validate and upload the tarball, and can
-  # never publish.
+  # until this file is on master there is no way to exercise it — including the
+  # OIDC publish, the one step a dry run cannot cover. Pushing to the branch
+  # below with a marker in the commit message runs it with the fallback
+  # parameters in the job's env block:
+  #
+  #   [build-module]    build, validate, pack, upload the tarball — no publish
+  #   [publish-module]  the same, then actually publish via trusted publishing
+  #
+  # Anything without a marker is ignored: the compiler build is far too
+  # expensive to fire on every push.
   # -------------------------------------------------------------------------
   push:
     branches: [faust-compiler-module-publish]
@@ -100,7 +105,7 @@ jobs:
   build-and-publish:
     # Push-triggered runs are opt-in per commit; the compiler build is far too
     # expensive to fire on every push to the bootstrap branch.
-    if: ${{ github.event_name != 'push' || contains(github.event.head_commit.message, '[build-module]') }}
+    if: ${{ github.event_name != 'push' || contains(github.event.head_commit.message, '[build-module]') || contains(github.event.head_commit.message, '[publish-module]') }}
     runs-on: ubuntu-latest
     # The faust-rs workspace is a compiler: a cold cargo build is the long pole.
     timeout-minutes: 120
@@ -108,14 +113,14 @@ jobs:
       PACKAGE: '@psalomo/wasm-music-faust'
       # Inputs are empty on push events; the fallbacks are the bootstrap
       # parameters and go away with the push trigger above.
-      VERSION: ${{ inputs.version || '0.1.0' }}
+      VERSION: ${{ inputs.version || '0.1.1' }}
       FAUST_RS_REF: ${{ inputs.faust_compiler_ref || 'main' }}
       FAUSTLIBRARIES_REF: ${{ inputs.faustlibraries_ref || 'master' }}
       E2E_REF: ${{ inputs.e2e_ref || 'faust-rich-diagnostics' }}
       RUN_E2E: ${{ github.event_name == 'push' && 'true' || inputs.run_e2e }}
-      # `A && B || C`: on push this is 'true'; on dispatch it is the input,
-      # including an explicit false.
-      DRY_RUN: ${{ github.event_name == 'push' && 'true' || inputs.dry_run }}
+      # On push, only a `[publish-module]` commit publishes; on dispatch this is
+      # the input, including an explicit false.
+      DRY_RUN: ${{ github.event_name == 'push' && (contains(github.event.head_commit.message, '[publish-module]') && 'false' || 'true') || inputs.dry_run }}
 
     steps:
       # ---------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ Humans: see [README.md](README.md) and [wasmaudioworklet/docs](wasmaudioworklet/
 - `wasmaudioworklet/` — the app (synth engine, sequencer, visualizer, web UI).
 - `wasmaudioworklet/docs/` — authoring & dev guides (start at its README).
 - `tools/` — dev tooling: `faust2as` (Faust→AssemblyScript), `claude-bridge`
-  (connect an agent to the app's editors), `shadertest` (shader harness).
+  (connect an agent to the app's editors), `shadertest` (shader harness),
+  `faust-compiler-module` (build/validate/publish the Faust compiler wasm).
 - Songs/visuals are usually authored in separate NEAR-backed git repos loaded
   via `?gitrepo=` (see [git-hosting](wasmaudioworklet/docs/git-hosting.md)); a
   song project holds `song.js`, `synth.ts`, `shaders/`, `images/` and

--- a/tools/faust-compiler-module/README.md
+++ b/tools/faust-compiler-module/README.md
@@ -1,0 +1,132 @@
+# faust-compiler-module
+
+Build and release tooling for **`@psalomo/wasm-music-faust`** — the npm package
+holding the Faust compiler this app runs.
+
+That package ships exactly one artifact, `faust-compiler-module.wasm`: the
+[faust-rs](https://github.com/grame-cncm/faust-rs) compiler built for
+`wasm32-unknown-unknown` with the AssemblyScript backend and the Faust standard
+libraries embedded. No JavaScript — the browser loads it with a bare
+`WebAssembly.instantiate(bytes, {})` from
+[faust-rs-transpile.js](../../wasmaudioworklet/faust/faust-rs-transpile.js), and
+node reads it off disk in [faust2asc.js](../faust2as/faust2asc.js). It resolves
+in this order:
+
+1. `$FAUST_RS_COMPILER_MODULE` (node only)
+2. `wasmaudioworklet/faust/faust_wasm_ffi.wasm` — gitignored local drop
+3. `@psalomo/wasm-music-faust@$COMPILER_MODULE_VERSION` from jsDelivr
+
+So a compiler release is: build the module, validate it, wrap it in the
+package, publish, then point `COMPILER_MODULE_VERSION` at the new version.
+
+> This replaced `@psalomo/faustwasm` (dist-tag `asc`), a fork of
+> grame-cncm/faustwasm that shipped 19 MB of JS, emscripten blobs and tests to
+> deliver one 10 MB file none of it was used with. Owning a purpose-built
+> package also gives it its own npm *trusted publisher* slot — a package can
+> have only one, and the fork's belongs to petersalomonsen/faustwasm.
+
+## Releasing
+
+Run the **Publish faust compiler module** workflow
+([.github/workflows/publish-faust-compiler-module.yml](../../.github/workflows/publish-faust-compiler-module.yml)).
+Start with `dry_run: true` — it builds, validates, packs and attaches the
+tarball to the run without publishing. Publishing uses OIDC trusted publishing:
+no npm token exists anywhere in this repository.
+
+The scripts it calls work the same on a laptop:
+
+```bash
+# 1. Build the module (in a grame-cncm/faust-rs checkout)
+rustup target add wasm32-unknown-unknown
+FAUST_RS_EMBEDDED_LIB_ROOT=<faustlibraries-checkout> \
+  cargo run --release -p xtask -- build-faustwasm-compiler-module
+# → target/wasm32-unknown-unknown/release/libfaust-rs.wasm
+
+# 2. Validate it — never publish a module that has not passed this
+node tools/faust-compiler-module/validate-module.mjs <faust-rs>/target/wasm32-unknown-unknown/release/libfaust-rs.wasm
+
+# 3. Build the package around it
+node tools/faust-compiler-module/build-package.mjs \
+  --module <faust-rs>/target/wasm32-unknown-unknown/release/libfaust-rs.wasm \
+  --license <faust-rs>/LICENSE \
+  --out staging/package --version 0.1.1 \
+  --faust-rs-commit $(git -C <faust-rs> rev-parse HEAD) \
+  --faustlibraries-commit $(git -C <faustlibraries> rev-parse HEAD)
+
+# 4. Pack, then check the tarball that will actually ship
+(cd staging/package && npm pack --pack-destination ../out)
+mkdir -p staging/repacked && tar -xzf staging/out/*.tgz -C staging/repacked
+node tools/faust-compiler-module/verify-package.mjs \
+  staging/repacked/package 0.1.1 <faust-rs>/target/wasm32-unknown-unknown/release/libfaust-rs.wasm
+
+# 5. Publish
+npm publish staging/out/*.tgz --access public
+```
+
+`FAUST_RS_EMBEDDED_LIB_ROOT` must point at a checkout of
+`grame-cncm/faustlibraries`: the standard `.lib` files are embedded into the
+module at build time, and without it the module still builds but
+`import("stdfaust.lib")` fails at runtime. `validate-module.mjs` catches that.
+
+Note that faust-rs's own CI pins an exact faustlibraries revision rather than
+tracking `master` — a lagging standard library once broke its `dx.algorithm`
+budget test. Pass that SHA as `faustlibraries_ref` when you want exactly the
+library the compiler was tested against.
+
+## The scripts
+
+| | |
+|---|---|
+| `validate-module.mjs <module.wasm>` | The release gate: full ABI surface, `--ec --os` producing a native `control()`/`frame()` class, structured diagnostics on a bad compile, and a compile-time budget for `dx.algorithm(5)`. Each check maps to a regression that has actually happened — see the script header. |
+| `build-package.mjs` | Assembles the package: generated package.json (with the faust-rs and faustlibraries commits recorded), the module, a generated README, and faust-rs's own LICENSE. |
+| `verify-package.mjs <extractedDir> <version> <module.wasm>` | Checks the packed tarball: exactly four files, the module byte-identical to the validated build, and the metadata npm depends on — including the `repository` field, which provenance rejects with a 422 if it does not match this repository. |
+
+## Testing the branch that is waiting on the release
+
+A branch that needs a compiler feature can be tested against the new module
+*before* it is published — set the workflow's `e2e_ref` input to that branch and
+leave `dry_run` on. The Playwright transpile spec then runs from that branch,
+against the build from this run, and nothing is published.
+
+This works because the local module drop outranks the CDN in the resolution
+order above: the branch can already pin an unpublished
+`COMPILER_MODULE_VERSION`, and the fallback URL is simply never used. So the
+order is *validate the consumer, then publish* — not the other way round.
+
+## Trusted publishing setup
+
+Publishing authenticates with a short-lived OIDC token from GitHub. There is no
+`NPM_TOKEN` secret. Configured once, on npmjs.com → the package → Settings →
+Trusted Publisher → GitHub Actions:
+
+```
+Organization or user:  petersalomonsen
+Repository:            javascriptmusic
+Workflow filename:     publish-faust-compiler-module.yml
+```
+
+All fields are case-sensitive, and npm does not validate them when you save —
+a typo shows up only as a failed publish.
+
+Two consequences worth knowing:
+
+- **A package must exist before a trusted publisher can be configured for it.**
+  The first release is therefore published by hand from the workflow's dry-run
+  tarball; every release after that is token-free.
+- **Provenance is generated automatically** for trusted publishes and requires
+  package.json's `repository` to match this repository exactly. That is why
+  `build-package.mjs` sets it to petersalomonsen/javascriptmusic and
+  `verify-package.mjs` asserts it.
+
+Trusted publishing needs npm ≥ 11.5.1 on Node ≥ 22, newer than the runner
+default, so the publish step installs it.
+
+## After publishing
+
+1. Bump `COMPILER_MODULE_VERSION` in
+   [faust-rs-transpile.js](../../wasmaudioworklet/faust/faust-rs-transpile.js) —
+   the CDN fallback URL is derived from it.
+2. Bump the `@psalomo/wasm-music-faust` dependency in
+   [tools/faust2as/package.json](../faust2as/package.json).
+3. Check that the CDN serves the new file (jsDelivr lags a publish by minutes):
+   `https://cdn.jsdelivr.net/npm/@psalomo/wasm-music-faust@<version>/faust-compiler-module.wasm`

--- a/tools/faust-compiler-module/build-package.mjs
+++ b/tools/faust-compiler-module/build-package.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// build-package.mjs — assemble the `@psalomo/wasm-music-faust` npm package
+// around a freshly built compiler module.
+//
+//   node tools/faust-compiler-module/build-package.mjs \
+//     --module <libfaust-rs.wasm> --license <faust-rs/LICENSE> \
+//     --out <dir> --version 0.1.0 \
+//     [--faust-rs-commit <sha>] [--faustlibraries-commit <sha>]
+//
+// The package carries exactly what this project consumes — the compiler module
+// — plus the license it inherits and the provenance of the build. The app never
+// touches a JS API from it: the browser does a bare
+// `WebAssembly.instantiate(bytes, {})` and tools/faust2as/faust2asc.js reads the
+// .wasm off disk, so a wrapper would be dead weight (the fork this replaced
+// shipped ~19 MB to deliver one 10 MB file).
+//
+// Licensing: the module is the faust-rs compiler compiled to wasm32, so it is
+// GRAME's code under LGPL-2.1-or-later, not ours. `--license` must point at the
+// LICENSE of the faust-rs checkout it was built from, so the text always
+// matches the source revision.
+
+import fs from 'fs';
+import path from 'path';
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i += 2) {
+        if (!argv[i].startsWith('--')) throw new Error(`Unexpected argument: ${argv[i]}`);
+        args[argv[i].slice(2)] = argv[i + 1];
+    }
+    return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const required = ['module', 'license', 'out', 'version'];
+const missing = required.filter(name => !args[name]);
+if (missing.length > 0) {
+    console.error(`Missing required argument(s): ${missing.map(m => `--${m}`).join(', ')}`);
+    console.error('Usage: build-package.mjs --module <wasm> --license <LICENSE> --out <dir> --version <semver>');
+    process.exit(2);
+}
+
+const PACKAGE_NAME = '@psalomo/wasm-music-faust';
+const MODULE_FILE = 'faust-compiler-module.wasm';
+const REPO_URL = 'https://github.com/petersalomonsen/javascriptmusic';
+
+if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(args.version)) {
+    console.error(`--version ${args.version} is not a semver version`);
+    process.exit(1);
+}
+
+const moduleBytes = fs.readFileSync(args.module);
+if (!(moduleBytes.length > 4 && moduleBytes[0] === 0x00 && moduleBytes[1] === 0x61
+    && moduleBytes[2] === 0x73 && moduleBytes[3] === 0x6d)) {
+    console.error(`${args.module} does not start with the \\0asm magic`);
+    process.exit(1);
+}
+
+// The module knows its own ABI version — record it rather than tracking it by
+// hand, so every published version says which compiler it carries.
+const { instance } = await WebAssembly.instantiate(moduleBytes, {});
+const e = instance.exports;
+const moduleVersion = new TextDecoder().decode(
+    new Uint8Array(e.memory.buffer).slice(
+        e.faust_wasm_version_ptr(),
+        e.faust_wasm_version_ptr() + e.faust_wasm_version_len()
+    )
+);
+
+const outDir = path.resolve(args.out);
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+const packageJson = {
+    name: PACKAGE_NAME,
+    version: args.version,
+    description:
+        'The Faust compiler (faust-rs) built for wasm32-unknown-unknown with the '
+        + 'AssemblyScript backend and the Faust standard libraries embedded — the '
+        + 'compiler module loaded by WebAssembly Music.',
+    license: 'LGPL-2.1-or-later',
+    author: 'Peter Salomonsen <contact@petersalomonsen.com>',
+    repository: {
+        type: 'git',
+        url: `git+${REPO_URL}.git`,
+    },
+    homepage: `${REPO_URL}/tree/master/tools/faust-compiler-module#readme`,
+    bugs: { url: `${REPO_URL}/issues` },
+    keywords: ['faust', 'faust-rs', 'webassembly', 'assemblyscript', 'audio', 'dsp', 'compiler'],
+    type: 'module',
+    files: [MODULE_FILE, 'README.md', 'LICENSE'],
+    exports: {
+        [`./${MODULE_FILE}`]: `./${MODULE_FILE}`,
+        './package.json': './package.json',
+    },
+    // Provenance of this specific build, for anyone asking "which compiler is
+    // this, and which standard library is baked into it?".
+    faustRs: {
+        compilerModule: moduleVersion,
+        faustRsCommit: args['faust-rs-commit'] || null,
+        faustLibrariesCommit: args['faustlibraries-commit'] || null,
+    },
+};
+
+const readme = `# ${PACKAGE_NAME}
+
+The [Faust](https://faust.grame.fr/) compiler — the Rust implementation,
+[faust-rs](https://github.com/grame-cncm/faust-rs) — built for
+\`wasm32-unknown-unknown\` with the **AssemblyScript backend** enabled and the
+Faust standard libraries embedded.
+
+This package ships one artifact, \`${MODULE_FILE}\`, and no JavaScript. It is
+the compiler module loaded by
+[WebAssembly Music](${REPO_URL}) to turn \`.dsp\` sources into AssemblyScript.
+
+## Using it
+
+The module is a plain wasm32 module: no emscripten loader, no MEMFS, no
+imports.
+
+\`\`\`js
+const bytes = await (await fetch(
+  'https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${args.version}/${MODULE_FILE}'
+)).arrayBuffer();
+const { instance } = await WebAssembly.instantiate(bytes, {});
+\`\`\`
+
+Compilation goes through \`faust_wasm_generate_aux_files_json(name, source, args)\`,
+with strings written into memory via \`faust_wasm_alloc\`. Failures carry a
+structured diagnostics-v2 report on the result handle
+(\`faust_wasm_text_result_diagnostics_ptr\`/\`_len\`). See
+[faust-rs-transpile.js](${REPO_URL}/blob/master/wasmaudioworklet/faust/faust-rs-transpile.js)
+for a complete working host, and the
+[faust-rs error model](https://github.com/grame-cncm/faust-rs) for the
+diagnostics schema.
+
+Because \`import("stdfaust.lib")\` resolves from libraries embedded at build
+time, no library files need to be provided at runtime. Sibling sources travel
+inline as \`--virtual-source <path>=<base64>\` arguments.
+
+## This build
+
+| | |
+|---|---|
+| compiler module | \`${moduleVersion}\` |
+| faust-rs commit | \`${packageJson.faustRs.faustRsCommit || 'unrecorded'}\` |
+| faustlibraries commit | \`${packageJson.faustRs.faustLibrariesCommit || 'unrecorded'}\` |
+
+Built and published by
+[this workflow](${REPO_URL}/blob/master/.github/workflows/publish-faust-compiler-module.yml),
+which validates every module before release.
+
+## License
+
+The compiler is **GRAME's** work, not this project's:
+
+> faust-rs — a Rust port of the FAUST compiler
+> Copyright (C) 2026 GRAME, Centre National de Creation Musicale
+> Derived from the FAUST compiler, Copyright (C) 2003-2024 GRAME.
+
+Licensed under **LGPL-2.1-or-later**; the full text is in \`LICENSE\`, copied
+from the faust-rs revision this module was built from. This package only
+repackages that build for npm.
+`;
+
+fs.writeFileSync(path.join(outDir, 'package.json'), JSON.stringify(packageJson, null, 2) + '\n');
+fs.writeFileSync(path.join(outDir, MODULE_FILE), moduleBytes);
+fs.writeFileSync(path.join(outDir, 'README.md'), readme);
+fs.copyFileSync(args.license, path.join(outDir, 'LICENSE'));
+
+console.log(`${PACKAGE_NAME}@${args.version} staged in ${outDir}`);
+console.log(`  ${MODULE_FILE}  ${moduleBytes.length} bytes (${moduleVersion})`);
+console.log(`  LICENSE         from ${path.resolve(args.license)}`);

--- a/tools/faust-compiler-module/validate-module.mjs
+++ b/tools/faust-compiler-module/validate-module.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// validate-module.mjs — gate a freshly built faust-rs compiler module before
+// it is repackaged as @psalomo/faustwasm and published.
+//
+//   node tools/faust-compiler-module/validate-module.mjs <faust-compiler-module.wasm>
+//
+// The module is loaded exactly the way the app loads it: a bare
+// `WebAssembly.instantiate(bytes, {})`, no emscripten loader, no MEMFS
+// (see wasmaudioworklet/faust/faust-rs-transpile.js and tools/faust2as/faust2asc.js
+// for the ABI). Every check below has a corresponding way of failing that has
+// actually happened, so none of them are decorative:
+//
+//   1. exports        — the whole ABI the two callers use must be present,
+//                       including the diagnostics-v2 exports (0.16.1-asc.4+).
+//   2. execution opts  — `--ec --os` must produce a native control()/frame()
+//                       class. Older modules silently ignored the flags and
+//                       emitted the classic block-compute class instead. The
+//                       fixture imports stdfaust.lib, so this also proves the
+//                       Faust standard libraries got embedded into the module
+//                       (build without FAUST_RS_EMBEDDED_LIB_ROOT → fails here).
+//   3. diagnostics     — a compile failure must carry a structured
+//                       diagnostics-v2 report, not just a message string.
+//   4. compile budget  — a real-world heavy DSP (dx.algorithm) must transpile
+//                       well inside the budget; front-end perf blow-ups in
+//                       this class have shipped before.
+//
+// Exit code 0 = all checks passed, 1 = at least one failed (all checks run, so
+// one run reports every problem).
+
+import fs from 'fs';
+import path from 'path';
+
+const modulePath = process.argv[2];
+if (!modulePath) {
+    console.error('Usage: node validate-module.mjs <faust-compiler-module.wasm>');
+    process.exit(2);
+}
+if (!fs.existsSync(modulePath)) {
+    console.error(`Compiler module not found: ${modulePath}`);
+    process.exit(2);
+}
+
+// Budget for check 4. Overridable so a slow/loaded runner can be given room
+// without editing the script; the default is the CI value.
+const BUDGET_MS = Number(process.env.FAUST_MODULE_BUDGET_MS || 30000);
+
+const REQUIRED_EXPORTS = [
+    'memory',
+    'faust_wasm_alloc',
+    'faust_wasm_dealloc',
+    'faust_wasm_generate_aux_files_json',
+    'faust_wasm_text_result_is_ok',
+    'faust_wasm_text_result_ptr',
+    'faust_wasm_text_result_len',
+    'faust_wasm_text_result_free',
+    'faust_wasm_version_ptr',
+    'faust_wasm_version_len',
+    // diagnostics-v2 (0.16.1-asc.4 and later)
+    'faust_wasm_text_result_diagnostics_ptr',
+    'faust_wasm_text_result_diagnostics_len',
+];
+
+const failures = [];
+function check(name, fn) {
+    try {
+        const detail = fn();
+        console.log(`  ok   ${name}${detail ? ` — ${detail}` : ''}`);
+    } catch (err) {
+        failures.push(name);
+        console.log(`  FAIL ${name} — ${err.message}`);
+    }
+}
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+const bytes = fs.readFileSync(modulePath);
+assert(
+    bytes.length > 4 && bytes[0] === 0x00 && bytes[1] === 0x61 && bytes[2] === 0x73 && bytes[3] === 0x6d,
+    `${modulePath} does not start with the \\0asm magic`
+);
+console.log(`Validating ${path.resolve(modulePath)} (${(bytes.length / 1048576).toFixed(2)} MiB)\n`);
+
+const { instance } = await WebAssembly.instantiate(bytes, {});
+const e = instance.exports;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+// Re-read the view on every use: the module grows its memory during a compile,
+// which detaches any previously taken Uint8Array.
+const mem = () => new Uint8Array(e.memory.buffer);
+
+function writeString(s) {
+    const b = encoder.encode(s);
+    const ptr = e.faust_wasm_alloc(b.length);
+    mem().set(b, ptr);
+    return [ptr, b.length];
+}
+
+// One generateAuxFiles call, returning everything the callers can observe:
+// success flag, the textual artifact (already base64-decoded) or the error
+// message, and the structured diagnostics payload when the compiler retained one.
+function compile(name, source, args) {
+    const [np, nl] = writeString(name);
+    const [sp, sl] = writeString(source);
+    const [ap, al] = writeString(args);
+    let handle;
+    try {
+        handle = e.faust_wasm_generate_aux_files_json(np, nl, sp, sl, ap, al);
+    } finally {
+        e.faust_wasm_dealloc(np, nl);
+        e.faust_wasm_dealloc(sp, sl);
+        e.faust_wasm_dealloc(ap, al);
+    }
+    const ok = !!e.faust_wasm_text_result_is_ok(handle);
+    const ptr = e.faust_wasm_text_result_ptr(handle);
+    const len = e.faust_wasm_text_result_len(handle);
+    const text = decoder.decode(mem().slice(ptr, ptr + len));
+    let diagnostics = null;
+    // Guarded the same way the callers guard it, so a pre-diagnostics module
+    // fails only the checks that are actually about diagnostics.
+    if (typeof e.faust_wasm_text_result_diagnostics_len === 'function') {
+        const dlen = e.faust_wasm_text_result_diagnostics_len(handle);
+        if (dlen > 0) {
+            const dptr = e.faust_wasm_text_result_diagnostics_ptr(handle);
+            diagnostics = decoder.decode(mem().slice(dptr, dptr + dlen));
+        }
+    }
+    e.faust_wasm_text_result_free(handle);
+
+    if (!ok) return { ok, error: text, diagnostics };
+    const files = JSON.parse(text);
+    const file = files.find(f => !f.binary);
+    assert(file, 'no textual artifact in the generateAuxFiles result');
+    return { ok, source: Buffer.from(file.content_base64, 'base64').toString('utf-8'), diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// 1. ABI exports
+// ---------------------------------------------------------------------------
+check('exports: full ABI present', () => {
+    const missing = REQUIRED_EXPORTS.filter(name => !(name in e));
+    assert(missing.length === 0, `missing exports: ${missing.join(', ')}`);
+    const version = decoder.decode(
+        mem().slice(e.faust_wasm_version_ptr(), e.faust_wasm_version_ptr() + e.faust_wasm_version_len())
+    );
+    return version;
+});
+
+// ---------------------------------------------------------------------------
+// 2. Execution options + embedded standard libraries
+// ---------------------------------------------------------------------------
+check('execution options: -lang asc --ec --os emits control()/frame()', () => {
+    const result = compile(
+        'validation',
+        'import("stdfaust.lib");\n'
+        + 'freq = hslider("freq", 440, 20, 20000, 0.01);\n'
+        + 'gain = hslider("gain", 0.5, 0, 1, 0.01);\n'
+        + 'process = os.osc(freq) * gain;\n',
+        '-lang asc -cn TDsp --ec --os -o /validation.out.ts'
+    );
+    assert(result.ok, `compilation failed: ${result.error}`);
+    assert(result.source.includes('class TDsp'), '-cn TDsp did not name the generated class');
+    assert(result.source.includes('control(): void {'), 'no control() in the generated class (--ec ignored?)');
+    assert(
+        result.source.includes('frame(inputs: StaticArray<f32>, outputs: StaticArray<f32>): void {'),
+        'no frame(inputs, outputs) in the generated class (--os ignored?)'
+    );
+    return `${result.source.length} chars, stdfaust.lib resolved from the embedded bundle`;
+});
+
+// ---------------------------------------------------------------------------
+// 3. Structured diagnostics on failure
+// ---------------------------------------------------------------------------
+check('diagnostics: misspelled identifier yields a structured report', () => {
+    const result = compile(
+        'validation',
+        'import("stdfaust.lib");\nprocess = os.osccc(440);\n',
+        '-lang asc -cn TDsp --ec --os -o /validation.out.ts'
+    );
+    assert(!result.ok, 'compiling a misspelled identifier unexpectedly succeeded');
+    assert(result.diagnostics, 'no diagnostics payload retained (diagnostics_len was 0)');
+    let payload;
+    try {
+        payload = JSON.parse(result.diagnostics);
+    } catch (err) {
+        throw new Error(`diagnostics payload is not valid JSON: ${err.message}`);
+    }
+    const diagnostics = payload.diagnostics || [];
+    assert(diagnostics.length > 0, 'diagnostics payload carries an empty diagnostics array');
+    const first = diagnostics[0];
+    assert(
+        first.code === 'FRS-EVAL-0002',
+        `expected the undefined-symbol code FRS-EVAL-0002, got ${JSON.stringify(first.code)}`
+    );
+    assert(
+        first.category === 'user_code',
+        `expected category "user_code", got ${JSON.stringify(first.category)}`
+    );
+    return `schema_version ${payload.schema_version}, ${diagnostics.length} diagnostic(s), ${first.code}`;
+});
+
+// ---------------------------------------------------------------------------
+// 4. Compile-time budget
+// ---------------------------------------------------------------------------
+check(`compile budget: dx.algorithm(5) under ${BUDGET_MS} ms`, () => {
+    const started = process.hrtime.bigint();
+    const result = compile(
+        'dx7_alg5',
+        'import("stdfaust.lib");\nprocess = dx.algorithm(5) <: _,_;\n',
+        '-lang asc -cn Dx7Alg5Dsp --ec --os -o /dx7_alg5.out.ts'
+    );
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+    assert(result.ok, `compilation failed: ${result.error}`);
+    // dx7.lib lives in a faustlibraries subdirectory — a regression in the
+    // flattened embed aliases shows up here rather than in check 2.
+    assert(result.source.includes('class Dx7Alg5Dsp'), 'dx.algorithm(5) produced no Dx7Alg5Dsp class');
+    assert(
+        elapsedMs < BUDGET_MS,
+        `took ${elapsedMs.toFixed(0)} ms, over the ${BUDGET_MS} ms budget`
+    );
+    return `${elapsedMs.toFixed(0)} ms, ${result.source.length} chars`;
+});
+
+console.log('');
+if (failures.length > 0) {
+    console.error(`Module validation FAILED: ${failures.length} check(s) — ${failures.join('; ')}`);
+    process.exit(1);
+}
+console.log('Module validation passed.');

--- a/tools/faust-compiler-module/validate-module.mjs
+++ b/tools/faust-compiler-module/validate-module.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // validate-module.mjs — gate a freshly built faust-rs compiler module before
-// it is repackaged as @psalomo/faustwasm and published.
+// it is packaged as @psalomo/wasm-music-faust and published.
 //
 //   node tools/faust-compiler-module/validate-module.mjs <faust-compiler-module.wasm>
 //

--- a/tools/faust-compiler-module/verify-package.mjs
+++ b/tools/faust-compiler-module/verify-package.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// verify-package.mjs — check the tarball that is about to be published.
+//
+//   node tools/faust-compiler-module/verify-package.mjs \
+//     <extractedPackageDir> <expectedVersion> <sourceModule.wasm>
+//
+// Run against a directory unpacked from the tarball `npm pack` produced, not
+// the directory it was built from: what ships is what gets checked. npm decides
+// tarball contents from `files`, .npmignore and its own default rules, so
+// "the staging directory looks right" is not the same claim.
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const [packageDir, expectedVersion, sourceModule] = process.argv.slice(2);
+if (!packageDir || !expectedVersion || !sourceModule) {
+    console.error('Usage: verify-package.mjs <extractedPackageDir> <expectedVersion> <sourceModule.wasm>');
+    process.exit(2);
+}
+
+const PACKAGE_NAME = '@psalomo/wasm-music-faust';
+const MODULE_FILE = 'faust-compiler-module.wasm';
+const EXPECTED_FILES = ['LICENSE', 'README.md', MODULE_FILE, 'package.json'].sort();
+
+const problems = [];
+
+function listFiles(root) {
+    const found = [];
+    (function walk(dir, relBase) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const relPath = relBase ? `${relBase}/${entry.name}` : entry.name;
+            if (entry.isDirectory()) walk(path.join(dir, entry.name), relPath);
+            else found.push(relPath);
+        }
+    })(root, '');
+    return found.sort();
+}
+
+// 1. Exactly the intended files — nothing dropped, nothing swept in.
+const files = listFiles(packageDir);
+if (JSON.stringify(files) !== JSON.stringify(EXPECTED_FILES)) {
+    problems.push(`file list is ${JSON.stringify(files)}, expected ${JSON.stringify(EXPECTED_FILES)}`);
+}
+
+// 2. The module is the one that was validated, byte for byte.
+const modulePath = path.join(packageDir, MODULE_FILE);
+if (fs.existsSync(modulePath)) {
+    const packed = fs.readFileSync(modulePath);
+    const source = fs.readFileSync(sourceModule);
+    const sha = buf => crypto.createHash('sha256').update(buf).digest('hex');
+    if (sha(packed) !== sha(source)) {
+        problems.push(`${MODULE_FILE} in the tarball does not match the validated build (${sha(packed)} vs ${sha(source)})`);
+    }
+    if (!(packed.length > 4 && packed[0] === 0x00 && packed[1] === 0x61 && packed[2] === 0x73 && packed[3] === 0x6d)) {
+        problems.push(`${MODULE_FILE} does not start with the \\0asm magic`);
+    }
+} else {
+    problems.push(`${MODULE_FILE} is missing from the tarball`);
+}
+
+// 3. Metadata that consumers and npm both depend on. `repository` matters
+//    beyond documentation: provenance attestation fails with a 422 unless it
+//    matches the repository the publishing workflow runs in.
+const pkg = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf-8'));
+const expectedFields = {
+    name: PACKAGE_NAME,
+    version: expectedVersion,
+    license: 'LGPL-2.1-or-later',
+};
+for (const [field, expected] of Object.entries(expectedFields)) {
+    if (pkg[field] !== expected) {
+        problems.push(`package.json ${field} is ${JSON.stringify(pkg[field])}, expected ${JSON.stringify(expected)}`);
+    }
+}
+const repoUrl = pkg.repository?.url;
+if (repoUrl !== 'git+https://github.com/petersalomonsen/javascriptmusic.git') {
+    problems.push(`package.json repository.url is ${JSON.stringify(repoUrl)} — provenance requires the publishing repository`);
+}
+if (!pkg.faustRs?.compilerModule) {
+    problems.push('package.json is missing the faustRs.compilerModule provenance field');
+}
+
+// 4. The license text must be GRAME's, not a placeholder.
+const license = fs.existsSync(path.join(packageDir, 'LICENSE'))
+    ? fs.readFileSync(path.join(packageDir, 'LICENSE'), 'utf-8')
+    : '';
+if (!/GRAME/.test(license)) {
+    problems.push('LICENSE does not carry the GRAME copyright — is it the faust-rs license?');
+}
+
+console.log(`${pkg.name}@${pkg.version} — ${files.length} files, module ${pkg.faustRs?.compilerModule}`);
+console.log(`files: ${files.join(', ')}`);
+console.log('');
+
+if (problems.length > 0) {
+    console.error('Package check FAILED:');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+}
+console.log('Package check passed.');


### PR DESCRIPTION
Releasing the Faust compiler module has meant one developer's laptop: build from the faust-rs workspace, repackage, publish. This makes it a workflow — build, validate, package, publish, with the validation as the gate.

**Already proven end to end, before merge:** `0.1.0` was published by hand from a dry-run tarball, the npm trusted publisher was configured against it, and **`0.1.1` was then published by this workflow itself** over OIDC with a signed provenance statement ([sigstore log 2294502309](https://search.sigstore.dev/?logIndex=2294502309)). The registry records it as published by `GitHub Actions <npm-oidc-no-reply@github.com>` with `trustedPublisher: github`.

## `@psalomo/wasm-music-faust`

A new package replaces the `@psalomo/faustwasm` fork (dist-tag `asc`) for this path. The fork shipped ~19 MB of JS, emscripten blobs and tests to deliver one 10 MB file that nothing here used the rest of — the browser instantiates the module directly, `faust2asc.js` reads it off disk. The new package is four files: the module, its license, a README and package.json.

It also unties npm's constraints. A package may have exactly **one** trusted publisher, and `@psalomo/faustwasm`'s belongs to petersalomonsen/faustwasm's own workflow; and provenance requires `repository` to match the publishing repo, which the fork's cannot. Its own package gets both: **no `NPM_TOKEN` anywhere**, and real provenance attested against this repository.

Licensing is corrected in passing: faust-rs is **LGPL-2.1-or-later** (GRAME's copyright, derived from the FAUST compiler), not the LGPL-3.0 the fork declares. The package ships faust-rs's own `LICENSE`, copied from the checkout it was built from, so it cannot drift from the source revision.

## What gates a release

`validate-module.mjs` runs against every build, in dry runs too: the full ABI surface, `--ec --os` emitting a native `control()`/`frame()` class, structured diagnostics on a failed compile (`FRS-EVAL-0002` / `user_code`), and a compile-time budget for `dx.algorithm(5)`. Each check stands for a regression that has actually happened.

The `e2e_ref` input goes further: it runs the in-browser transpile spec **from the branch that is waiting on the module**, against the build from that same run. The local module drop outranks the CDN, so a branch can pin a version that does not exist on npm yet — the consumer is validated *before* the release, not after. Both runs here did exactly that against #189.

Two build traps are handled. faust-rs's `build.rs` embeds the standard libraries without declaring them as build inputs, so a cached target dir would silently keep a stale copy (`cargo clean -p wasm-ffi`). And the tarball is verified *after* packing, since npm decides contents at pack time — checking the staging directory would be checking the wrong thing.

## Follow-up

#189 migrates to the new package (`COMPILER_MODULE_VERSION` → `0.1.1`, the CDN URL, `tools/faust2as`). Docs and the IFC2026 talk material still name the old fork; those are a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)