### PR TITLE
Name the compiler package the docs actually describe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Install tools dependencies
         run: |
           # tools/faust2as/ — needed for the faust source generator below
-          #   (depends on @psalomo/faustwasm)
+          #   (depends on @psalomo/wasm-music-faust)
           # tools/claude-bridge/ — needed by claude-bridge.spec.js, which
           #   spawns the local relay (depends on ws)
           (cd tools/faust2as && npm install --no-audit --no-fund)
@@ -132,7 +132,7 @@ jobs:
           # faust2as-compilation.spec.js loads faust-test-sources.js, which
           # is generated from upstream Faust examples via the ASC backend.
           # No system faust install needed — the generator drives
-          # @psalomo/faustwasm via node.
+          # @psalomo/wasm-music-faust via node.
           node tools/faust2as/generate-test-sources.js
       - name: Run Playwright tests
         run: |

--- a/docs/presentations/ifc2026-plan.md
+++ b/docs/presentations/ifc2026-plan.md
@@ -111,7 +111,7 @@ both and contrast them.
 | ~4 min | **Intro — What is WebAssembly Music + why** (see §1.1) | architecture in one slide, 4klang quote, why AS for live coding, where Faust fits |
 | ~2 min | Why source-to-source vs runtime linking for Faust specifically | one wasm module, shared voice allocation, MidiVoice/MidiChannel integration, tiny binaries preserved |
 | ~5 min | **`faust2as` — C-backend approach** (the abstract) | `faust -lang c` → AS reshape; offline only (Node CLI) |
-| ~5 min | **`faust2asc` + `transpile-core` — ASC-backend approach** (post-abstract work) | `faust -lang asc` via `@psalomo/faustwasm` in the browser → in-place reshape; **no host install needed**; closes the live-coding loop entirely inside the browser |
+| ~5 min | **`faust2asc` + `transpile-core` — ASC-backend approach** (post-abstract work) | `faust -lang asc` via `@psalomo/wasm-music-faust` in the browser → in-place reshape; **no host install needed**; closes the live-coding loop entirely inside the browser |
 | ~1 min | What we get for free in both: typed channel fields with doc comments, CC/NRPN auto-mapping, `transpileEffect` standalone-effect path | |
 | ~10 min | Live demo (see §1.5) | |
 | ~3 min | Q&A | |
@@ -120,7 +120,7 @@ both and contrast them.
 
 | | `faust2as.js` (C backend) | `faust2asc.js` + `transpile-core.js` (ASC backend) |
 | --- | --- | --- |
-| Input | C from `faust -lang c` | AssemblyScript from `faust -lang asc` (via faustwasm `@psalomo/faustwasm`) |
+| Input | C from `faust -lang c` | AssemblyScript from `faust -lang asc` (via `@psalomo/wasm-music-faust`) |
 | Where it runs | Node CLI (offline) | Node CLI **and** in-browser (`wasmaudioworklet/faust/browser-transpile.js`) |
 | Reshape work | Parse C, rewrite to AS (`dsp->` → `this.`, `fminf` → `Mathf.min`, `(float)` casts, etc.) | Parse AS, restructure fields & methods to fit `MidiVoice`/`MidiChannel`/`Effect` |
 | UI metadata source | C `buildUserInterface` calls (`ui_interface->declare(...)` for `[symbol:foo]`) | `getJSON()` embedded in the AS output |

--- a/examples/dx7/README.md
+++ b/examples/dx7/README.md
@@ -45,7 +45,7 @@ node tools/faust2as/faust2as.js --bundle \
   --out examples/dx7/dx7-synth.ts
 ```
 
-**ASC backend** (`faust2asc.js` — uses `faust -lang asc` via [`@psalomo/faustwasm`](https://www.npmjs.com/package/@psalomo/faustwasm); `npm install` once in `tools/faust2as/`):
+**ASC backend** (`faust2asc.js` — uses `faust -lang asc` via [`@psalomo/wasm-music-faust`](https://www.npmjs.com/package/@psalomo/wasm-music-faust); `npm install` once in `tools/faust2as/`):
 
 ```sh
 node tools/faust2as/faust2asc.js --bundle \

--- a/examples/master_me/README.md
+++ b/examples/master_me/README.md
@@ -34,7 +34,7 @@ node tools/faust2as/faust2asc.js --mastering \
   examples/master_me/dsp/master_me.dsp
 ```
 
-The transpiler runs `faust -lang asc` via [`@psalomo/faustwasm`](https://www.npmjs.com/package/@psalomo/faustwasm) — a wasm-compiled libfaust with the AssemblyScript backend enabled — so no native Faust install is required. Run `npm install` in `tools/faust2as/` once. The transpiler parses the generated class and emits a standalone class plus `initializeMidiSynth()` / `postprocess()` exports.
+The transpiler runs `faust -lang asc` via [`@psalomo/wasm-music-faust`](https://www.npmjs.com/package/@psalomo/wasm-music-faust) — the Faust compiler itself compiled to WebAssembly, with the AssemblyScript backend and the standard libraries embedded — so no native Faust install is required. Run `npm install` in `tools/faust2as/` once. The transpiler parses the generated class and emits a standalone class plus `initializeMidiSynth()` / `postprocess()` exports.
 
 ## Parameters
 

--- a/wasmaudioworklet/presentations/ifc2026-slides.md
+++ b/wasmaudioworklet/presentations/ifc2026-slides.md
@@ -185,7 +185,7 @@ Both emit the same shape. Different starting languages.
 
 | | `faust2as.js` (the abstract) | `faust2asc.js` (post-abstract) |
 | --- | --- | --- |
-| Faust output stage | `faust -lang c` | `faust -lang asc` (via `@psalomo/faustwasm`) |
+| Faust output stage | `faust -lang c` | `faust -lang asc` (via `@psalomo/wasm-music-faust`) |
 | Where it runs | Node CLI, offline | Node CLI **and in the browser** |
 | Live-coding workflow | Save .dsp → re-run CLI → reload | Save .dsp in the editor → DSP recompiles and hot-swaps |
 
@@ -270,7 +270,7 @@ Speaker notes:
 What changed since the abstract was submitted.
 
 ```
-your_dsp.dsp  →  faust -lang asc (via @psalomo/faustwasm)
+your_dsp.dsp  →  faust -lang asc (via @psalomo/wasm-music-faust)
               ↓     (runs in the browser, no host install)
               ↓  transpile-core.js parses & restructures
               ↓
@@ -285,9 +285,12 @@ running synth — no Node CLI, no separate build step.
 
 <!--
 Speaker notes:
-  - The `@psalomo/faustwasm` fork bundles the Faust compiler itself
-    as wasm (~3 MB one-time download). After that, transpilation is
-    pure browser work.
+  - The `@psalomo/wasm-music-faust` package *is* the Faust compiler
+    itself as wasm — ~2 MB one-time download (10 MB unpacked). After
+    that, transpilation is pure browser work.
+  - It is built and published from this repo by CI, straight from the
+    faust-rs sources, so the compiler in the browser is traceable to a
+    commit rather than to someone's laptop.
   - Live-coding workflow loop time: from save → hear is ~1-2 seconds
     typical, ~3-5s with heavy DSPs like master_me.
 -->


### PR DESCRIPTION
Follow-up to #190 and #189: prose left over from the `@psalomo/faustwasm` fork, now that the compiler module ships as [`@psalomo/wasm-music-faust`](https://www.npmjs.com/package/@psalomo/wasm-music-faust). No functional changes — those landed in the two PRs above.

Two of these were wrong on the substance, not just the name:

- `examples/master_me/README.md` described the module as "a wasm-compiled libfaust with the AssemblyScript backend enabled". It hasn't been libfaust for a while — it's [faust-rs](https://github.com/grame-cncm/faust-rs), the Rust port, compiled to wasm32 with the standard libraries embedded.
- The IFC2026 speaker note claimed "~3 MB one-time download". Measured from the CDN: **2.0 MB brotli, 2.4 MB gzip**, 10.2 MB unpacked. I also added a note that the module is now built and published by CI from faust-rs sources, since "traceable to a commit rather than to someone's laptop" is a better story on stage than it was a week ago.

After #189 merges, the only remaining `@psalomo/faustwasm` mentions in the tree are the two deliberate ones — in the new tooling's README and workflow header — explaining why the fork was left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)