### PR TITLE
Studio agent: project kit in context, plus two agent-misleading bugs

### DIFF
--- a/tools/session-video/cuts/kit-play-it-yourself.mjs
+++ b/tools/session-video/cuts/kit-play-it-yourself.mjs
@@ -1,0 +1,111 @@
+// A CUT: the ~1 minute version of the 2026-07-31 rehearsal.
+//
+// The long cut (kit-zero-to-track.mjs) walks through every instrument. This one
+// keeps only the loop that matters for the IEEE IS² 2026 set: ask → it plays →
+// build the thing I want to play → play it → it becomes code I can edit.
+//
+// The agent's tool calls are replayed from the session log with their ORIGINAL
+// arguments. The PLAYER's half is re-enacted, because a log cannot hold it:
+//
+//   • The take is performed live through `window.playNoteMessage`, the same
+//     `processNoteMessage` the virtual keyboard and a real MIDI keyboard both
+//     reach — so it hits the synth, the visualizer and the sequencer's recorder
+//     exactly as a human performance does. Notes and velocities are the real
+//     ones, lifted from the take in the finished song.
+//   • The paste is the app's own insert-recording button.
+//   • The quantize is a real `edit_song` tool call, but its arguments are
+//     computed at runtime: it has to anchor on notes that do not exist until
+//     the take has been played.
+//
+// Two liberties, both for the minute:
+//   • The take is an EXCERPT — the phrase from beat 16.2 of the original, with
+//     its four-bar lead-in trimmed, replayed from zero.
+//   • The lead is demonstrated by the take itself rather than twice.
+//
+// Every ask from the session is kept, run in `quick` mode. Dropping the chords
+// and bass asks to save time does NOT work: later edits anchor on text those
+// asks create (`import { Bass } …`, `const bass = createTrack(4)`), so skipping
+// them leaves the lead unwired and the take with no channel to land on.
+
+export const SESSION_LOG =
+    'tools/studio-agent/logs/session-2026-07-31T10-25-31-918Z.jsonl';
+
+// Started from an empty repo — nothing to seed, keep the app's own default.
+export const START_SONG = null;
+
+export const OUTRO_MS = 6000;
+
+const BPM = 112;
+
+// The real take, from the finished song. App note names map to MIDI as
+// `<name><octave>` → octave*12 + semitone, so a6 = 81, c7 = 84, d7 = 86.
+// [ beat, midi, durationBeats, velocity ] — offset so the phrase starts at 0.
+const TAKE = [
+    [0.00, 81, 0.50, 78], [0.52, 84, 0.38, 99], [0.98, 86, 0.19, 75],
+    [1.49, 86, 0.37, 97], [1.92, 81, 0.50, 65], [2.45, 84, 0.46, 87],
+    [2.92, 86, 0.14, 77], [3.20, 86, 0.20, 90], [3.69, 86, 0.21, 82],
+    [3.92, 84, 0.32, 82], [4.40, 81, 0.39, 95], [5.39, 79, 0.34, 94],
+    [5.85, 77, 0.39, 60], [6.38, 79, 0.36, 94], [6.88, 81, 0.42, 82],
+];
+
+export const BEATS = [
+    {
+        title: 'beat',
+        prompt: 'give me a beat',
+        // Jump cut: three Faust drum voices, wired and compiled, no waiting.
+        quick: true,
+        tools: [0, 1, 2, 6, 4, 8, 9],
+        showAfter: 'song',
+        showMs: 4000,
+        holdMs: 600,
+    },
+    {
+        title: 'chords',
+        prompt: 'add chords: dminor, a#major, c major, g major',
+        say: ['Detuned-saw pad on channel 3.'],
+        quick: true,
+        tools: [13, 14, 15, 16, 17],
+        holdMs: 400,
+    },
+    {
+        title: 'bass',
+        prompt: 'a punchy bass, octaves like italo disco',
+        say: ['Filter-swept and saturated, channel 4.'],
+        quick: true,
+        tools: [20, 21, 22, 23, 24],
+        showAfter: 'song',
+        showMs: 2500,
+        holdMs: 400,
+    },
+    {
+        title: 'lead',
+        prompt: 'now a fat lead I can play myself',
+        say: ['Three detuned saws and a sub, on channel 5. No melody — that part is yours.'],
+        quick: true,
+        tools: [27, 28, 29, 30, 31],
+        showAfter: 'faust',
+        showMs: 2500,
+        holdMs: 400,
+    },
+    {
+        title: 'echo',
+        prompt: 'give it an echo, every 3rd step at 4 steps per beat',
+        say: ['0.75 of a beat — 402 ms at 112 BPM.'],
+        quick: true,
+        tools: [33, 34],
+        holdMs: 600,
+    },
+    {
+        title: 'record',
+        prompt: 'add recording markers, I want to play the lead',
+        say: ['Wrapping the loop in `startRecording()` / `stopRecording()`.'],
+        quick: true,
+        tools: [37, 38, 39, 40],
+        // Now the player takes over: select the lead, play it, paste it, fix it.
+        perform: { instrument: 'lead', notes: TAKE, bpm: BPM },
+        pasteRecording: true,
+        quantizeTake: 4,
+        outro: 'Played live — now it is code.',
+        holdMs: 1200,
+    },
+];

--- a/tools/session-video/cuts/kit-play-it-yourself.mjs
+++ b/tools/session-video/cuts/kit-play-it-yourself.mjs
@@ -21,14 +21,17 @@
 // echo — so you can hear what the effect actually did.
 //
 // Liberties, all for the minute:
-//   • The take is an EXCERPT — the phrase from beat 16.2 of the original, with
-//     its four-bar lead-in trimmed, replayed from zero.
-//   • It is played on the 16th grid and starts on a bar line
-//     (`syncToBeats: 4`), and the paste snaps it (`quantize: 4`). Play latency
+//   • The take is an EXCERPT — the 8-beat phrase from beat 16.2 of the original,
+//     with its four-bar lead-in trimmed, played twice to fill the loop.
+//   • It is played on the 16th grid and starts half way through the loop
+//     (`syncToBeats: 8`), and the paste snaps it (`quantize: 4`). Play latency
 //     means even a perfectly-played take lands a few milliseconds late, so
 //     snapping on the way in is the only way a FIRST take reads as quantized —
 //     the session's separate quantize step is dropped entirely. Velocities and
 //     note lengths are untouched, so it still breathes.
+//   • The song is restructured from 8 bars to 4 by two AUTHORED edits (marked in
+//     the beats below). The session never asked for it, but a 7-beat take under
+//     an 8-bar loop leaves the lead silent for most of what you hear.
 //
 // Every ask from the session is kept, run in `quick` mode. Dropping the chords
 // and bass asks to save time does NOT work: later edits anchor on text those
@@ -44,7 +47,7 @@ export const START_SONG = null;
 // Open on silence; the first beat starts the transport.
 export const START_PAUSED = true;
 
-export const OUTRO_MS = 6000;
+export const OUTRO_MS = 4000;
 
 const BPM = 112;
 
@@ -52,13 +55,17 @@ const BPM = 112;
 // `<name><octave>` → octave*12 + semitone, so a6 = 81, c7 = 84, d7 = 86.
 // [ beat, midi, durationBeats, velocity ] — beats snapped to the 16th grid,
 // velocities and lengths exactly as played.
-const TAKE = [
+const PHRASE = [
     [0.00, 81, 0.50, 78], [0.50, 84, 0.38, 99], [1.00, 86, 0.19, 75],
     [1.50, 86, 0.37, 97], [2.00, 81, 0.50, 65], [2.50, 84, 0.46, 87],
     [3.00, 86, 0.14, 77], [3.25, 86, 0.20, 90], [3.75, 86, 0.21, 82],
     [4.00, 84, 0.32, 82], [4.50, 81, 0.39, 95], [5.50, 79, 0.34, 94],
     [5.75, 77, 0.39, 60], [6.50, 79, 0.36, 94], [7.00, 81, 0.42, 82],
 ];
+
+// The phrase is 8 beats and the shortened song is 16, so it is played twice —
+// otherwise the lead covers only half of what everything else is doing.
+const TAKE = [...PHRASE, ...PHRASE.map(([b, n, d, v]) => [b + 8, n, d, v])];
 
 // A short figure from the same phrase, for hearing the lead on its own.
 const DEMO = [
@@ -73,9 +80,13 @@ export const BEATS = [
         // Jump cut: three Faust drum voices, wired and compiled, no waiting.
         quick: true,
         tools: [0, 1, 2, 6, 4, 8, 9],
+        // AUTHORED: the session's song is 8 bars. A 4-bar loop is the right
+        // length here — the take has to cover what everything else is playing,
+        // and 8 bars would leave the lead absent for half of it.
+        edits: [{ old_string: '.repeat(7));', new_string: '.repeat(3));', replace_all: true }],
         startPlayback: true,
         showAfter: 'song',
-        showMs: 4000,
+        showMs: 3000,
         holdMs: 500,
     },
     {
@@ -92,6 +103,9 @@ export const BEATS = [
         say: ['Filter-swept and saturated, channel 4.'],
         quick: true,
         tools: [20, 21, 22, 23, 24],
+        // AUTHORED: pad and bass were written as 8 bars too — drop their repeat
+        // so every part is the same 4 bars.
+        edits: [{ old_string: '].repeat(1));', new_string: ']);', replace_all: true }],
         showAfter: 'song',
         showMs: 2000,
         holdMs: 400,
@@ -119,9 +133,13 @@ export const BEATS = [
         prompt: 'add recording markers, I want to play the lead',
         say: ['Wrapping the loop in `startRecording()` / `stopRecording()`.'],
         quick: true,
-        tools: [37, 38, 39, 40],
-        // Start on a bar line so the captured take lands on the grid.
-        perform: { instrument: 'lead', notes: TAKE, bpm: BPM, syncToBeats: 4 },
+        // 39 is the session's stopRecording insert; it anchors on `.repeat(7))`,
+        // which the 4-bar edit above rewrote, so it is authored here instead.
+        tools: [37, 38],
+        edits: [{ old_string: 'loopHere();', new_string: 'stopRecording();\n\nloopHere();' }],
+        // Start half way through the 4-bar loop, so the 16 beats of playing wrap
+        // once and land across the whole loop rather than only its first half.
+        perform: { instrument: 'lead', notes: TAKE, bpm: BPM, syncToBeats: 8 },
         // Snap on the way in — a first take that reads as played, on the grid.
         pasteRecording: { quantize: 4 },
         outro: 'Played live — now it is code.',

--- a/tools/session-video/cuts/kit-play-it-yourself.mjs
+++ b/tools/session-video/cuts/kit-play-it-yourself.mjs
@@ -7,20 +7,28 @@
 // The agent's tool calls are replayed from the session log with their ORIGINAL
 // arguments. The PLAYER's half is re-enacted, because a log cannot hold it:
 //
-//   • The take is performed live through `window.playNoteMessage`, the same
+//   • Phrases are performed live through `window.playNoteMessage`, the same
 //     `processNoteMessage` the virtual keyboard and a real MIDI keyboard both
-//     reach — so it hits the synth, the visualizer and the sequencer's recorder
+//     reach — so they hit the synth, the visualizer and the sequencer's recorder
 //     exactly as a human performance does. Notes and velocities are the real
 //     ones, lifted from the take in the finished song.
 //   • The paste is the app's own insert-recording button.
-//   • The quantize is a real `edit_song` tool call, but its arguments are
-//     computed at runtime: it has to anchor on notes that do not exist until
-//     the take has been played.
 //
-// Two liberties, both for the minute:
+// The video opens SILENT: the audio graph has to be live for the capture to tap
+// it, but the transport only starts once the first beat exists.
+//
+// The lead is played twice before it is recorded — once dry, once through the
+// echo — so you can hear what the effect actually did.
+//
+// Liberties, all for the minute:
 //   • The take is an EXCERPT — the phrase from beat 16.2 of the original, with
 //     its four-bar lead-in trimmed, replayed from zero.
-//   • The lead is demonstrated by the take itself rather than twice.
+//   • It is played on the 16th grid and starts on a bar line
+//     (`syncToBeats: 4`), and the paste snaps it (`quantize: 4`). Play latency
+//     means even a perfectly-played take lands a few milliseconds late, so
+//     snapping on the way in is the only way a FIRST take reads as quantized —
+//     the session's separate quantize step is dropped entirely. Velocities and
+//     note lengths are untouched, so it still breathes.
 //
 // Every ask from the session is kept, run in `quick` mode. Dropping the chords
 // and bass asks to save time does NOT work: later edits anchor on text those
@@ -33,19 +41,29 @@ export const SESSION_LOG =
 // Started from an empty repo — nothing to seed, keep the app's own default.
 export const START_SONG = null;
 
+// Open on silence; the first beat starts the transport.
+export const START_PAUSED = true;
+
 export const OUTRO_MS = 6000;
 
 const BPM = 112;
 
 // The real take, from the finished song. App note names map to MIDI as
 // `<name><octave>` → octave*12 + semitone, so a6 = 81, c7 = 84, d7 = 86.
-// [ beat, midi, durationBeats, velocity ] — offset so the phrase starts at 0.
+// [ beat, midi, durationBeats, velocity ] — beats snapped to the 16th grid,
+// velocities and lengths exactly as played.
 const TAKE = [
-    [0.00, 81, 0.50, 78], [0.52, 84, 0.38, 99], [0.98, 86, 0.19, 75],
-    [1.49, 86, 0.37, 97], [1.92, 81, 0.50, 65], [2.45, 84, 0.46, 87],
-    [2.92, 86, 0.14, 77], [3.20, 86, 0.20, 90], [3.69, 86, 0.21, 82],
-    [3.92, 84, 0.32, 82], [4.40, 81, 0.39, 95], [5.39, 79, 0.34, 94],
-    [5.85, 77, 0.39, 60], [6.38, 79, 0.36, 94], [6.88, 81, 0.42, 82],
+    [0.00, 81, 0.50, 78], [0.50, 84, 0.38, 99], [1.00, 86, 0.19, 75],
+    [1.50, 86, 0.37, 97], [2.00, 81, 0.50, 65], [2.50, 84, 0.46, 87],
+    [3.00, 86, 0.14, 77], [3.25, 86, 0.20, 90], [3.75, 86, 0.21, 82],
+    [4.00, 84, 0.32, 82], [4.50, 81, 0.39, 95], [5.50, 79, 0.34, 94],
+    [5.75, 77, 0.39, 60], [6.50, 79, 0.36, 94], [7.00, 81, 0.42, 82],
+];
+
+// A short figure from the same phrase, for hearing the lead on its own.
+const DEMO = [
+    [0.00, 81, 0.45, 78], [0.50, 84, 0.38, 99],
+    [1.00, 86, 0.40, 90], [1.75, 81, 0.60, 82],
 ];
 
 export const BEATS = [
@@ -55,9 +73,10 @@ export const BEATS = [
         // Jump cut: three Faust drum voices, wired and compiled, no waiting.
         quick: true,
         tools: [0, 1, 2, 6, 4, 8, 9],
+        startPlayback: true,
         showAfter: 'song',
         showMs: 4000,
-        holdMs: 600,
+        holdMs: 500,
     },
     {
         title: 'chords',
@@ -74,25 +93,25 @@ export const BEATS = [
         quick: true,
         tools: [20, 21, 22, 23, 24],
         showAfter: 'song',
-        showMs: 2500,
+        showMs: 2000,
         holdMs: 400,
     },
     {
-        title: 'lead',
+        title: 'lead (dry)',
         prompt: 'now a fat lead I can play myself',
         say: ['Three detuned saws and a sub, on channel 5. No melody — that part is yours.'],
         quick: true,
         tools: [27, 28, 29, 30, 31],
-        showAfter: 'faust',
-        showMs: 2500,
+        perform: { instrument: 'lead', notes: DEMO, bpm: BPM },
         holdMs: 400,
     },
     {
-        title: 'echo',
+        title: 'echo (wet)',
         prompt: 'give it an echo, every 3rd step at 4 steps per beat',
-        say: ['0.75 of a beat — 402 ms at 112 BPM.'],
+        say: ['0.75 of a beat — 402 ms at 112 BPM. Same phrase again:'],
         quick: true,
         tools: [33, 34],
+        perform: { instrument: 'lead', notes: DEMO, bpm: BPM },
         holdMs: 600,
     },
     {
@@ -101,10 +120,10 @@ export const BEATS = [
         say: ['Wrapping the loop in `startRecording()` / `stopRecording()`.'],
         quick: true,
         tools: [37, 38, 39, 40],
-        // Now the player takes over: select the lead, play it, paste it, fix it.
-        perform: { instrument: 'lead', notes: TAKE, bpm: BPM },
-        pasteRecording: true,
-        quantizeTake: 4,
+        // Start on a bar line so the captured take lands on the grid.
+        perform: { instrument: 'lead', notes: TAKE, bpm: BPM, syncToBeats: 4 },
+        // Snap on the way in — a first take that reads as played, on the grid.
+        pasteRecording: { quantize: 4 },
         outro: 'Played live — now it is code.',
         holdMs: 1200,
     },

--- a/tools/session-video/cuts/kit-zero-to-track.mjs
+++ b/tools/session-video/cuts/kit-zero-to-track.mjs
@@ -1,0 +1,108 @@
+// A CUT: one curated video, made from one real studio-agent session.
+//
+// 2026-07-31 session — an EMPTY repo to a full track in six asks, then
+// recording markers so the lead can be played live. This was the rehearsal for
+// the IEEE IS² 2026 set (see wasmaudioworklet/docs/presentation/), and the
+// first run with a project KIT: the repo's AGENT.md sits in the model's context
+// from turn 0, so the agent writes instruments straight out instead of spending
+// a round-trip looking up how. Nine turns, 51s median, 2 discovery calls in 50.
+//
+// Source of truth is the session log itself — every tool call is replayed with
+// its ORIGINAL arguments, so the music you hear is the actual output of the
+// actual edits, not a re-enactment. Only the prose is edited.
+//
+// `tools` are ordinals into the session's mcp__studio__ tool calls, in order.
+// Left out, per the house style: song_summary and probe_instrument (the agent
+// checking its own work — no sound, ~10s each).
+//
+// Two deliberate omissions beyond that:
+//
+// 1. Ordinals 3 and 5 are a set_synth that imported `KickDsp` and the compile
+//    that failed on it. That was a real bug in write_faust's own hint — it
+//    reported the internal Faust class alongside the public wrapper — and it is
+//    FIXED as of this branch. Replaying it would advertise behaviour that no
+//    longer exists, so beat 1 jumps to the corrected set_synth at ordinal 6.
+// 2. The session continued past beat 6: a take played live on the lead, pasted
+//    in with the app's insert button, then quantized. That paste is a UI action,
+//    not a tool call, so a replay cannot produce it — and the quantize edit
+//    anchors on text only the take provides. The video ends where the player
+//    takes over, which is the better ending anyway.
+
+// Path is relative to the repo root. Session logs are not committed, so a cut
+// only replays on a machine that has the log it names.
+export const SESSION_LOG =
+    'tools/studio-agent/logs/session-2026-07-31T10-25-31-918Z.jsonl';
+
+// This session opened on an EMPTY repo, so there is no starting song to seed and
+// no early get_song to recover one from — null keeps the app's own default.
+export const START_SONG = null;
+
+export const BEATS = [
+    {
+        title: 'beat',
+        prompt: 'give me a beat',
+        say: [
+            'Empty repo — but the project ships an `AGENT.md`, so I already know its six instruments and channel layout. No lookups needed.\n\n'
+            + 'Three Faust drum voices, one file each:',
+        ],
+        tools: [0, 1, 2],
+        sayThen: [
+            'Kick is a pitch-swept sine with a click; snare is tone plus filtered noise; hi-hat is highpassed noise.\n\n'
+            + 'Wiring them to channels 0-2 and writing the pattern:',
+        ],
+        thenTools: [6, 4, 8, 9],
+        outro: '112 BPM, eight bars. Kick on every beat, snare on 2 and 4, hats on the offbeats.',
+    },
+    {
+        title: 'chords',
+        prompt: 'add a chord progression, dminor, a#major, c major, g major',
+        say: [
+            'A detuned triple-saw pad on channel 3. The chords go in as **arrays inside the step grid** — a slot holding `[d4, f4, a4]` fires all three together.',
+        ],
+        tools: [13],
+        sayThen: ['Registering the channel and writing the progression, one bar each:'],
+        thenTools: [14, 15, 16, 17],
+        outro: 'Dm → A♯ → C → G, held across the beat that is already running.',
+    },
+    {
+        title: 'bass',
+        prompt: 'can you add a punchy bass-line on that. alternate the bass notes with octaves like italo disco',
+        say: [
+            'Punchy means an envelope-swept resonant lowpass and a bit of saturation. Channel 4:',
+        ],
+        tools: [20],
+        sayThen: ['Now the octave alternation — root, octave up, root, octave up, in eighths under each chord:'],
+        thenTools: [21, 22, 23, 24],
+        outro: '64 notes across the eight bars, roots following the progression.',
+    },
+    {
+        title: 'lead',
+        prompt: 'now I need a fat lead that I can play myself on top.',
+        say: [
+            'Fat = three detuned saws plus a sub square, through a swept resonant filter.\n\n'
+            + 'You said *you* will play it — so I am building the instrument and declaring the channel, and **not** writing a melody over it.',
+        ],
+        tools: [27],
+        sayThen: ['Channel 5, and one line in the song so the channel exists for you to play into:'],
+        thenTools: [28, 29, 30, 31],
+        outro: 'Instrument ready, channel empty — that part is yours.',
+    },
+    {
+        title: 'echo',
+        prompt: 'can you have an echo effect on the lead. it should echo every 3rd step given 4 steps per beat',
+        say: [
+            'Three steps at four steps per beat is 0.75 of a beat — at 112 BPM, a 402 ms delay. Adding it to the lead:',
+        ],
+        tools: [33, 34],
+        outro: 'Dotted-eighth echo, locked to the tempo.',
+    },
+    {
+        title: 'over to me',
+        prompt: 'can you insert recording markers in the beginning and end, and I will record a pattern with the lead.',
+        say: [
+            'Wrapping the loop in `startRecording()` / `stopRecording()`. Whatever you play on channel 5 between them gets captured — and pastes back into the song as code you can edit.',
+        ],
+        tools: [37, 38, 39, 40],
+        outro: 'Built from silence in six asks. The music never stopped — and now I play.',
+    },
+];

--- a/tools/session-video/record.mjs
+++ b/tools/session-video/record.mjs
@@ -96,9 +96,11 @@ function loadTools() {
         tools[ord] = { ord, name: o.name.replace('mcp__studio__', ''), args: o.input };
         ord++;
     }
-    // The song the session started from is whatever get_song first returned.
+    // The song the session started from is whatever get_song first returned —
+    // which only works if the session opened by reading an existing song. A cut
+    // whose session started from an empty repo states START_SONG itself.
     const gi = lines.findIndex((o) => o.kind === 'tool_use' && o.name === 'mcp__studio__get_song');
-    const startSong = lines.slice(gi + 1).find((o) => o.kind === 'tool_result')?.text ?? '';
+    const startSong = gi < 0 ? '' : (lines.slice(gi + 1).find((o) => o.kind === 'tool_result')?.text ?? '');
     return { tools, startSong };
 }
 
@@ -191,9 +193,22 @@ async function streamText(mock, text, msPerChunk = 14, chunk = 3) {
 }
 
 // ---- main -------------------------------------------------------------------
-const { tools, startSong } = loadTools();
-if (!startSong) throw new Error('could not recover the starting song from the session log');
-log(`loaded ${tools.filter(Boolean).length} tool calls; starting song ${startSong.length} bytes`);
+const { tools, startSong: songFromLog } = loadTools();
+// A cut may state the starting song itself: `null` keeps whatever the app boots
+// with, which is what a session that began from an EMPTY repo started from.
+const startSong = 'START_SONG' in cut ? cut.START_SONG : songFromLog;
+if (startSong === undefined || (startSong === '' && !('START_SONG' in cut))) {
+    throw new Error('could not recover the starting song from the session log — '
+        + 'set START_SONG in the cut (null keeps the app default)');
+}
+// Session logs cap tool results at 1000 chars, so a longer starting song comes
+// back mangled and would seed a syntax error rather than a song.
+if (startSong && /…\[\+\d+ chars\]$/.test(startSong.trimEnd())) {
+    throw new Error('the starting song recovered from the session log is TRUNCATED — '
+        + 'set START_SONG in the cut with the real source');
+}
+log(`loaded ${tools.filter(Boolean).length} tool calls; starting song `
+    + (startSong ? `${startSong.length} bytes` : '(app default)'));
 
 const mock = startMockServer();
 log('mock agent server on port', mock.port());
@@ -232,12 +247,17 @@ await page.evaluate((css) => {
     sr.appendChild(s);
 }, RECORDING_CSS);
 
-// Seed the exact song the session started from (NEAR AI's arpeggiated version)
-await page.evaluate((text) => {
-    document.querySelector('app-javascriptmusic').shadowRoot
-        .querySelector('#editor .CodeMirror').CodeMirror.setValue(text);
-}, startSong);
-log('seeded starting song');
+// Seed the exact song the session started from, unless the cut says the session
+// began from the app's own default (an empty repo).
+if (startSong) {
+    await page.evaluate((text) => {
+        document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror.setValue(text);
+    }, startSong);
+    log('seeded starting song');
+} else {
+    log('no starting song seeded — using the app default');
+}
 
 await mock.waitForClient();
 log('agent client connected');

--- a/tools/session-video/record.mjs
+++ b/tools/session-video/record.mjs
@@ -269,6 +269,18 @@ await page.evaluate(() => {
 await page.waitForFunction(() => !!window.audioworkletnode, { timeout: 180000 });
 await page.waitForFunction(() => window.WASM_SYNTH_BYTES != null, { timeout: 180000 });
 log('audio running');
+// The audio graph has to be live before capture can tap it, but the SEQUENCER
+// does not. A cut that opens on an empty project pauses it here and starts the
+// transport from a beat, so the video does not open on the default song.
+if (cut.START_PAUSED) {
+    await page.evaluate(() => {
+        window.toggleSongPlay(false);
+        const box = document.querySelector('app-javascriptmusic').shadowRoot
+            .getElementById('toggleSongPlayCheckbox');
+        if (box) box.checked = false;
+    });
+    log('sequencer paused — waiting for a beat to exist');
+}
 await sleep(2000);
 
 // ---- start capture: tab video + synth audio into ONE recorder ---------------
@@ -358,7 +370,7 @@ const CM = () => document.querySelector('app-javascriptmusic').shadowRoot
 // Play a phrase through the app's live-input path — the same `processNoteMessage`
 // the virtual keyboard and a real MIDI keyboard both reach — so the sequencer
 // captures it exactly as it would a human performance.
-async function performPhrase({ instrument, notes, bpm }) {
+async function performPhrase({ instrument, notes, bpm, syncToBeats }) {
     await setView('song');
     if (instrument) {
         await page.evaluate((name) => {
@@ -371,6 +383,19 @@ async function performPhrase({ instrument, notes, bpm }) {
         }, instrument);
         log(`  instrument → ${instrument}`);
         await sleep(600);
+    }
+    // Wait for the sequencer's playhead to reach a beat boundary before the
+    // first note. Without this the phrase starts wherever the loop happens to
+    // be, and every captured time carries that arbitrary offset — so a take
+    // played exactly on the grid still pastes as ragged numbers.
+    if (syncToBeats) {
+        await page.evaluate(async ({ unitSeconds }) => {
+            const nap = (ms) => new Promise((r) => setTimeout(r, ms));
+            const now = window.songTimeSeconds();
+            if (typeof now !== 'number') return;
+            const next = Math.ceil((now + 0.08) / unitSeconds) * unitSeconds;
+            await nap((next - now) * 1000);
+        }, { unitSeconds: (60 / bpm) * syncToBeats });
     }
     const t0 = Date.now();
     await page.evaluate(async ({ notes, msPerBeat }) => {
@@ -397,7 +422,7 @@ async function performPhrase({ instrument, notes, bpm }) {
 
 // The app's insert-recording button: turns the captured take into song source.
 // Put the cursor inside the recording markers first, where a player would.
-async function pasteRecording() {
+async function pasteRecording({ quantize } = {}) {
     await setView('song');
     await page.evaluate(() => {
         const cm = document.querySelector('app-javascriptmusic').shadowRoot
@@ -406,8 +431,8 @@ async function pasteRecording() {
         cm.setCursor({ line: line < 0 ? 0 : line + 1, ch: 0 });
     });
     await sleep(400);
-    await page.evaluate(() => window.insertRecording());
-    log('  pasted the recorded take into the song');
+    await page.evaluate((q) => window.insertRecording(q), quantize);
+    log(`  pasted the recorded take into the song${quantize ? ` (quantized to 1/${quantize} beat)` : ''}`);
     await sleep(1600);
 }
 
@@ -455,6 +480,16 @@ for (const [n, beat] of beats.entries()) {
 
     for (const line of beat.say ?? []) { await streamText(mock, line + '\n\n'); await sleep(250); }
     for (const ord of beat.tools ?? []) await runTool(ord, { quick: beat.quick });
+    // Start the transport only once there is something to hear.
+    if (beat.startPlayback) {
+        await page.evaluate(() => {
+            window.toggleSongPlay(true);
+            const box = document.querySelector('app-javascriptmusic').shadowRoot
+                .getElementById('toggleSongPlayCheckbox');
+            if (box) box.checked = true;
+        });
+        log('  transport started');
+    }
     // Jump cut: after a quick run, land on the result and let it play.
     if (beat.quick && beat.showAfter) { await setView(beat.showAfter); await sleep(beat.showMs ?? 3000); }
 
@@ -466,7 +501,7 @@ for (const [n, beat] of beats.entries()) {
 
     // The player's half of the loop: perform, paste, quantize.
     if (beat.perform) await performPhrase(beat.perform);
-    if (beat.pasteRecording) await pasteRecording();
+    if (beat.pasteRecording) await pasteRecording(beat.pasteRecording === true ? {} : beat.pasteRecording);
     if (beat.quantizeTake) await quantizeTake(beat.quantizeTake);
 
     if (beat.outro) { await setView('agent'); await streamText(mock, beat.outro + '\n'); }

--- a/tools/session-video/record.mjs
+++ b/tools/session-video/record.mjs
@@ -322,9 +322,17 @@ const drainTimer = setInterval(drain, 5000);
 let currentView = null;
 const setView = async (v) => { if (v !== currentView) { await showOnly(page, v); currentView = v; } };
 
-async function runTool(ord) {
+// `quick` runs the call without the deliberate look-at-the-code pauses — for a
+// jump cut, where the point is the RESULT rather than watching each edit land.
+async function runTool(ord, { quick = false } = {}) {
     const t = tools[ord];
     if (!t) throw new Error(`no tool #${ord} in the log`);
+    if (quick) {
+        mock.send({ t: 'tool', name: t.name });
+        const res = await mock.callTool(t.name, t.args);
+        log(`  #${ord} ${t.name} → ${res.ok ? 'ok' : 'ERROR'} (quick)`);
+        return res;
+    }
     // Watch the document being edited; stay put through the compile that applies it.
     const want = VIEW_FOR_TOOL[t.name];
     if (want) { await setView(want); await sleep(600); }
@@ -336,6 +344,100 @@ async function runTool(ord) {
     const secs = ((Date.now() - t0) / 1000).toFixed(1);
     log(`  #${ord} ${t.name} → ${res.ok ? 'ok' : 'ERROR'} (${secs}s)`);
     if (want) await sleep(1400); // let the edit be read on screen
+    return res;
+}
+
+// ---- live actions: things the PLAYER does, which no log can replay ----------
+// A session log holds the agent's tool calls, not the human's. Playing a take
+// and pasting it are the player's half of the loop, so they are re-enacted here
+// against the running app rather than replayed.
+
+const CM = () => document.querySelector('app-javascriptmusic').shadowRoot
+    .querySelector('#editor .CodeMirror').CodeMirror;
+
+// Play a phrase through the app's live-input path — the same `processNoteMessage`
+// the virtual keyboard and a real MIDI keyboard both reach — so the sequencer
+// captures it exactly as it would a human performance.
+async function performPhrase({ instrument, notes, bpm }) {
+    await setView('song');
+    if (instrument) {
+        await page.evaluate((name) => {
+            const root = document.querySelector('app-javascriptmusic').shadowRoot;
+            const sel = root.getElementById('midichannelmappingselection');
+            sel.value = name;
+            window.currentMidiChannelMapping = name;
+            sel.dispatchEvent(new Event('change'));
+            root.getElementById('vkeyboardinputelement').focus();
+        }, instrument);
+        log(`  instrument → ${instrument}`);
+        await sleep(600);
+    }
+    const t0 = Date.now();
+    await page.evaluate(async ({ notes, msPerBeat }) => {
+        const root = document.querySelector('app-javascriptmusic').shadowRoot;
+        const vk = root.getElementById('vkeyboardinputelement');
+        const names = new Array(128).fill(null).map((v, n) =>
+            ['c', 'cs', 'd', 'ds', 'e', 'f', 'fs', 'g', 'gs', 'a', 'as', 'b'][n % 12] + Math.floor(n / 12));
+        const nap = (ms) => new Promise((r) => setTimeout(r, ms));
+        const held = new Set();
+        const show = () => { vk.value = [...held].map((n) => names[n]).join(','); };
+        const start = performance.now();
+        await Promise.all(notes.map(async ([beat, note, durBeats, vel]) => {
+            await nap(Math.max(0, start + beat * msPerBeat - performance.now()));
+            window.playNoteMessage(note, vel);
+            held.add(note); show();
+            await nap(durBeats * msPerBeat);
+            window.playNoteMessage(note, 0);
+            held.delete(note); show();
+        }));
+        vk.value = '';
+    }, { notes, msPerBeat: 60000 / bpm });
+    log(`  performed ${notes.length} notes in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+}
+
+// The app's insert-recording button: turns the captured take into song source.
+// Put the cursor inside the recording markers first, where a player would.
+async function pasteRecording() {
+    await setView('song');
+    await page.evaluate(() => {
+        const cm = document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror;
+        const line = cm.getValue().split('\n').findIndex((l) => l.includes('startRecording()'));
+        cm.setCursor({ line: line < 0 ? 0 : line + 1, ch: 0 });
+    });
+    await sleep(400);
+    await page.evaluate(() => window.insertRecording());
+    log('  pasted the recorded take into the song');
+    await sleep(1600);
+}
+
+// Quantize the take that was just pasted. This is a REAL edit_song tool call —
+// only its arguments are computed here, because they have to anchor on notes
+// that did not exist until the take was played.
+async function quantizeTake(stepsPerBeat) {
+    const tail = await page.evaluate(() => {
+        const cm = document.querySelector('app-javascriptmusic').shadowRoot
+            .querySelector('#editor .CodeMirror').CodeMirror;
+        const lines = cm.getValue().split('\n');
+        const i = lines.findIndex((l) => l.includes('.play([') && l.includes('createTrack('));
+        if (i < 0) return null;
+        for (let j = i; j < lines.length; j++) if (lines[j].trimEnd().endsWith(']);')) return lines[j];
+        return null;
+    });
+    if (!tail) {
+        // Losing the last beat should not throw away the whole render — the
+        // usual cause is an empty take, which the log above makes obvious.
+        log('  WARNING: no recorded take found to quantize — skipping');
+        return null;
+    }
+    await setView('song');
+    mock.send({ t: 'tool', name: 'edit_song' });
+    const res = await mock.callTool('edit_song', {
+        old_string: tail,
+        new_string: tail.replace(/\]\);\s*$/, `].quantize(${stepsPerBeat}));`),
+    });
+    log(`  quantize(${stepsPerBeat}) → ${res.ok ? 'ok' : 'ERROR'}`);
+    await sleep(1400);
     return res;
 }
 
@@ -352,23 +454,30 @@ for (const [n, beat] of beats.entries()) {
     await sleep(700);
 
     for (const line of beat.say ?? []) { await streamText(mock, line + '\n\n'); await sleep(250); }
-    for (const ord of beat.tools ?? []) await runTool(ord);
+    for (const ord of beat.tools ?? []) await runTool(ord, { quick: beat.quick });
+    // Jump cut: after a quick run, land on the result and let it play.
+    if (beat.quick && beat.showAfter) { await setView(beat.showAfter); await sleep(beat.showMs ?? 3000); }
 
     for (const line of beat.sayThen ?? []) { await setView('agent'); await streamText(mock, line + '\n\n'); await sleep(250); }
-    for (const ord of beat.thenTools ?? []) await runTool(ord);
+    for (const ord of beat.thenTools ?? []) await runTool(ord, { quick: beat.quick });
 
     for (const line of beat.sayAfterFail ?? []) { await setView('agent'); await streamText(mock, line + '\n\n'); await sleep(250); }
     for (const ord of beat.failFixTools ?? []) await runTool(ord);
 
+    // The player's half of the loop: perform, paste, quantize.
+    if (beat.perform) await performPhrase(beat.perform);
+    if (beat.pasteRecording) await pasteRecording();
+    if (beat.quantizeTake) await quantizeTake(beat.quantizeTake);
+
     if (beat.outro) { await setView('agent'); await streamText(mock, beat.outro + '\n'); }
     mock.send({ t: 'done' });
-    await sleep(1800);
+    await sleep(beat.holdMs ?? 1800);
 }
 
 // Play the finished track out over the song
 log('outro');
 await setView('song');
-await sleep(12000);
+await sleep(cut.OUTRO_MS ?? 12000);
 
 // ---- stop + mux --------------------------------------------------------------
 clearInterval(drainTimer);

--- a/tools/session-video/record.mjs
+++ b/tools/session-video/record.mjs
@@ -420,6 +420,19 @@ async function performPhrase({ instrument, notes, bpm, syncToBeats }) {
     log(`  performed ${notes.length} notes in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
 }
 
+// An AUTHORED edit: a real edit_song/edit_synth executed in the browser, whose
+// arguments are written for the video rather than replayed from the log. Use it
+// only for structure the session never asked about — the cut's value is that
+// the music is the session's actual output, so say why in the cut when you do.
+async function runEdit({ tool = 'edit_song', old_string, new_string, replace_all = false }) {
+    await setView(tool === 'edit_synth' ? 'synth' : 'song');
+    mock.send({ t: 'tool', name: tool });
+    const res = await mock.callTool(tool, { old_string, new_string, replace_all });
+    log(`  authored ${tool} → ${res.ok ? 'ok' : 'ERROR'}`);
+    if (!res.ok) throw new Error(`authored ${tool} failed: ${res.result}`);
+    return res;
+}
+
 // The app's insert-recording button: turns the captured take into song source.
 // Put the cursor inside the recording markers first, where a player would.
 async function pasteRecording({ quantize } = {}) {
@@ -480,6 +493,13 @@ for (const [n, beat] of beats.entries()) {
 
     for (const line of beat.say ?? []) { await streamText(mock, line + '\n\n'); await sleep(250); }
     for (const ord of beat.tools ?? []) await runTool(ord, { quick: beat.quick });
+    // Authored structural edits, then a compile so they are audible.
+    if (beat.edits?.length) {
+        for (const e of beat.edits) await runEdit(e);
+        mock.send({ t: 'tool', name: 'compile' });
+        const res = await mock.callTool('compile', {});
+        log(`  compile after authored edits → ${res.ok ? 'ok' : 'ERROR'}`);
+    }
     // Start the transport only once there is something to hear.
     if (beat.startPlayback) {
         await page.evaluate(() => {

--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -37,6 +37,12 @@ const HEAVY_TOOLS = new Set(['write_faust', 'compile']);
 // Optional model override for speed/depth tradeoff, e.g. STUDIO_AGENT_MODEL=sonnet
 // (faster) vs opus (deeper). Unset = the SDK/Claude Code default.
 const MODEL = process.env.STUDIO_AGENT_MODEL || undefined;
+// Reasoning effort. Turn latency here is dominated by the NUMBER of model
+// round-trips, not by thinking depth, and lower effort buys fewer and more
+// consolidated tool calls plus less preamble — so it is the cheapest latency
+// win available. 'medium' keeps musical judgement while trimming the tail;
+// raise to 'high'/'xhigh' for gnarlier work, drop to 'low' for a rehearsed set.
+const EFFORT = process.env.STUDIO_AGENT_EFFORT || 'medium';
 // Proactive compaction threshold (tokens of per-call context). The SDK only
 // auto-compacts near the model's context LIMIT (~1M on opus) — far beyond the
 // point where every turn is already slow and expensive (a ~570k-token session
@@ -172,6 +178,11 @@ function makeStudioServer(ws) {
   return createSdkMcpServer({
     name: 'studio',
     version: '1.0.0',
+    // Pin the studio tool schemas into the turn-1 prompt instead of letting
+    // them sit behind tool search. Deferred schemas cost an extra ToolSearch
+    // round-trip before the agent can act at all — measured at ~1.4x the
+    // median turn and a much worse tail on real sessions.
+    alwaysLoad: true,
     tools: [
       ...toolDefsFor('browser').map((d) => proxy(d.name, d.description, zodShape(d.parameters))),
       ...toolDefsFor('loadfile').map((d) => loadInto(d)),
@@ -183,13 +194,29 @@ function makeStudioServer(ws) {
 const t0 = () => new Date().toISOString().slice(11, 23);
 const dlog = (...a) => console.log(`  [${t0()}]`, ...a);
 
-async function handleChat(ws, { text, sessionId, summary }, isRetry = false) {
+// The project's kit (its AGENT.md, or the shipped default) arrives from the
+// browser — the server has no view of OPFS. It goes into the SYSTEM PROMPT so
+// the model has the project's instruments and conventions from turn 0 instead
+// of spending a round-trip discovering them. Identical text every turn keeps
+// the cached prefix intact; a changed kit costs one cold turn, as it should.
+function systemPromptWith(kit) {
+  if (!kit || !kit.trim()) return SYSTEM_PROMPT;
+  return `${SYSTEM_PROMPT}\n\n## Project kit (from the project's AGENT.md)\n\n` +
+    `These are the user's instructions for THIS project — instrument sources, ` +
+    `channel layout and conventions. Prefer them over generic defaults, and use ` +
+    `them directly instead of searching the repository for the same information.` +
+    `\n\n${kit}`;
+}
+
+async function handleChat(ws, { text, sessionId, summary, kit }, isRetry = false) {
   const send = (obj) => { if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(obj)); };
   const studio = makeStudioServer(ws);
+  const systemPrompt = systemPromptWith(kit);
   let sid = sessionId || null;
   let contextTokens = 0; // last model call's input size (fresh + cached)
-  dlog('chat:', JSON.stringify(text).slice(0, 100), sessionId ? `(resume ${sessionId.slice(0, 8)})` : '(new)');
-  logEvent({ kind: 'chat', sessionId: sid, resumed: !!sessionId, text });
+  dlog('chat:', JSON.stringify(text).slice(0, 100), sessionId ? `(resume ${sessionId.slice(0, 8)})` : '(new)',
+    kit ? `kit ${kit.length} chars` : 'NO KIT');
+  logEvent({ kind: 'chat', sessionId: sid, resumed: !!sessionId, text, kitChars: kit ? kit.length : 0 });
 
   try {
     for await (const m of query({
@@ -197,8 +224,9 @@ async function handleChat(ws, { text, sessionId, summary }, isRetry = false) {
       options: {
         resume: sessionId || undefined,
         model: MODEL,
+        effort: EFFORT,
         cwd: REPO_ROOT,
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt,
         mcpServers: { studio },
         allowedTools: [...ALLOWED],
         disallowedTools: DISALLOWED,
@@ -251,7 +279,7 @@ async function handleChat(ws, { text, sessionId, summary }, isRetry = false) {
     }
     dlog('query loop ended');
     if (sid && contextTokens > COMPACT_THRESHOLD) {
-      await autoCompact(send, sid, contextTokens);
+      await autoCompact(send, sid, contextTokens, systemPrompt);
     }
   } catch (e) {
     const emsg = String(e?.message || e);
@@ -265,7 +293,7 @@ async function handleChat(ws, { text, sessionId, summary }, isRetry = false) {
       const prompt = summary
         ? `A previous session (possibly on another machine) was compacted to this summary:\n\n${summary}\n\n---\nContinue from that context. The user's request:\n${text}`
         : text;
-      return handleChat(ws, { text: prompt, sessionId: null }, true);
+      return handleChat(ws, { text: prompt, sessionId: null, kit }, true);
     }
     dlog('EXCEPTION', emsg);
     logEvent({ kind: 'error', sessionId: sid, error: emsg });
@@ -306,14 +334,16 @@ async function sendCompactSummary(send, sid) {
 
 // Run /compact on the session between turns (chats are serialized through
 // chatChain, so a message the user sends meanwhile simply waits for this).
-async function autoCompact(send, sid, contextTokens) {
+async function autoCompact(send, sid, contextTokens, systemPrompt = SYSTEM_PROMPT) {
   dlog(`auto-compact: context ~${Math.round(contextTokens / 1000)}k tokens > ${Math.round(COMPACT_THRESHOLD / 1000)}k threshold`);
   send({ t: 'compacting', tokens: contextTokens });
   logEvent({ kind: 'autocompact', sessionId: sid, contextTokens });
   try {
     for await (const m of query({
       prompt: '/compact',
-      options: { resume: sid, model: MODEL, cwd: REPO_ROOT, systemPrompt: SYSTEM_PROMPT, maxTurns: 2 },
+      // Same system prompt as the chat turns — a different one here would
+      // invalidate the cached prefix for the whole session.
+      options: { resume: sid, model: MODEL, effort: EFFORT, cwd: REPO_ROOT, systemPrompt, maxTurns: 2 },
     })) {
       if (m.type === 'system' && m.subtype === 'compact_boundary') {
         dlog('context compacted', JSON.stringify(m.compact_metadata || {}));
@@ -357,4 +387,5 @@ wss.on('connection', (ws) => {
 console.log(`\n  studio-agent → ws://localhost:${PORT}`);
 console.log(`  repo root:     ${REPO_ROOT}`);
 console.log(`  model:         ${MODEL || '(default)'}`);
+console.log(`  effort:        ${EFFORT}`);
 console.log('  auth:          Claude Code subscription login (no API key)\n');

--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -185,6 +185,13 @@ export function initAudioWorkletNode(componentRoot) {
         componentRoot.getElementById('stopaudiobutton').style.display = 'none';
     }
 
+    // Automation hook for e2e specs and tools/session-video: play a note through
+    // exactly the path the virtual keyboard and a real MIDI keyboard both take,
+    // so a scripted performance reaches the synth, the visualizer AND the
+    // recorder the same way a human's does. Honours the selected instrument
+    // (window.currentMidiChannelMapping) like any other live input.
+    window.playNoteMessage = (note, velocity) => processNoteMessage(note, velocity);
+
     window.toggleSongPlay = (status) => {
         if (audioworkletnode) {
             audioworkletnode.port.postMessage({ toggleSongPlay: status });

--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -1,6 +1,6 @@
 import { startWAM, postSong as wamPostSong, pauseWAMSong, onMidi as wamOnMidi, wamsynth, resumeWAMSong } from './webaudiomodules/wammanager.js';
 import { createAudioWorklet as createMidiSynthAudioWorklet, onmidi as midiSynthOnMidi, setBroadcastUiHandlers, releaseAudioWorklet } from './synth1/audioworklet/midisynthaudioworklet.js';
-import { visualizeNoteOn, clearVisualization, setUseDefaultVisualizer } from './visualizer/defaultvisualizer.js';
+import { visualizeNoteOn, clearVisualization, setUseDefaultVisualizer, getCurrentTimeSeconds } from './visualizer/defaultvisualizer.js';
 import { setPaused } from './visualizer/midieventlistvisualizer.js';
 import { attachSeek, detachSeek } from './app.js';
 import { recordAudioNode, startVideoRecording, stopVideoRecording } from './screenrecorder/screenrecorder.js';
@@ -191,6 +191,10 @@ export function initAudioWorkletNode(componentRoot) {
     // recorder the same way a human's does. Honours the selected instrument
     // (window.currentMidiChannelMapping) like any other live input.
     window.playNoteMessage = (note, velocity) => processNoteMessage(note, velocity);
+    // Where the sequencer's playhead is, in seconds — lets a scripted take start
+    // on a beat boundary, so the captured notes land on the grid rather than
+    // wherever in the loop the script happened to begin.
+    window.songTimeSeconds = () => getCurrentTimeSeconds();
 
     window.toggleSongPlay = (status) => {
         if (audioworkletnode) {

--- a/wasmaudioworklet/docs/README.md
+++ b/wasmaudioworklet/docs/README.md
@@ -12,6 +12,13 @@ itself see the [app README](../README.md); for the monorepo overview see the
   finished example lives at
   [petersalomonsen/wasm-music-2026](https://github.com/petersalomonsen/wasm-music-2026).)
 
+## Talks & performances
+
+- [Agentic Composition, Live](presentation/is2-2026-performance-plan.md) — plan
+  for the 12-minute set proposed to IEEE IS² 2026 (Cannes, October 2026): a
+  track built from silence by talking to the agent, with the music never
+  stopping, and the finished piece pushed to a repo the audience can open.
+
 ## Authoring a song
 
 - [Writing songs in JavaScript](writing-songs.md) — **start here.** A song is a

--- a/wasmaudioworklet/docs/presentation/is2-2026-performance-plan.md
+++ b/wasmaudioworklet/docs/presentation/is2-2026-performance-plan.md
@@ -1,0 +1,224 @@
+# Agentic Composition, Live — IEEE IS² 2026 performance plan
+
+*A track built from silence in a browser tab, by talking to an agent — with the
+music never stopping. Plan for the set proposed to the 7th IEEE International
+Symposium on the Internet of Sounds, Cannes, 28–30 October 2026.*
+
+**Duration:** about 11 minutes · **Performer:** Peter Salomonsen · **Rig:** a
+laptop, a MIDI keyboard, a browser tab, and a projector.
+
+Section lengths below are targets, not a script. The set is built from a
+sequence of asks, and which ones make the final run — and in what order — will
+be settled in rehearsal closer to the date.
+
+## The idea
+
+A complete track is built live on stage, from nothing to a full arrangement, by
+talking to the [Studio Agent](../agenticcomposition.md) inside the app — and the
+music never stops while it happens. There is no DAW, no plugin host and no
+pre-rendered audio. The agent writes [Faust](https://faust.grame.fr/) DSP and
+JavaScript sequence code; that code compiles to WebAssembly in the page and is
+hot-swapped into a running audio graph: the transport never stops, so each new
+instrument or section joins the music that is already playing rather than
+arriving after a silence.
+
+Partway through I stop talking and play. A lead melody performed on the MIDI
+keyboard is captured and inserted back into the song source, where it becomes
+editable, versionable code like everything else. At the end the whole piece —
+song, synth, Faust instruments, shaders and the agent conversation — is
+committed and pushed to a public repository from inside the browser, and the URL
+goes on screen so the audience can run the piece on their own devices.
+
+**The agent is an instrument, not a composer.** I decide the arrangement, the
+harmony, the order material arrives in and when to strip back; I play the parts.
+What the agent gives me is speed — a synthesizer voice in seconds instead of
+minutes. Everything it produces is inspectable code, not generated audio. The
+audience sees the code and hears the result at the same time.
+
+**Play through the thinking time.** The median ask takes around a minute, and
+that minute is performing time, not waiting time: I play over the running
+arrangement on the keyboard while the next instrument is being written, adding
+notes by hand so the music develops instead of looping unchanged. This is what
+keeps the set musical between asks, and it is worth rehearsing as deliberately as
+the prompts — knowing which instrument to play over, and in which register, while
+each kind of edit lands.
+
+## Set structure
+
+| Section | Target | On stage |
+|---|---|---|
+| **Cold open** | ~1½ min | Open a near-empty project from a URL; it clones and boots in seconds. Ask for a beat. The agent authors Faust drum voices — kick, snare, hi-hat — compiles them, and the groove starts. First sound inside about a minute. |
+| **Harmony** | ~2 min | Ask for a chord progression. The agent writes chords into the sequence (a step slot holding an array of notes) and builds a pad in Faust. The chords join the running loop; the drums never drop out. |
+| **Bass** | ~2 min | Ask for a bassline locked to the progression. A new Faust voice, wired in as its own MIDI channel, then refined conversationally — punchier, longer decay, more filter movement — each recompile landing without interrupting playback. |
+| **I play** | ~2½ min | Switch from talking to playing: a lead melody performed live over the running arrangement, then **captured back into the song code**. This is the hinge of the set — conversation, to code, to performance, and back to code. |
+| **Arrangement & visuals** | ~2½ min | Ask for structure: a break, a variation, a lift. The agent edits the arrangement in place. Song-driven [shader visuals](../shaders.md), also authored as code, react to the same MIDI events driving the sound. |
+| **Hand it over** | ~½ min | Commit and push the finished piece from inside the browser — one button in the app, not an agent step. The URL goes on screen; anyone in the room, or watching the stream, can open it and the piece compiles and plays on their machine. Not a recording of tonight — the instrument itself. |
+
+The first four sections are the rehearsed core, budgeted at **8 minutes**
+together; the last two add about three more.
+
+## Rehearsal timings (31 July 2026)
+
+A full run of the first four sections on the real rig, timed from the agent's
+own session log. Nine conversational turns took **6.3 minutes of agent time
+inside 9.8 minutes of wall clock** — the remaining 35% being typing, playing and
+listening. Per-turn median 51s, worst 86s.
+
+| Ask | Time | Tool calls |
+|---|---|---|
+| "give me a beat" | 62s | 13 |
+| "add a chord progression, dminor, a#major, c major, g major" | 51s | 7 |
+| "add a punchy bass-line, alternate octaves like italo disco" | 46s | 7 |
+| "a fat lead that I can play myself on top" | 36s | 6 |
+| "an echo on the lead, every 3rd step at 4 steps per beat" | 86s | 4 |
+| "insert recording markers" | 21s | 4 |
+| *(played a take, pasted it in)* | — | — |
+| "see the recording I just inserted" | 17s | 1 |
+| "adjust the notes so they're on the beat" | 62s | 3 |
+
+What makes those numbers possible is that the project repo carries an
+`AGENT.md` — a **kit** describing its instruments, channel layout and
+conventions, loaded into the model's context at the start of every turn. With it
+the agent acts immediately; without it, it spends a round-trip discovering the
+same facts first. Across 50 tool calls in that run, only two were lookups, and
+both were reading the current song before editing it. A tailored kit for the
+performance repo is the single highest-leverage piece of preparation.
+
+**Getting to 8 minutes.** The rehearsed run came in at 9.8 minutes against an
+8-minute target for these sections. The overrun is concentrated rather than
+spread: the echo ask alone was 86 seconds — the worst turn of the run, and the
+most musically optional. Dropping it, or pre-baking the effect into the lead,
+recovers most of the gap; tightening the kit and cutting one further ask covers
+the rest.
+
+## How it works
+
+### Faust as the instrument language
+
+Every instrument in the set is written in Faust, and that is the reason this
+works at performance speed. A Faust program expresses a DSP algorithm in a few
+declarative lines — a drum voice, a filtered bass, a pad are each a handful of
+them — which is small enough for a language model to write correctly and revise
+reliably in seconds. Piano-roll editing has nothing this compact.
+
+The pipeline:
+
+```
+Faust (.dsp) → faust2as → AssemblyScript → WebAssembly → AudioWorklet
+```
+
+The [faust2as transpiler](../../../tools/faust2as/README.md) generates
+AssemblyScript classes that are wired into `synth.ts`, which acts purely as a
+multitimbral combiner — one Faust voice per MIDI channel. Effects come from the
+same place, per-instrument or across the whole mix
+(see [Faust effects](../effects.md)).
+
+Two recent additions matter on stage. Structured faust-rs diagnostics are
+surfaced to the agent, so DSP that fails to compile comes back as a precise
+error the agent repairs itself, without me intervening. And the agent **probes
+the compiled synth for actual sound** rather than trusting that a clean compile
+means audio — it verifies the song against the compiled MIDI events. It knows
+whether what it just built makes a noise.
+
+### The agent
+
+A chat panel drives an LLM agent loop whose tools execute **inside the browser**,
+acting on the code editors, the WebAssembly compiler and the audio worklet. The
+tools are musical rather than generic file I/O: read, search and *surgically*
+edit the song and synth sources; write, read and list Faust instruments; author
+shaders; compile. Surgical edits are what let it add a voice to a
+14,000-line instrument bundle without rewriting it or dragging it through its
+context window.
+
+### Music that never stops
+
+Song scripts run in a QuickJS WebAssembly sandbox, off the audio thread.
+Compiling a new synth swaps the WebAssembly module into the running audio graph,
+and a new sequence is spliced in at the current playhead — the transport keeps
+its position instead of restarting. That is what makes the set continuous: I am
+editing a running instrument, not stopping to render.
+
+The splice is immediate rather than quantised to a bar, and it sends an
+all-notes-off first, so a sustaining pad is cut at the moment of the swap while
+short percussive parts are unaffected. In practice that means recompiling under
+drums is seamless and recompiling under a held chord is audible — worth choosing
+where in the arrangement each edit lands.
+
+Demonstrated here: [*The agent edits the synth while the music keeps
+playing*](https://www.youtube.com/shorts/Zn3m7TlbPck).
+
+### Everything is a URL
+
+The whole work is a git repository, pushed from inside the browser via wasm-git.
+Where that repository lives is deliberately not fixed — the app can push to a
+conventional hosted git service through a CORS proxy, or to on-chain,
+[NEAR-backed storage](../git-hosting.md); the choice for the performance will be
+made nearer the date. Either way, opening the app with a repo URL clones and
+runs the piece. No server renders audio and there is nothing to install: each
+listener's browser compiles the WebAssembly and synthesizes the music locally.
+For the symposium's hybrid concert format that means remote attendees are not
+limited to watching a stream — they can hold the instrument.
+
+### Beyond the browser
+
+The same WebAssembly instruments load into the native
+[DAW plugin](../../../dawplugin/README.md) — JUCE-based, AOT-compiling the `.wasm`
+to native code with WasmEdge, with low-latency real-time audio and MIDI and
+dynamic instrument switching. An instrument written on stage in Faust is not
+trapped in the browser; it is a portable artifact that runs in a professional
+production environment too.
+
+## Live capture — verified end to end
+
+The capture-take-to-code step at 5:30–8:00 needed no new development. Rehearsed
+on 31 July 2026, the whole loop ran on the existing app:
+
+1. I asked the agent for recording markers; it wrapped the loop in
+   `startRecording()` / `stopRecording()`.
+2. I played a take against the running arrangement.
+3. One button press pasted the captured notes into the song source as a
+   `createTrack(5).play([...])` array.
+4. I asked the agent to put the notes on the beat; it appended `.quantize(4)`
+   to that array and confirmed all 32 notes survived the snap.
+
+The take stays in the source **at its original timing** — quantization is
+applied at playback, so removing eleven characters restores the live feel. For a
+performance whose one irreplaceable artifact is the take itself, that matters.
+
+One sharp edge to rehearse around: compiling clears the recording buffer, so the
+take must be pasted into the source *before* the agent compiles again. Insert
+first, then talk to the agent.
+
+## Risk notes
+
+Live agent-driven performance has obvious failure modes. The mitigations:
+
+- **The music keeps playing regardless.** Because edits are hot-swapped into a
+  running graph, a slow or failed agent step means the current arrangement
+  continues rather than silence.
+- **Rehearsed prompt path with fallbacks.** Every step has a known-good
+  alternative I can type straight into the editor. The agent is a fast path, not
+  a single point of failure — I can always write the code myself, live.
+- **No network dependency for the music.** The piece runs fully offline once
+  loaded; the network is needed only for the initial clone, inference calls and
+  the closing push.
+- **Compile failures are caught, not shipped.** Structured Faust diagnostics and
+  the audio probe mean broken DSP is repaired rather than silently played as
+  silence. In the rehearsal the agent hit one compile error, read it, and fixed
+  itself without intervention.
+- **A rehearsed kit keeps turns short and predictable.** The 51s median above is
+  a property of the project's `AGENT.md`, not of the model — the same asks
+  without one historically ran roughly twice as long with a far worse tail.
+- **The known sharp edges are the ones to drill**, not the ones to hope about:
+  paste a take before the next compile; land recompiles under drums rather than
+  under a held chord; keep a fallback commit in the repo that a single
+  `load_song_from_file` restores if a step goes wrong.
+
+## Background
+
+- *Converting Faust to AssemblyScript for WebAssembly Music* — paper and talk,
+  5th International Faust Conference (IFC-26), Cannes, June 2026.
+- *WebAssembly Music* — evening concert, IFC-26, Cannes, 4 June 2026
+  ([recording, from 1:27:30](https://www.youtube.com/watch?v=u7ZJreOHOAU&t=5250s)).
+- Web Audio Conference 2025 award — WebAssembly Music instrument plugin NFTs.
+- [Agentic Composition](../agenticcomposition.md) — the practice this set performs.

--- a/wasmaudioworklet/e2e/studio-agent-kit.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-kit.spec.js
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+import ws from 'ws';
+import { waitForAppReady, waitForStudioAgentTools, clearOPFS } from './near-git-helpers.js';
+
+// The project KIT (its AGENT.md, or the shipped default) has to reach the model
+// as context at the START of a turn — never as something the agent discovers
+// with a tool call. Measured over real sessions, turns that opened with a
+// discovery call ran about twice the median and roughly three times the p90 of
+// turns that could act immediately, so a regression here is a silent
+// performance cliff rather than a visible break.
+//
+// This spec pins the WIRING: browser reads the kit → ships it on the chat
+// message → the agent server can put it in the system prompt. The selection
+// rules (repo file wins, fallback, truncation, caching) are unit-tested in
+// studio-agent/kit.test.mjs.
+//
+// No NEAR sandbox needed: an unregistered `?gitrepo=` name fails to clone and
+// falls back to a local OPFS repo, which is also the "no AGENT.md" case.
+
+const REPO = 'kit-e2e-test';
+
+// Mock agent server — only needs to capture what the client sends.
+function startMockAgentServer() {
+    const wss = new ws.Server({ port: 0 });
+    const state = { socket: null, chats: [] };
+    wss.on('connection', (socket) => {
+        state.socket = socket;
+        socket.on('close', () => { if (state.socket === socket) state.socket = null; });
+        socket.on('message', (data) => {
+            let msg;
+            try { msg = JSON.parse(data.toString()); } catch { return; }
+            if (msg.t === 'chat') state.chats.push(msg);
+        });
+    });
+    const waitForClient = async (timeoutMs = 30000) => {
+        const t0 = Date.now();
+        while (!(state.socket && state.socket.readyState === ws.OPEN)) {
+            if (Date.now() - t0 > timeoutMs) throw new Error('no live studio-agent client connection');
+            await new Promise((r) => setTimeout(r, 100));
+        }
+    };
+    const waitForChat = async (timeoutMs = 30000) => {
+        const t0 = Date.now();
+        while (state.chats.length === 0) {
+            if (Date.now() - t0 > timeoutMs) throw new Error('client never sent a chat message');
+            await new Promise((r) => setTimeout(r, 100));
+        }
+        return state.chats[0];
+    };
+    return {
+        state, waitForClient, waitForChat,
+        port: () => wss.address().port,
+        close: () => new Promise((resolve) => wss.close(resolve)),
+    };
+}
+
+async function typeIntoAgentChat(page, text) {
+    await page.evaluate((t) => {
+        const shadow = document.querySelector('app-javascriptmusic').shadowRoot;
+        window.toggleStudioAgent(true);
+        const input = shadow.getElementById('studioagentinput');
+        input.value = t;
+        shadow.getElementById('studioagentform').requestSubmit();
+    }, text);
+}
+
+test.describe('studio-agent project kit', () => {
+    let mock;
+
+    test.beforeEach(async ({ page }) => {
+        mock = startMockAgentServer();
+        await page.addInitScript((port) => { window.STUDIO_AGENT_PORT = port; }, mock.port());
+    });
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, REPO);
+        await mock.close();
+    });
+
+    test('a chat message carries the kit, so the agent never has to look it up', async ({ page }) => {
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await page.goto(`http://localhost:8080/?gitrepo=${REPO}`);
+        await waitForAppReady(page);
+        await waitForStudioAgentTools(page);
+        await mock.waitForClient();
+
+        await typeIntoAgentChat(page, 'give me a beat');
+        const chat = await mock.waitForChat();
+
+        expect(chat.text).toBe('give me a beat');
+        // A fresh repo has no AGENT.md, so this is the shipped default kit.
+        expect(typeof chat.kit).toBe('string');
+        expect(chat.kit.length).toBeGreaterThan(1000);
+        expect(chat.kit).toContain('Performance kit');
+    });
+
+    test('the default kit carries what the agent needs to build without lookups', async ({ page }) => {
+        await page.goto(`http://localhost:8080/?gitrepo=${REPO}`);
+        await waitForAppReady(page);
+        await waitForStudioAgentTools(page);
+        await mock.waitForClient();
+
+        await typeIntoAgentChat(page, 'hello');
+        const { kit } = await mock.waitForChat();
+
+        // The channel map and a runnable source for each instrument — without
+        // these the agent has to go and find them, which is the cost this
+        // whole mechanism exists to avoid.
+        for (const instrument of ['kick', 'snare', 'hihat', 'pad', 'bass', 'lead']) {
+            expect(kit, `kit should describe ${instrument}`).toContain(instrument);
+        }
+        expect(kit).toContain('import("stdfaust.lib")');
+        expect(kit).toContain('initializeMidiSynth');
+        // Hard-won gotchas that cost real compile round-trips when missing.
+        expect(kit, 'must warn against ma.tanh').toContain('ma.tanh');
+        expect(kit, 'must state the sat() replacement').toContain('sat(x) = x / (1.0 + abs(x))');
+    });
+
+    test('every turn carries the kit, not just the first', async ({ page }) => {
+        await page.goto(`http://localhost:8080/?gitrepo=${REPO}`);
+        await waitForAppReady(page);
+        await waitForStudioAgentTools(page);
+        await mock.waitForClient();
+
+        await typeIntoAgentChat(page, 'first');
+        await mock.waitForChat();
+        await typeIntoAgentChat(page, 'second');
+        await expect.poll(() => mock.state.chats.length).toBe(2);
+
+        // The server rebuilds the system prompt per turn; identical kit text
+        // each time is what keeps the cached prompt prefix intact.
+        const [a, b] = mock.state.chats;
+        expect(b.kit).toBe(a.kit);
+        expect(b.kit.length).toBeGreaterThan(1000);
+    });
+});

--- a/wasmaudioworklet/e2e/studio-agent-nearai.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-nearai.spec.js
@@ -87,7 +87,12 @@ test('proxy mode (/nearai on): no key, no system prompt, no tools sent — serve
     expect(requests[0].headers.authorization).toBeUndefined();      // server holds the key
     expect(requests[0].body.tools).toBeUndefined();                  // server injects tools
     expect(requests[0].body.messages.some((m) => m.role === 'system')).toBe(false); // server injects the prompt
-    expect(requests[0].body.messages.at(-1)).toEqual({ role: 'user', content: 'hello there' });
+    // The project kit rides in on the FIRST user turn, never as a system message:
+    // the proxy strips those, and repo content carries user authority anyway.
+    const last = requests[0].body.messages.at(-1);
+    expect(last.role).toBe('user');
+    expect(last.content.endsWith('hello there')).toBe(true);
+    expect(last.content).toContain('Performance kit');
 });
 
 test('API errors surface in the chat and /nearai off restores the local agent path', async ({ page }) => {

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -475,7 +475,10 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
                 toggleEditors('presetsui', true);
                 componentRoot.querySelector('#preseteditortogglecheckbox').checked = true;
             }
-            window.insertRecording = () => insertMidiRecording(insertStringIntoEditor);
+            // Optional arg: steps-per-beat to snap the take to on the way in
+            // (the toolbar button passes nothing, keeping the raw timing).
+            window.insertRecording = (quantizeStepsPerBeat) =>
+                insertMidiRecording(insertStringIntoEditor, quantizeStepsPerBeat);
             try {
                 const eventlist = await compileMidiSong(songsource);
                 if (midiInstrumentNames.length > 0) {

--- a/wasmaudioworklet/midisequencer/editorfunctions.js
+++ b/wasmaudioworklet/midisequencer/editorfunctions.js
@@ -1,16 +1,28 @@
-import { getRecordedData as getWAMRecordedData } from '../webaudiomodules/wammanager.js';
+import { getRecordedData as getWAMRecordedData } from '../webaudiomodules/wammanager.js';
 import { getRecordedData as getMidiSynthRecordedData } from '../synth1/audioworklet/midisynthaudioworklet.js';
 import { RecordConverter } from './recording.js';
 import { recordingStartTimeMillis } from './songcompiler.js';
 import { bpm } from './pattern.js';
 
-export async function insertMidiRecording(insertStringIntoEditor) {
+/**
+ * Insert the captured take into the song editor as source.
+ *
+ * `quantizeStepsPerBeat` snaps note starts to that grid on the way in, so a take
+ * arrives already on the beat instead of needing a fix-up pass afterwards. Play
+ * latency alone makes a grid-perfect capture impossible — a note reaches the
+ * sequencer some milliseconds after it is struck — so this is the only way a
+ * FIRST take reads as quantized. Omit it to keep the raw timing, which is what
+ * the toolbar button does and stays the default. Note lengths and velocities
+ * are never touched, so the take still breathes.
+ */
+export async function insertMidiRecording(insertStringIntoEditor, quantizeStepsPerBeat) {
     let recordedData;
     if (window.audioworkletnode) {
         recordedData = await getMidiSynthRecordedData();
     } else {
         recordedData = await getWAMRecordedData();
     }
-    insertStringIntoEditor(new RecordConverter(recordedData, bpm,
-        recordingStartTimeMillis / 1000).trackerPatternData);
+    const converter = new RecordConverter(recordedData, bpm, recordingStartTimeMillis / 1000);
+    if (quantizeStepsPerBeat > 0) converter.quantize(quantizeStepsPerBeat);
+    insertStringIntoEditor(converter.trackerPatternData);
 }

--- a/wasmaudioworklet/studio-agent/client.js
+++ b/wasmaudioworklet/studio-agent/client.js
@@ -17,6 +17,7 @@ import { probeNote, probeNotes, probeWarnings } from '../audioprobe/instrumentpr
 import { parseNote, noteName } from '../audioprobe/audioanalysis.js';
 import { runAgentTurn, resolveDefaultBaseUrl, DEFAULT_MODEL, SERVERLESS_PROMPT_SUFFIX } from './nearai-core.js';
 import { SYSTEM_PROMPT } from './prompt.js';
+import { loadKit, formatKit } from './kit.js';
 
 const DEFAULT_PORT = 17891;
 const FAUST_DIR = 'faust/';
@@ -482,7 +483,7 @@ function reply(id, ok, result) {
   }
 }
 
-function sendChat(text) {
+async function sendChat(text) {
   // /nearai provider commands are handled locally and never enter the
   // conversation (the API key must not be persisted into the OPFS repo).
   if (text.startsWith('/nearai')) { handleNearaiCommand(text); return; }
@@ -505,9 +506,13 @@ function sendChat(text) {
   startAgentMessage();
   setBusy(true);
   startActivity();
+  // The server has no view of OPFS, so the project's kit has to travel from
+  // here. It rides on EVERY turn: the server builds the system prompt per
+  // query, and an unchanged prompt keeps the cached prefix intact.
+  const kit = (await loadKit()).text;
   // summary rides along so the server can seed a FRESH session from it when
   // the sessionId can't be resumed (SDK sessions are per-machine).
-  socket.send(JSON.stringify({ t: 'chat', text, sessionId, summary: sessionSummary }));
+  socket.send(JSON.stringify({ t: 'chat', text, sessionId, summary: sessionSummary, kit }));
 }
 
 // ---- NEAR AI serverless provider (no local studio-agent process) ------------
@@ -603,12 +608,19 @@ let nearaiMessages = null; // model-visible history (in-memory for iteration 1)
 
 async function runNearaiTurn(text) {
   const cfg = nearaiConfig();
+  let content = text;
   if (!nearaiMessages) {
     // In proxy mode the server injects the system prompt (and tools) —
     // sending them from here would be stripped anyway.
     nearaiMessages = cfg.proxy ? [] : [{ role: 'system', content: SYSTEM_PROMPT + SERVERLESS_PROMPT_SUFFIX }];
+    // ...and that includes a system message carrying the project kit, so the
+    // kit rides in as part of the FIRST user turn instead. That is its honest
+    // authority level anyway (repo content is the user talking), and merging
+    // it into the turn keeps the history strictly alternating.
+    const kit = formatKit((await loadKit()).text);
+    if (kit) content = `${kit}\n\n---\n\n${text}`;
   }
-  nearaiMessages.push({ role: 'user', content: text });
+  nearaiMessages.push({ role: 'user', content });
   setPhase(`${cfg.model.split('/').pop()} thinking…`);
   try {
     const { usage } = await runAgentTurn({

--- a/wasmaudioworklet/studio-agent/default-kit.md
+++ b/wasmaudioworklet/studio-agent/default-kit.md
@@ -1,0 +1,246 @@
+# Performance kit — generic starter
+
+This kit is in your context from the start of the session, so the sounds and
+wiring below need **no lookup**: write them straight out.
+
+Everything here is verified end to end with `tools/instrumenttest/render.mjs` —
+each `.dsp` transpiles, compiles into the real synth, and renders audio. Each
+generates only a voice class (no `<Name>Channel`), so all register with the
+plain `MidiChannel`.
+
+## Channel map
+
+| ch | name  | faust file        | class   |
+|----|-------|-------------------|---------|
+| 0  | kick  | `faust/kick.dsp`  | `Kick`  |
+| 1  | snare | `faust/snare.dsp` | `Snare` |
+| 2  | hihat | `faust/hihat.dsp` | `Hihat` |
+| 3  | pad   | `faust/pad.dsp`   | `Pad`   |
+| 4  | bass  | `faust/bass.dsp`  | `Bass`  |
+| 5  | lead  | `faust/lead.dsp`  | `Lead` + `LeadChannel` |
+
+Build only the channels the user asked for. "Give me a beat" is channels 0-2 and
+nothing else — do not add the pad, bass or lead uninvited.
+
+**There is no drum note map here.** Each drum has its own channel, so the note
+only sets `freq`: kick and snare pitch follow the note played, and the hihat
+ignores pitch entirely (it is filtered noise). Never tell the user "c3 is the
+kick" for these voices.
+
+**Octaves: `c4` is middle C, so `c2` is 32.7 Hz and `f1` is 21.8 Hz** — below
+audibility on most systems. Keep bass roots at `c2`/32.7 Hz or above.
+
+## Effects belong on the channel, not in the voice
+
+An echo, reverb or chorus written into `process` runs **per voice** and is torn
+down when that voice is released and recycled — measured: a 0.4s echo inside the
+voice was silent 0.5s after note-off, while the same echo as a channel effect
+still rang at 2s. Put it in an `effect = ...` declaration instead, which runs
+once over the channel's mixed voices (see `faust/lead.dsp` below). That also
+generates a `<Name>Channel` class you must register in place of `MidiChannel`.
+
+Expose timing as an `hslider` rather than hard-coding the BPM: sliders become
+channel parameters the song can set, so a tempo change does not mean re-writing
+the DSP.
+
+## Saturation — read this before writing any DSP
+
+Use this soft clipper:
+
+```
+sat(x) = x / (1.0 + abs(x));
+```
+
+**Do NOT use `tanh` or `ma.tanh`.** Bare `tanh` is not a Faust primitive
+(`undefined symbol`), and `ma.tanh` passes Faust but emits `tanhf`, which the
+AssemblyScript backend has no name for — so it fails at `compile` with
+`TS2304: Cannot find name 'tanhf'` *after* `write_faust` reported success.
+
+## Instruments (write these verbatim with `write_faust`)
+
+### kick — `write_faust('kick', ...)` → `Kick`
+```
+import("stdfaust.lib");
+freq = hslider("freq", 55, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.8, 0, 1, 0.01);
+pitchEnv = en.ar(0.001, 0.055, gate);
+ampEnv = en.ar(0.002, 0.32, gate);
+body = os.osc(freq + freq * 5 * pitchEnv);
+click = no.noise * en.ar(0.0005, 0.012, gate) * 0.35;
+sat(x) = x / (1.0 + abs(x));
+process = sat((body * ampEnv + click) * gain * 2.2) * 1.5;
+```
+Punchier: raise the `5` in `body` (bigger pitch drop). Longer tail: raise `0.32`.
+
+### snare — `write_faust('snare', ...)` → `Snare`
+```
+import("stdfaust.lib");
+freq = hslider("freq", 180, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.7, 0, 1, 0.01);
+tone = (os.osc(freq) + os.osc(freq * 1.6)) * 0.5 * en.ar(0.001, 0.11, gate);
+snap = (no.noise : fi.highpass(2, 1200)) * en.ar(0.001, 0.17, gate);
+process = (tone * 0.5 + snap * 0.7) * gain;
+```
+More crack: raise the `0.7` on `snap`. More body: raise the `0.5` on `tone`.
+
+### hihat — `write_faust('hihat', ...)` → `Hihat`
+```
+import("stdfaust.lib");
+freq = hslider("freq", 8000, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+process = (no.noise : fi.highpass(4, 7000)) * en.ar(0.001, 0.05, gate) * gain;
+```
+Open hat: raise the release `0.05` to ~0.25. Darker: lower the `7000`.
+
+### pad — `write_faust('pad', ...)` → `Pad`
+Detuned triple saw, for chord progressions.
+```
+import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.5, 0, 1, 0.01);
+det = 1.004;
+saws = (os.sawtooth(freq) + os.sawtooth(freq * det) + os.sawtooth(freq / det)) / 3;
+env = en.adsr(0.08, 0.3, 0.7, 0.45, gate);
+process = (saws : fi.lowpass(2, 1800)) * env * gain * 0.5;
+```
+Wider: raise `det` toward 1.01. Brighter: raise the `1800`. Slower swell: raise
+the attack `0.08`.
+
+### bass — `write_faust('bass', ...)` → `Bass`
+Punchy: saw+sine through an envelope-swept resonant lowpass, then saturation.
+```
+import("stdfaust.lib");
+freq = hslider("freq", 55, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.8, 0, 1, 0.01);
+env = en.adsr(0.005, 0.12, 0.6, 0.12, gate);
+fenv = en.ar(0.005, 0.18, gate);
+osc = os.sawtooth(freq) * 0.7 + os.osc(freq) * 0.5;
+cutoff = 60 + 2200 * fenv;
+sat(x) = x / (1.0 + abs(x));
+process = sat((osc : fi.resonlp(cutoff, 3, 1)) * env * gain * 2.4) * 1.1;
+```
+More punch: raise the `2200` (bigger sweep) or shorten `fenv`'s `0.18`. Dirtier:
+raise the `2.4` drive. Longer notes: raise the sustain `0.6`. The 2nd harmonic
+sits above the fundamental by design — that is what makes it audible on small
+speakers.
+
+### lead — `write_faust('lead', ...)` → `Lead` + `LeadChannel`
+Fat: three detuned saws plus a sub square, swept resonant lowpass, saturated,
+with a channel-level echo.
+```
+import("stdfaust.lib");
+freq = hslider("freq", 440, 20, 20000, 0.01);
+gate = button("gate");
+gain = hslider("gain", 0.7, 0, 1, 0.01);
+saws = (os.sawtooth(freq) + os.sawtooth(freq * 1.006) + os.sawtooth(freq * 0.994) + os.square(freq * 0.5) * 0.35) / 3.6;
+env = en.adsr(0.01, 0.2, 0.75, 0.25, gate);
+fenv = en.adsr(0.02, 0.25, 0.5, 0.25, gate);
+cutoff = 400 + 5000 * fenv;
+sat(x) = x / (1.0 + abs(x));
+process = sat((saws : fi.resonlp(cutoff, 4, 1)) * env * gain * 1.6) * 0.7;
+
+echotime = hslider("echotime", 0.402, 0.02, 1.2, 0.001);
+echofb = hslider("echofb", 0.5, 0, 0.95, 0.01);
+echomix = hslider("echomix", 0.4, 0, 1, 0.01);
+echo = + ~ (de.fdelay(131072, echotime * ma.SR) : *(echofb));
+effect = _ <: _, (echo : *(echomix)) :> _;
+```
+Because it declares `effect`, this one DOES generate `LeadChannel` — register it
+in place of `MidiChannel` (see the combiner below). `echotime` defaults to a
+dotted-8th at 112 BPM; the formula is `3 / stepsPerBeat * 60 / bpm`.
+Fatter: push the detune `1.006`/`0.994` further apart. Screamier: raise the
+resonance `4`. Softer: lower the `1.6` drive.
+
+**Do not raise the sub-square's `0.35` much.** It is an octave below the note,
+and at `0.6` it dominates the three saws — probing then reports a dominant of
+exactly half the played pitch (a4 sounds as a3). If you want more weight, widen
+the detune instead.
+
+These levels are balanced against each other as written (kick/snare/hihat all
+render around peak 0.11). If you change a drive or output scale, expect to
+rebalance the others.
+
+## synth.ts — the combiner (only the channels you built)
+
+```typescript
+import { midichannels, MidiChannel } from '../mixes/globalimports';
+import { Kick } from '../faust/kick';
+import { Snare } from '../faust/snare';
+import { Hihat } from '../faust/hihat';
+import { Pad } from '../faust/pad';
+import { Bass } from '../faust/bass';
+import { Lead, LeadChannel } from '../faust/lead';
+
+export function initializeMidiSynth(): void {
+    midichannels[0] = new MidiChannel(2, (channel: MidiChannel) => new Kick(channel));
+    midichannels[1] = new MidiChannel(2, (channel: MidiChannel) => new Snare(channel));
+    midichannels[2] = new MidiChannel(3, (channel: MidiChannel) => new Hihat(channel));
+    midichannels[3] = new MidiChannel(8, (channel: MidiChannel) => new Pad(channel));
+    midichannels[4] = new MidiChannel(2, (channel: MidiChannel) => new Bass(channel));
+    midichannels[5] = new LeadChannel(4, (channel: MidiChannel) => new Lead(channel));
+}
+export function postprocess(): void {}
+```
+
+## Song skeleton
+
+Eight bars at 4/4. Dm → A#maj → F → C, one bar each, played twice. Note the
+shape: everything that sounds together is a plain call, and the **kick is
+awaited and comes last**.
+
+```javascript
+setBPM(112);
+
+addInstrument('kick');   // 0
+addInstrument('snare');  // 1
+addInstrument('hihat');  // 2
+addInstrument('pad');    // 3
+addInstrument('bass');   // 4
+addInstrument('lead');   // 5
+
+const kick  = createTrack(0);
+const snare = createTrack(1);
+const hihat = createTrack(2);
+const pad   = createTrack(3);
+const bass  = createTrack(4);
+
+pad.steps(1, [
+    [d4(3.95), f4(3.95), a4(3.95)], , , ,
+    [as3(3.95), d4(3.95), f4(3.95)], , , ,
+    [f3(3.95), a3(3.95), c4(3.95)], , , ,
+    [c4(3.95), e4(3.95), g4(3.95)], , , ,
+].repeat(1));
+
+bass.steps(2, [
+    d2, , d2, , d2, , d2, ,
+    as2, , as2, , as2, , as2, ,
+    f2, , f2, , f2, , f2, ,
+    c2, , c2, , c2, , c2, ,
+].repeat(1));
+
+hihat.steps(2, [ , fs3, , fs3, , fs3, , fs3 ].repeat(7));
+snare.steps(1, [ , d3, , d3 ].repeat(7));
+await kick.steps(1, [ c2, c2, c2, c2 ].repeat(7));
+
+loopHere();
+```
+
+All five parts are 32 beats: `.repeat(n)` gives n+1 copies, so `.repeat(7)` on a
+4-beat pattern is 8 bars and `.repeat(1)` on a 16-beat pattern is the same 32.
+Chord durations are `3.95`, not `4.0`, so a tone held into a chord sharing that
+pitch is not cut.
+
+## Workflow
+
+1. `write_faust` each instrument the request needs — one call each, not a batch.
+2. `set_synth` the combiner (or `edit_synth` to add one channel to an existing one).
+3. Write or edit the song. Adding a part for an instrument that already exists is
+   a **song edit only** — do not re-run `write_faust`.
+4. `compile`.
+5. `probe_instrument` the channel you built and quote the numbers before saying
+   it is ready. "compiled OK" is not evidence of sound.

--- a/wasmaudioworklet/studio-agent/kit.js
+++ b/wasmaudioworklet/studio-agent/kit.js
@@ -1,0 +1,97 @@
+// The performance kit: agent instructions that travel WITH the project.
+//
+// A project repo may carry an `AGENT.md` describing the instruments, style and
+// conventions for that piece. It is delivered to the model as context at the
+// START of the session, never as something the agent has to go and read:
+// measured over real sessions, turns that began with discovery tool calls ran
+// ~2x the median and ~3x the p90 of turns that could act immediately. A kit
+// that costs a `read_repo_file` round-trip would give most of that back.
+//
+// Two deliveries, because the two providers have different trust boundaries:
+//   • local studio-agent — the kit rides on the chat message and the server
+//     appends it to the system prompt (the user's own machine, own repo, and
+//     the server cannot see OPFS at all, so the browser must send it).
+//   • NEAR AI — the shared-key proxy deliberately STRIPS client system
+//     messages and injects its own prompt, so the kit goes in as the first
+//     USER message instead. That is the honest authority level anyway: repo
+//     content is the user talking, not operator policy.
+//
+// Falls back to a generic starter kit so the app is usable with no repo.
+
+export const KIT_FILE = 'AGENT.md';
+// Kept well inside the proxy's 300k-char conversation cap — the kit is resent
+// on every turn, so a bloated one is paid for over and over.
+export const MAX_KIT_CHARS = 20000;
+
+const DEFAULT_KIT_URL = new URL('./default-kit.md', import.meta.url);
+
+let cached = null; // { text, source } once resolved
+
+/**
+ * Load the project's kit, falling back to the shipped default.
+ * `readFile`/`fetchFn` are injectable so the logic can be unit-tested outside a
+ * browser; production callers pass nothing.
+ * @returns {Promise<{ text: string, source: 'repo' | 'default' | 'none' }>}
+ */
+export async function loadKit({ readFile, fetchFn = fetch } = {}) {
+    if (cached) return cached;
+
+    // Imported lazily: wasmgitclient pulls in browser-only modules, and keeping
+    // it off the module's top level is what lets this file be unit-tested.
+    const read = readFile
+        || (async (name) => (await import('../wasmgit/wasmgitclient.js')).readfile(name));
+
+    let text = '';
+    let source = 'none';
+
+    try {
+        const fromRepo = await read(KIT_FILE);
+        if (fromRepo && fromRepo.trim()) {
+            text = fromRepo;
+            source = 'repo';
+        }
+    } catch {
+        // No AGENT.md in this project (or no repo at all) — fall through.
+    }
+
+    if (!text) {
+        try {
+            const res = await fetchFn(DEFAULT_KIT_URL);
+            if (res.ok) {
+                const fallback = await res.text();
+                if (fallback.trim()) {
+                    text = fallback;
+                    source = 'default';
+                }
+            }
+        } catch {
+            // Serve without a kit rather than failing the turn.
+        }
+    }
+
+    if (text.length > MAX_KIT_CHARS) {
+        text = text.slice(0, MAX_KIT_CHARS) + '\n\n[kit truncated]';
+    }
+
+    cached = { text, source };
+    return cached;
+}
+
+/** Drop the cache so the next turn re-reads the repo (after an edit/clone). */
+export function resetKit() {
+    cached = null;
+}
+
+/**
+ * Wrap kit text for delivery. The heading tells the model what authority the
+ * content carries, which matters most on the NEAR AI path where the kit
+ * arrives as an ordinary user message.
+ */
+export function formatKit(text) {
+    if (!text || !text.trim()) return '';
+    return `## Project kit (from the project's ${KIT_FILE})\n\n` +
+        `These are the user's instructions for THIS project — instrument sources, ` +
+        `channel layout and conventions. Prefer them over generic defaults, and ` +
+        `use them directly instead of searching the repository for the same ` +
+        `information.\n\n${text}`;
+}

--- a/wasmaudioworklet/studio-agent/kit.test.mjs
+++ b/wasmaudioworklet/studio-agent/kit.test.mjs
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadKit, resetKit, formatKit, KIT_FILE, MAX_KIT_CHARS } from './kit.js';
+
+// The kit is the project's AGENT.md, delivered into the model's context at the
+// start of every turn instead of being discovered with a tool call. These pin
+// the selection rules; the browser→server delivery is covered by
+// e2e/studio-agent-kit.spec.js.
+
+const DEFAULT_TEXT = '# Performance kit — generic starter\n\nfallback body\n';
+const okFetch = async () => ({ ok: true, text: async () => DEFAULT_TEXT });
+const missingFetch = async () => ({ ok: false, text: async () => '' });
+const noRepoFile = async () => { throw new Error('ENOENT'); };
+
+test.beforeEach(() => resetKit());
+
+test("the project's AGENT.md wins over the shipped default", async () => {
+    const kit = await loadKit({
+        readFile: async (name) => {
+            assert.equal(name, KIT_FILE);
+            return '# My performance\n\nchannel 0 is the kick.\n';
+        },
+        fetchFn: okFetch,
+    });
+    assert.equal(kit.source, 'repo');
+    assert.match(kit.text, /My performance/);
+});
+
+test('falls back to the shipped default when the repo has no AGENT.md', async () => {
+    const kit = await loadKit({ readFile: noRepoFile, fetchFn: okFetch });
+    assert.equal(kit.source, 'default');
+    assert.match(kit.text, /generic starter/);
+});
+
+test('an empty or whitespace-only AGENT.md is treated as absent', async () => {
+    const kit = await loadKit({ readFile: async () => '   \n\n', fetchFn: okFetch });
+    assert.equal(kit.source, 'default');
+});
+
+test('serves no kit rather than failing the turn when both sources are gone', async () => {
+    const kit = await loadKit({ readFile: noRepoFile, fetchFn: missingFetch });
+    assert.equal(kit.source, 'none');
+    assert.equal(kit.text, '');
+});
+
+test('a runaway kit is truncated — it is resent on every turn', async () => {
+    const kit = await loadKit({ readFile: async () => 'x'.repeat(MAX_KIT_CHARS * 2), fetchFn: okFetch });
+    assert.ok(kit.text.length < MAX_KIT_CHARS + 100, 'capped near the limit');
+    assert.match(kit.text, /\[kit truncated\]$/);
+});
+
+test('the result is cached — the repo is not re-read every turn', async () => {
+    let reads = 0;
+    const readFile = async () => { reads++; return '# once\n'; };
+    await loadKit({ readFile, fetchFn: okFetch });
+    await loadKit({ readFile, fetchFn: okFetch });
+    assert.equal(reads, 1);
+    resetKit();
+    await loadKit({ readFile, fetchFn: okFetch });
+    assert.equal(reads, 2);
+});
+
+test('formatKit labels the content as the user\'s project instructions', async () => {
+    const out = formatKit('channel 0 is the kick.');
+    assert.match(out, /AGENT\.md/);
+    assert.match(out, /channel 0 is the kick\./);
+    // Steers away from the discovery round-trip the kit exists to remove.
+    assert.match(out, /instead of searching/);
+});
+
+test('formatKit returns nothing for an empty kit, so no empty section is sent', () => {
+    assert.equal(formatKit(''), '');
+    assert.equal(formatKit('   '), '');
+});

--- a/wasmaudioworklet/studio-agent/tools-core.js
+++ b/wasmaudioworklet/studio-agent/tools-core.js
@@ -68,6 +68,13 @@ export function songSourceWarnings(source) {
 const NOTE_ON = 0x90;
 const CONTROL_CHANGE = 0xb0;
 const END_OF_SONG = -1;
+// The sequencer encodes its own control messages as NEGATIVE single-byte
+// statuses: -1 loop/end, -2 startRecording, -3 stopRecording, -4 broadcastSend,
+// -5 broadcastWait (midisequencer/audioworkletprocessorsequencer.js). They are
+// not MIDI, so `status & 0x0f` on them mints phantom channels — a song with
+// recording markers reported ch13 and ch14 "no notes" (-3 & 0x0f = 13,
+// -2 & 0x0f = 14), and broadcast sync would add ch11/ch12.
+const isSequencerControl = (status) => status < 0;
 
 // eventlist: [{ time (ms), message: [status, data1, data2] }], as returned by
 // compileSong. bpm is needed to express times in beats; song BPM lives inside
@@ -83,7 +90,8 @@ export function summarizeSongEvents(eventlist, bpm = 110, { beatsPerBar = 4, ins
     if (status === undefined) continue;
     const beat = toBeat(evt.time);
     lengthBeats = Math.max(lengthBeats, beat);
-    if (status === END_OF_SONG) continue;
+    // Control messages still extend the song's length, but must not become channels.
+    if (isSequencerControl(status)) continue;
 
     const channel = status & 0x0f;
     let c = byChannel.get(channel);
@@ -164,7 +172,7 @@ function findNoteCollisions(eventlist, toBeat, minHeldBeats = 1) {
   const byKey = new Map();
   for (const evt of eventlist) {
     const [status, note, velocity] = evt.message || [];
-    if (status === undefined || status === END_OF_SONG) continue;
+    if (status === undefined || isSequencerControl(status)) continue;
     const type = status & 0xf0;
     const isOn = type === NOTE_ON && velocity > 0;
     const isOff = type === 0x80 || (type === NOTE_ON && velocity === 0);
@@ -302,7 +310,19 @@ export function songBpmFromSource(source, fallback = 110) {
 // import and how to register the channel. Uses the base MidiChannel when no
 // <Name>Channel was generated (fixes the recurring "no exported member" error).
 export function faustRegistrationHint(ts, stem) {
-  const classes = [...ts.matchAll(/export class (\w+)/g)].map((m) => m[1]);
+  const exported = [...ts.matchAll(/export class (\w+)/g)].map((m) => m[1]);
+  // The transpiler compiles the native Faust class as `<Name>Dsp` (and
+  // `<Name>EffectDsp`) so the thin wrappers can keep the public names
+  // `<Name>`/`<Name>Channel` — see faust/transpile-core.js. Both are exported,
+  // but only the wrappers are the API. Reporting the internal one first made
+  // the agent register `new KickDsp(channel)`, which fails to compile with
+  // "TS2554: Expected 0 arguments, but got 1". Drop a `*Dsp` name only when
+  // its public wrapper is actually present, so an instrument genuinely called
+  // e.g. "mydsp" still reports its own class.
+  const classes = exported.filter((c) => {
+    const m = /^(\w+?)(?:Effect)?Dsp$/.exec(c);
+    return !(m && exported.includes(m[1]));
+  });
   const voice = classes.find((c) => !/Channel$/.test(c)) || 'Xxx';
   const chan = classes.find((c) => /Channel$/.test(c));
   const reg = chan

--- a/wasmaudioworklet/studio-agent/tools-core.test.mjs
+++ b/wasmaudioworklet/studio-agent/tools-core.test.mjs
@@ -341,3 +341,53 @@ addInstrument('hihat');`;
   assert.deepEqual(declaredInstruments(src), ['piano', 'kick', 'hihat']);
   assert.deepEqual(declaredInstruments(''), []);
 });
+
+test('faustRegistrationHint reports the public wrapper, not the native <Name>Dsp class', () => {
+  // What the in-browser transpiler actually emits: the native Faust class
+  // compiled as <Name>Dsp plus the thin public wrapper.
+  const ts = 'export class KickDsp {\n}\nexport class Kick extends MidiVoice {\n}\n';
+  const hint = faustRegistrationHint(ts, 'kick');
+  assert.deepEqual(hint.classes, ['Kick']);
+  assert.equal(hint.voice, 'Kick');
+  assert.ok(!hint.message.includes('KickDsp'), 'must not name the internal class');
+});
+
+test('faustRegistrationHint keeps a <Name>Channel and drops the effect internals', () => {
+  const ts = 'export class BassDsp {\n}\nexport class BassEffectDsp {\n}\n'
+    + 'export class Bass extends MidiVoice {\n}\nexport class BassChannel extends MidiChannel {\n}\n';
+  const hint = faustRegistrationHint(ts, 'bass');
+  assert.deepEqual(hint.classes, ['Bass', 'BassChannel']);
+  assert.equal(hint.voice, 'Bass');
+  assert.equal(hint.chan, 'BassChannel');
+});
+
+test('faustRegistrationHint keeps a genuine class whose name just ends in Dsp', () => {
+  // No `Mydsp` wrapper exported, so `MydspDsp` is not an internal to drop.
+  const ts = 'export class MydspDsp extends MidiVoice {\n}\n';
+  assert.deepEqual(faustRegistrationHint(ts, 'mydsp').classes, ['MydspDsp']);
+});
+
+test('summarizeSongEvents ignores sequencer control messages, not just the end marker', () => {
+  // startRecording/stopRecording are single-byte -2/-3. Read as MIDI they are
+  // `& 0x0f` = 14 and 13, which used to appear as phantom "no notes" channels.
+  const events = [
+    { time: 0, message: [-2] },              // startRecording
+    { time: 0, message: [0x90, 60, 100] },   // ch0 note on
+    { time: 500, message: [0x80, 60, 0] },
+    { time: 1000, message: [-4] },           // broadcastSend
+    { time: 1000, message: [-5] },           // broadcastWait
+    { time: 2000, message: [-3] },           // stopRecording
+    { time: 2000, message: [-1] },           // end of song
+  ];
+  const s = summarizeSongEvents(events, 120, { instruments: ['kick'] });
+  assert.deepEqual(s.channels.map((c) => c.channel), [0], 'only the real channel');
+  assert.equal(s.channels[0].notes, 1);
+});
+
+test('summarizeSongEvents still takes song length from the end marker', () => {
+  const events = [
+    { time: 0, message: [0x90, 60, 100] },
+    { time: 4000, message: [-1] }, // end marker at beat 8 @120bpm
+  ];
+  assert.equal(Math.round(summarizeSongEvents(events, 120).lengthBeats), 8);
+});


### PR DESCRIPTION
Adds a **project kit** to the studio agent, fixes two bugs that were actively sending it down wrong paths, and includes the IEEE IS² 2026 performance plan these were built for.

## The kit

A project repo can carry an `AGENT.md` describing its instruments, channel layout and conventions. It is delivered into the model's context at the **start of every turn** rather than discovered with tool calls. A generic default ships with the app for projects that have none.

Why it matters, from 26 real sessions (112 turns):

| turn shape | n | median | p90 |
|---|---|---|---|
| zero discovery calls | 38 | **57s** | **155s** |
| ≥1 discovery call | 68 | 118s | 436s |

35% of all tool calls were discovery. A rehearsal run with the kit in place did 9 turns at a **51s median**, with 2 discovery calls out of 50 — both `get_song` before an edit, which is the kind worth keeping.

Delivery differs per provider because their trust boundaries do:

- **local studio-agent** — rides on the chat message; the server appends it to the system prompt. The server has no view of OPFS, so the browser has to send it regardless.
- **NEAR AI** — the shared-key proxy deliberately strips client system messages, so the kit is merged into the first *user* turn. That is its honest authority level: repo content is the user talking, not operator policy.

Two further latency fixes in the same area: `alwaysLoad: true` on the studio MCP server (deferred tool schemas cost a `ToolSearch` round-trip — 113s median vs 79s), and an `effort` setting (default `medium`, `STUDIO_AGENT_EFFORT` to override).

## Bug fixes

Both were caught by watching a live session, and both cost the agent a wasted round-trip:

- **`faustRegistrationHint` recommended the internal class.** The transpiler compiles the native Faust class as `<Name>Dsp`; both it and the public wrapper are exported, so `write_faust` said "exports: KickDsp, Kick … then `new KickDsp(channel)`". The agent obeyed and compile failed with `TS2554`.
- **`summarizeSongEvents` invented channels from sequencer control messages.** Only `-1` was skipped, so a song with recording markers reported phantom `ch13`/`ch14` (`-3 & 0x0f` = 13, `-2 & 0x0f` = 14). Those feed the "declared but plays no notes" warning, which is otherwise a useful signal.

## Verification

- **65 unit tests** (13 new) and **3 e2e tests**, all passing.
- The default kit's six instruments are verified end to end with `tools/instrumenttest/render.mjs` — each transpiles, compiles into the real synth, and renders audio at balanced levels (drums all near peak 0.11).
- That harness caught two traps now documented in the kit: `ma.tanh` passes Faust but emits `tanhf`, which AssemblyScript has no name for (fails at compile *after* `write_faust` reports success); and effects written into `process` run per voice and die with it — a 0.4s echo inside the voice measured **silent 0.5s after note-off**, while the same echo as a channel `effect` still rang at 2s.

## Not included

The pad sits ~9 dB under the drums in the default kit. Real, but it wants an ear on it before I pick a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)