### PR TITLE
Studio agent: a stop button for a running turn

### DIFF
--- a/tools/studio-agent/server.mjs
+++ b/tools/studio-agent/server.mjs
@@ -92,9 +92,24 @@ function safeResolve(p) {
 }
 
 // ---- WebSocket plumbing: one browser at a time -----------------------------
-let pending = new Map();   // id -> { resolve }
+let pending = new Map();   // id -> { resolve, started, fail }
 let nextId = 1;
 let chatChain = Promise.resolve(); // serialize chat turns (and post-turn auto-compact)
+// The turn currently in flight, so the browser's stop button can end it. A live
+// set cannot wait out a turn that has gone wrong: the SDK's own interrupt() is
+// streaming-input only, but Options.abortController works with a plain prompt.
+let currentTurn = null;    // { controller, aborted }
+
+// Abort the running turn: tear down the query, then settle every tool call
+// still waiting on the browser. Without that second half the SDK's tool handler
+// keeps awaiting a promise that will never resolve.
+function abortCurrentTurn() {
+  if (!currentTurn || currentTurn.aborted) return false;
+  currentTurn.aborted = true;
+  try { currentTurn.controller.abort(); } catch { /* already torn down */ }
+  for (const entry of [...pending.values()]) entry.fail('turn stopped by the user');
+  return true;
+}
 
 function callBrowser(ws, name, args) {
   return new Promise((resolveCall, rejectCall) => {
@@ -107,6 +122,7 @@ function callBrowser(ws, name, args) {
       rejectCall(new Error(msg));
     };
     const entry = {
+      fail: (msg) => { if (timer) clearTimeout(timer); fail(msg); },
       resolve: (res) => { if (timer) clearTimeout(timer); pending.delete(id); resolveCall(res); },
       // Browser acked that execution began (the serial queue reached this call):
       // swap the queue-wait timer for the per-tool run timer.
@@ -218,10 +234,16 @@ async function handleChat(ws, { text, sessionId, summary, kit }, isRetry = false
     kit ? `kit ${kit.length} chars` : 'NO KIT');
   logEvent({ kind: 'chat', sessionId: sid, resumed: !!sessionId, text, kitChars: kit ? kit.length : 0 });
 
+  // One controller per turn; the stop button aborts through it. A retry reuses
+  // the same slot, so an abort during the retry still lands.
+  const controller = new AbortController();
+  currentTurn = { controller, aborted: false };
+
   try {
     for await (const m of query({
       prompt: text,
       options: {
+        abortController: controller,
         resume: sessionId || undefined,
         model: MODEL,
         effort: EFFORT,
@@ -278,11 +300,26 @@ async function handleChat(ws, { text, sessionId, summary, kit }, isRetry = false
       }
     }
     dlog('query loop ended');
+    // An aborted query can simply END rather than throw, so the stopped case is
+    // handled here as well as in the catch below.
+    if (currentTurn?.aborted) {
+      dlog('turn stopped by the user');
+      send({ t: 'stopped', sessionId: sid });
+      return;
+    }
     if (sid && contextTokens > COMPACT_THRESHOLD) {
       await autoCompact(send, sid, contextTokens, systemPrompt);
     }
   } catch (e) {
     const emsg = String(e?.message || e);
+    // A stop is not a failure: report it as one and the agent looks broken, and
+    // the chat fills with an error the user deliberately caused.
+    if (currentTurn?.aborted) {
+      dlog('turn stopped by the user (query threw:', emsg.slice(0, 60), ')');
+      logEvent({ kind: 'stopped', sessionId: sid });
+      send({ t: 'stopped', sessionId: sid });
+      return;
+    }
     // SDK sessions are per-machine: a repo opened on another machine carries a
     // sessionId this machine has never seen. Start FRESH, seeded with the
     // compact summary the browser keeps in the repo (studioagent-session.json).
@@ -298,6 +335,9 @@ async function handleChat(ws, { text, sessionId, summary, kit }, isRetry = false
     dlog('EXCEPTION', emsg);
     logEvent({ kind: 'error', sessionId: sid, error: emsg });
     send({ t: 'error', error: emsg });
+  } finally {
+    // Only clear the slot if this turn still owns it — a retry replaced it.
+    if (currentTurn?.controller === controller) currentTurn = null;
   }
 }
 
@@ -379,6 +419,11 @@ wss.on('connection', (ws) => {
       if (p && typeof p.started === 'function') p.started();
     } else if (msg.t === 'chat') {
       chatChain = chatChain.then(() => handleChat(ws, msg));
+    } else if (msg.t === 'abort') {
+      const stopped = abortCurrentTurn();
+      dlog(stopped ? 'ABORT requested by user' : 'abort requested but no turn is running');
+      logEvent({ kind: 'abort', requested: true, stopped });
+      if (ws.readyState === ws.OPEN) ws.send(JSON.stringify({ t: 'aborted', stopped }));
     }
   });
   ws.on('close', () => { clearInterval(keepalive); console.log('  browser disconnected'); });

--- a/wasmaudioworklet/app.html.js
+++ b/wasmaudioworklet/app.html.js
@@ -101,6 +101,8 @@ export default /*html*/ `<link rel="stylesheet" href="https://cdnjs.cloudflare.c
       <textarea id="studioagentinput" rows="2"
         placeholder="Ask the studio agent…  e.g. 'make a song with a four-on-the-floor beat and a bassline'"></textarea>
       <button type="submit" id="studioagentsend">Send</button>
+      <button type="button" id="studioagentstop" style="display: none"
+        title="stop the current turn — the music keeps playing">Stop</button>
     </form>
   </div>
 

--- a/wasmaudioworklet/e2e/studio-agent-abort.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-abort.spec.js
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test';
+import ws from 'ws';
+import { waitForAppReady, waitForStudioAgentTools, clearOPFS } from './near-git-helpers.js';
+
+// Stopping a running turn. Nothing in the system could do this before: the
+// Agent SDK's own interrupt() is streaming-input only, and the studio agent
+// sends a plain prompt, so a turn that went wrong ran to completion. Real
+// sessions had turns of 10+ minutes. During a live set that is the difference
+// between losing a bar and losing the performance.
+//
+// These drive the CLIENT half against a mock agent server: the stop button
+// appears only while a turn is running, sends `abort`, and a `stopped` reply
+// clears the busy state without looking like a failure.
+//
+// No NEAR sandbox needed: an unregistered `?gitrepo=` falls back to local OPFS.
+
+const REPO = 'abort-e2e-test';
+
+function startMockAgentServer() {
+    const wss = new ws.Server({ port: 0 });
+    const state = { socket: null, messages: [] };
+    wss.on('connection', (socket) => {
+        state.socket = socket;
+        socket.on('close', () => { if (state.socket === socket) state.socket = null; });
+        socket.on('message', (data) => {
+            let msg;
+            try { msg = JSON.parse(data.toString()); } catch { return; }
+            state.messages.push(msg);
+        });
+    });
+    const waitForClient = async (timeoutMs = 30000) => {
+        const t0 = Date.now();
+        while (!(state.socket && state.socket.readyState === ws.OPEN)) {
+            if (Date.now() - t0 > timeoutMs) throw new Error('no live studio-agent client connection');
+            await new Promise((r) => setTimeout(r, 100));
+        }
+    };
+    const waitFor = async (type, timeoutMs = 15000) => {
+        const t0 = Date.now();
+        for (;;) {
+            const hit = state.messages.find((m) => m.t === type);
+            if (hit) return hit;
+            if (Date.now() - t0 > timeoutMs) throw new Error(`client never sent "${type}"`);
+            await new Promise((r) => setTimeout(r, 50));
+        }
+    };
+    return {
+        state, waitForClient, waitFor,
+        send: (obj) => state.socket?.send(JSON.stringify(obj)),
+        port: () => wss.address().port,
+        close: () => new Promise((resolve) => wss.close(resolve)),
+    };
+}
+
+const stopButton = (page) => page.locator('#studioagentstop');
+const chatLog = (page) => page.locator('#studioagentlog');
+
+async function openChat(page, mock) {
+    await page.addInitScript((port) => { window.STUDIO_AGENT_PORT = port; }, mock.port());
+    await page.goto(`http://localhost:8080/?gitrepo=${REPO}`);
+    await waitForAppReady(page);
+    await waitForStudioAgentTools(page);
+    await mock.waitForClient();
+    await page.evaluate(() => window.toggleStudioAgent(true));
+}
+
+async function ask(page, text) {
+    await page.evaluate((t) => {
+        const shadow = document.querySelector('app-javascriptmusic').shadowRoot;
+        shadow.getElementById('studioagentinput').value = t;
+        shadow.getElementById('studioagentform').requestSubmit();
+    }, text);
+}
+
+test.describe('studio-agent stop button', () => {
+    let mock;
+
+    test.beforeEach(() => { mock = startMockAgentServer(); });
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, REPO);
+        await mock.close();
+    });
+
+    test('appears only while a turn is running, and asks the server to stop', async ({ page }) => {
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await openChat(page, mock);
+
+        // Idle: nothing to stop.
+        await expect(stopButton(page)).toBeHidden();
+
+        await ask(page, 'build me something slow');
+        await mock.waitFor('chat');
+        await expect(stopButton(page)).toBeVisible();
+
+        await stopButton(page).click();
+        const abort = await mock.waitFor('abort');
+        expect(abort.t).toBe('abort');
+
+        // The server confirms the turn ended; the UI must leave the busy state.
+        mock.send({ t: 'stopped' });
+        await expect(stopButton(page)).toBeHidden();
+        await expect(chatLog(page)).toContainText('stopped');
+    });
+
+    test('a stopped turn is not reported as an error', async ({ page }) => {
+        await openChat(page, mock);
+        await ask(page, 'something long');
+        await mock.waitFor('chat');
+        await stopButton(page).click();
+        await mock.waitFor('abort');
+        mock.send({ t: 'stopped' });
+
+        await expect(chatLog(page)).toContainText('stopped');
+        // "⚠" is the error prefix — a deliberate stop must never render as one.
+        await expect(chatLog(page)).not.toContainText('⚠');
+    });
+
+    test('work the agent already reported is kept when the turn is stopped', async ({ page }) => {
+        await openChat(page, mock);
+        await ask(page, 'start explaining');
+        await mock.waitFor('chat');
+
+        mock.send({ t: 'text', text: 'Here is what I found so far.' });
+        await expect(chatLog(page)).toContainText('Here is what I found so far.');
+
+        await stopButton(page).click();
+        await mock.waitFor('abort');
+        mock.send({ t: 'stopped' });
+
+        // Stop ends the turn; it does not throw away what was already said.
+        await expect(chatLog(page)).toContainText('Here is what I found so far.');
+        await expect(stopButton(page)).toBeHidden();
+    });
+
+    test('Escape stops the turn without reaching for the mouse', async ({ page }) => {
+        await openChat(page, mock);
+        await ask(page, 'a long one');
+        await mock.waitFor('chat');
+
+        await page.locator('#studioagentinput').press('Escape');
+        const abort = await mock.waitFor('abort');
+        expect(abort.t).toBe('abort');
+    });
+});

--- a/wasmaudioworklet/studio-agent/client.js
+++ b/wasmaudioworklet/studio-agent/client.js
@@ -428,6 +428,20 @@ async function onMessage(msg) {
     case 'freshsession': // resume failed (e.g. repo opened on another machine)
       addLine('tool', '— previous session not on this machine; started fresh from the saved summary —');
       break;
+    case 'aborted': // the server acknowledged the stop request
+      if (!msg.stopped) addLine('tool', '— nothing was running —');
+      break;
+    case 'stopped': { // the turn actually ended because it was stopped
+      // Keep whatever the agent had already said: the work it completed before
+      // the stop is real, and losing it would make Stop feel destructive.
+      const partial = agentMsgEl ? agentMsgEl.textContent : '';
+      if (partial) { conversation.push({ role: 'agent', text: partial }); saveSession(); }
+      addLine('tool', '— stopped —');
+      finishAgentMessage();
+      stopActivity('stopped');
+      setBusy(false);
+      break;
+    }
     case 'error':
       addLine('error', `⚠ ${msg.error}`);
       finishAgentMessage();
@@ -605,9 +619,11 @@ async function runNearaiServerlessTool(name, args) {
 }
 
 let nearaiMessages = null; // model-visible history (in-memory for iteration 1)
+let nearaiAbort = null;    // AbortController for the turn in flight
 
 async function runNearaiTurn(text) {
   const cfg = nearaiConfig();
+  nearaiAbort = new AbortController();
   let content = text;
   if (!nearaiMessages) {
     // In proxy mode the server injects the system prompt (and tools) —
@@ -624,7 +640,9 @@ async function runNearaiTurn(text) {
   setPhase(`${cfg.model.split('/').pop()} thinking…`);
   try {
     const { usage } = await runAgentTurn({
-      fetchFn: (...a) => fetch(...a),
+      // The signal rides on every request of the turn, so Stop lands mid-loop
+      // rather than only between tool calls.
+      fetchFn: (url, init) => fetch(url, { ...init, signal: nearaiAbort.signal }),
       baseUrl: cfg.baseUrl,
       apiKey: cfg.apiKey,
       model: cfg.model,
@@ -647,10 +665,18 @@ async function runNearaiTurn(text) {
     finishAgentMessage();
     stopActivity(`done ✓ (${usage?.total_tokens ?? '?'} tokens)`);
   } catch (e) {
-    addLine('error', `⚠ ${e?.message || e}`);
-    finishAgentMessage();
-    stopActivity('error ✗');
+    // A user-requested stop is not a failure — don't report it as one.
+    if (e?.name === 'AbortError' || nearaiAbort?.signal.aborted) {
+      addLine('tool', '— stopped —');
+      finishAgentMessage();
+      stopActivity('stopped');
+    } else {
+      addLine('error', `⚠ ${e?.message || e}`);
+      finishAgentMessage();
+      stopActivity('error ✗');
+    }
   }
+  nearaiAbort = null;
   setBusy(false);
 }
 
@@ -662,6 +688,24 @@ function setStatus(s) { const e = el('studioagentstatus'); if (e) e.textContent 
 function setBusy(b) {
   const send = el('studioagentsend');
   if (send) { send.disabled = b; send.textContent = b ? '…' : 'Send'; }
+  // Stop is only offered while a turn is actually running.
+  const stop = el('studioagentstop');
+  if (stop) { stop.style.display = b ? '' : 'none'; stop.disabled = false; stop.textContent = 'Stop'; }
+}
+
+// Stop the running turn. The audio graph is untouched — whatever is playing
+// keeps playing; only the agent's turn ends. That is the whole point on stage:
+// a turn that has gone wrong costs a bar of vamping, not the performance.
+function abortTurn() {
+  const stop = el('studioagentstop');
+  if (stop) { stop.disabled = true; stop.textContent = 'stopping…'; }
+  if (nearaiConfig()) {
+    if (nearaiAbort) nearaiAbort.abort();
+    return;
+  }
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ t: 'abort' }));
+  }
 }
 
 function addLine(kind, text) {
@@ -737,7 +781,11 @@ export function initStudioAgent(shadowRoot) {
   });
   input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); form.requestSubmit(); }
+    // Escape stops a running turn without reaching for the mouse — the one
+    // interaction worth having a shortcut for when a set is in progress.
+    if (e.key === 'Escape') { e.preventDefault(); abortTurn(); }
   });
+  el('studioagentstop').addEventListener('click', abortTurn);
 
   loadSession(); // restore prior conversation from the OPFS repo (if any)
   connect();


### PR DESCRIPTION
Closes the last single point of failure identified in the [IS² performance plan](wasmaudioworklet/docs/presentation/is2-2026-performance-plan.md) review: **nothing could end a turn once it started.**

The Agent SDK's `interrupt()` is documented for streaming input only, and the studio agent sends a plain string prompt — so a turn that went wrong ran to completion. Real session logs recorded turns of 10+ minutes. During a live set that is the difference between losing a bar and losing the performance.

## Does it actually work?

`Options.abortController` does accept a plain prompt, but the docs don't promise it stops one, so I verified it directly against the SDK before building the UI:

```
[3.0s] aborting…
ended after 5.0s via threw: Error (5 messages)
PASS — abort stopped the query promptly
```

Two things that changed the implementation:

- **~2s to tear down**, not instant. Fine for the use case, worth knowing.
- **It throws a generic `Error`, not an `AbortError`** — so the server keys off its own per-turn flag rather than sniffing the error type.

## Server

One `AbortController` per turn; `{t:'abort'}` over the socket aborts it. Critically, it also **fails every tool call still waiting on the browser** — without that the SDK's tool handler keeps awaiting a promise that can never resolve.

An aborted query can *end* rather than throw, so both paths report `{t:'stopped'}`. Neither is logged as an error: a deliberate stop isn't a failure, and reporting it as one makes the agent look broken.

## Client

A Stop button that exists only while a turn is running, plus **Escape** in the chat input — the one interaction worth a shortcut mid-set.

Text the agent already produced is **kept**. The work it finished before the stop is real, and discarding it would make Stop feel destructive.

The NEAR AI path gets the same treatment via an `AbortController` on its fetches, so Stop lands mid-loop there too rather than only between tool calls.

**The audio graph is deliberately untouched** — stopping a turn never stops the music. That's the property the whole set depends on.

## Tests

4 e2e tests: the button's visibility, the abort round trip, that a stop never renders as an error (`⚠`), that partial work survives, and the Escape shortcut. 21.7s locally.

## Not covered

The server half is exercised by the SDK check above and by hand, not by an automated test — driving it in CI would need a live model call. The client half is fully covered against a mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)