### PR TITLE
Export the OPFS repo as a zip, git history included

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ jobs:
           npm run test-agent-tools
           npm run test-gitproxy
           npm run test-quickjs-sandbox
+          # Zip writer for the repo export — pure bytes, and checked against
+          # the system `unzip` when it is available (it is, on ubuntu-latest).
+          npm run test-repozip
   web-test-runner:
     name: Web Test Runner
     runs-on: ubuntu-latest

--- a/wasmaudioworklet/e2e/repo-zip-export.spec.js
+++ b/wasmaudioworklet/e2e/repo-zip-export.spec.js
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { waitForAppReady, clearOPFS } from './near-git-helpers.js';
+
+// Downloading the OPFS repo as a zip. A project that exists only in a browser's
+// origin-private storage is a project you can lose — there is no file on disk to
+// back up, and clearing site data takes it with no warning.
+//
+// The unit tests (wasmgit/repozip.test.mjs) prove the archive is well formed.
+// This proves the parts only a browser has: that wasm-git can list `.git`,
+// that binary reads come back as bytes rather than mangled UTF-8, and that the
+// download actually reaches the user.
+//
+// No NEAR sandbox needed: an unregistered `?gitrepo=` falls back to local OPFS.
+
+const REPO = 'zip-export-test';
+
+test.describe('export the repo as a zip', () => {
+    // Fail fast: a wasm-git call that never answers should not burn 10 minutes.
+    test.setTimeout(180000);
+    test.afterEach(async ({ page }) => { await clearOPFS(page, REPO); });
+
+    test('produces a zip containing the working tree and the git history', async ({ page }) => {
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        await page.goto(`http://localhost:8080/?gitrepo=${REPO}`);
+        await waitForAppReady(page);
+
+        // A freshly-initialised local repo has `.git` but an empty working tree.
+        // Staging two files gives us both halves — and staging writes real git
+        // BLOB OBJECTS, which are zlib-compressed binary. Those are exactly what
+        // a UTF-8 read would corrupt, and exactly what `git fsck` will catch.
+        await page.evaluate(async () => {
+            const git = await import('/wasmgit/wasmgitclient.js');
+            await git.writefileandstage('song.js', 'setBPM(112);\n\nloopHere();\n');
+            await git.writefileandstage('faust/kick.dsp', 'import("stdfaust.lib");\nprocess = os.osc(55);\n');
+        });
+
+        const listed = await page.evaluate(async () => {
+            const git = await import('/wasmgit/wasmgitclient.js');
+            const withGit = await git.listfiles('', { includeGit: true });
+            const withoutGit = await git.listfiles('');
+            return {
+                withGit: withGit.filter((f) => f.startsWith('.git/')).length,
+                withoutGit: withoutGit.filter((f) => f.startsWith('.git/')).length,
+                total: withGit.length,
+            };
+        });
+        // The default (working tree) must stay clean; the opt-in must add history.
+        expect(listed.withoutGit).toBe(0);
+        expect(listed.withGit).toBeGreaterThan(0);
+        expect(listed.total).toBeGreaterThan(listed.withGit);
+
+        const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+        await page.evaluate(async () => {
+            const git = await import('/wasmgit/wasmgitclient.js');
+            const { zipRepo, downloadBlob } = await import('/wasmgit/repozip.js');
+            const { blob } = await zipRepo({ listfiles: git.listfiles, readfile: git.readfile });
+            downloadBlob(blob, 'zip-export-test.zip');
+        });
+        const download = await downloadPromise;
+        expect(download.suggestedFilename()).toBe('zip-export-test.zip');
+
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zipexport-'));
+        const zipPath = path.join(dir, 'repo.zip');
+        await download.saveAs(zipPath);
+        expect(fs.statSync(zipPath).size).toBeGreaterThan(0);
+
+        // Read it with a real zip tool, not our own parser.
+        const listing = execFileSync('unzip', ['-l', zipPath], { encoding: 'utf8' });
+        expect(listing).toMatch(/\.git\//);          // history came along
+        expect(listing).toMatch(/song\.js/);         // and so did the working tree
+        expect(execFileSync('unzip', ['-t', zipPath], { encoding: 'utf8' }))
+            .toMatch(/No errors detected/);
+
+        // A git object read as UTF-8 instead of bytes still extracts — it is
+        // just silently corrupt. Extract and let git itself be the judge.
+        const out = path.join(dir, 'out');
+        execFileSync('unzip', ['-o', '-q', zipPath, '-d', out]);
+        const fsck = execFileSync('git', ['fsck', '--no-progress', '--strict'], {
+            cwd: out, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        expect(fsck).not.toMatch(/error|corrupt|invalid|bad/i);
+        // git must also agree the staged content is what we put in — proof the
+        // blob objects survived the round trip as bytes.
+        const staged = execFileSync('git', ['ls-files', '--stage'], { cwd: out, encoding: 'utf8' });
+        expect(staged).toMatch(/song\.js/);
+        expect(staged).toMatch(/faust\/kick\.dsp/);
+        const blob = execFileSync('git', ['cat-file', '-p', ':song.js'], { cwd: out, encoding: 'utf8' });
+        expect(blob).toBe('setBPM(112);\n\nloopHere();\n');
+
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+});

--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -11,6 +11,7 @@ import { readfile, writefileandstage, unlinkfile, initWASMGitClient, addRemoteSy
 import { transpileDspSource } from './faust/faust-rs-transpile.js';
 import { createPatternToolsGlobal } from './pattern_tools.js';
 import { modal, modalPrompt, modalAlert } from './common/ui/modal.js';
+import { zipRepo, downloadBlob } from './wasmgit/repozip.js';
 import { updateSong, updateSynth, exportToWav } from './synth1/audioworklet/midisynthaudioworklet.js';
 import { compileWebAssemblySynth } from './synth1/browsersynthcompiler.js';
 
@@ -527,6 +528,7 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
                                     <label><input type="radio" name="exporttype" value="${EXPORT_MODE_MIDIPARTS_JSON}">MIDI parts as JSON</label><br />
                                     <label><input type="radio" name="exporttype" value="pngsources">source code as PNG image</label><br />
                                     <label><input type="radio" name="exporttype" value="video">Shader video (without sound)</label><br />
+                                    <label><input type="radio" name="exporttype" value="repozip">Project repository as ZIP (with git history)</label><br />
                                 </form>
                             </p>
                             <button onclick="getRootNode().result(null)">Cancel</button>
@@ -536,6 +538,36 @@ process = os.sawtooth(freq) * gain * en.adsr(0.01, 0.1, 0.7, 0.2, gate);
                         `);
 
                         toggleSpinner(true);
+                        if (exportProject === 'repozip') {
+                            // The whole OPFS repo, history included, as a file
+                            // on disk — a project that lives only in a browser's
+                            // origin-private storage is one you can lose.
+                            if (!gitrepoconfig) {
+                                toggleSpinner(false);
+                                await modalAlert('No repository',
+                                    'This project is not backed by a git repository, so there is nothing to zip. '
+                                    + 'Open the app with ?gitrepo=<name> to get one.');
+                                return;
+                            }
+                            try {
+                                const { blob, fileCount, unreadable } = await zipRepo({ listfiles, readfile });
+                                // The ?gitrepo= name is the repo's identity in
+                                // OPFS, so it is the honest filename here.
+                                const name = (new URLSearchParams(location.search).get('gitrepo')
+                                    || 'wasm-music-project').replace(/[^\w.-]+/g, '-');
+                                downloadBlob(blob, `${name}.zip`);
+                                toggleSpinner(false);
+                                if (unreadable.length) {
+                                    await modalAlert('Exported with omissions',
+                                        `${fileCount} files zipped. These could not be read and were left out:\n\n`
+                                        + unreadable.slice(0, 10).join('\n'));
+                                }
+                            } catch (e) {
+                                toggleSpinner(false);
+                                await modalAlert('Export failed', String(e?.message || e));
+                            }
+                            return;
+                        }
                         if (exportProject === 'wav' || exportProject === 'wav48k') {
                             const exportSampleRate = exportProject === 'wav48k' ? 48000 : 44100;
                             const wasmBytes = await compileWebAssemblySynth(

--- a/wasmaudioworklet/package.json
+++ b/wasmaudioworklet/package.json
@@ -34,7 +34,8 @@
         "test-faust": "node ../tools/faust2as/generate-test-sources.js && npx playwright test e2e/faust2as-compilation.spec.js",
         "test-agent-tools": "node --test studio-agent/tools-core.test.mjs studio-agent/nearai-core.test.mjs studio-agent/tools-def.test.mjs",
         "test-quickjs-sandbox": "node --test quickjs-sandbox-poc.test.mjs",
-        "test-gitproxy": "node --test gitproxy.test.mjs nearai-proxy.test.mjs"
+        "test-gitproxy": "node --test gitproxy.test.mjs nearai-proxy.test.mjs",
+        "test-repozip": "node --test wasmgit/repozip.test.mjs"
     },
     "resolutions": {
         "playwright": "1.59.1"

--- a/wasmaudioworklet/wasmgit/repozip.js
+++ b/wasmaudioworklet/wasmgit/repozip.js
@@ -1,0 +1,176 @@
+// Build a .zip of the OPFS git repo, in the browser, with no dependency.
+//
+// The app has no zip library and does not need one: `CompressionStream` gives
+// real deflate natively, and the rest of the format is a few headers. Adding a
+// bundled dependency for this would be more code, not less.
+//
+// The archive includes `.git`, so what comes out is a working clone — you can
+// unzip it, `git log`, and push it somewhere. That is the point: a project that
+// only exists inside a browser's origin-private storage is a project you can
+// lose. Git objects are already deflate-compressed, so they are STORED rather
+// than deflated again (compressing them a second time only wastes time).
+
+const LOCAL_SIG = 0x04034b50;
+const CENTRAL_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+const METHOD_STORE = 0;
+const METHOD_DEFLATE = 8;
+// The ZIP header count fields are 16-bit; past this the archive needs Zip64,
+// which is a different format. Refuse rather than emit something subtly broken.
+const MAX_ENTRIES = 0xffff;
+
+let crcTable = null;
+function crc32(bytes) {
+    if (!crcTable) {
+        crcTable = new Uint32Array(256);
+        for (let n = 0; n < 256; n++) {
+            let c = n;
+            for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+            crcTable[n] = c >>> 0;
+        }
+    }
+    let crc = 0xffffffff;
+    for (let i = 0; i < bytes.length; i++) crc = crcTable[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+async function deflateRaw(bytes) {
+    if (typeof CompressionStream !== 'function') return null;
+    try {
+        const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('deflate-raw'));
+        return new Uint8Array(await new Response(stream).arrayBuffer());
+    } catch {
+        return null; // deflate-raw unsupported — fall back to storing
+    }
+}
+
+// DOS date/time. A fixed timestamp would make every export byte-identical,
+// which is tempting for tests but shows every file as 1980 in a file manager.
+function dosDateTime(date) {
+    const year = Math.max(1980, date.getFullYear());
+    return {
+        time: (date.getHours() << 11) | (date.getMinutes() << 5) | (date.getSeconds() >> 1),
+        date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+    };
+}
+
+function u8(...parts) {
+    const total = parts.reduce((n, p) => n + p.length, 0);
+    const out = new Uint8Array(total);
+    let at = 0;
+    for (const p of parts) { out.set(p, at); at += p.length; }
+    return out;
+}
+
+function le(values) { // [[value, byteWidth], ...]
+    const size = values.reduce((n, [, w]) => n + w, 0);
+    const buf = new Uint8Array(size);
+    const view = new DataView(buf.buffer);
+    let at = 0;
+    for (const [value, width] of values) {
+        if (width === 2) view.setUint16(at, value, true);
+        else view.setUint32(at, value, true);
+        at += width;
+    }
+    return buf;
+}
+
+/**
+ * @param {Array<{path: string, bytes: Uint8Array}>} files
+ * @param {Date} [now] timestamp recorded for every entry
+ * @returns {Promise<Blob>} a zip, ready to download
+ */
+export async function buildZip(files, now = new Date()) {
+    if (files.length > MAX_ENTRIES) {
+        throw new Error(`${files.length} files exceeds the ${MAX_ENTRIES}-entry limit of a plain zip (Zip64 not supported)`);
+    }
+    const { time, date } = dosDateTime(now);
+    const encoder = new TextEncoder();
+    const localParts = [];
+    const centralParts = [];
+    let offset = 0;
+
+    for (const { path, bytes } of files) {
+        // A trailing slash is a DIRECTORY entry: zero length, and the MS-DOS
+        // directory attribute so every extractor recreates it even when empty.
+        const isDir = path.endsWith('/');
+        const name = encoder.encode(path);
+        const crc = isDir ? 0 : crc32(bytes);
+        // Already-compressed data (git objects, packfiles, png, wasm) does not
+        // shrink again; skip the work and store it.
+        const precompressed = isDir || /^\.git\/objects\//.test(path)
+            || /\.(png|jpe?g|gif|webp|wasm|zip|mp3|mp4|ogg)$/i.test(path);
+        const deflated = precompressed ? null : await deflateRaw(bytes);
+        const useDeflate = deflated && deflated.length < bytes.length;
+        const body = useDeflate ? deflated : bytes;
+        const method = useDeflate ? METHOD_DEFLATE : METHOD_STORE;
+
+        localParts.push(u8(
+            le([[LOCAL_SIG, 4], [20, 2], [0, 2], [method, 2], [time, 2], [date, 2],
+                [crc, 4], [body.length, 4], [bytes.length, 4], [name.length, 2], [0, 2]]),
+            name, body,
+        ));
+        centralParts.push(u8(
+            le([[CENTRAL_SIG, 4], [20, 2], [20, 2], [0, 2], [method, 2], [time, 2], [date, 2],
+                [crc, 4], [body.length, 4], [bytes.length, 4], [name.length, 2],
+                [0, 2], [0, 2], [0, 2], [0, 2], [isDir ? 0x10 : 0, 4], [offset, 4]]),
+            name,
+        ));
+        offset += 30 + name.length + body.length;
+    }
+
+    const central = u8(...centralParts);
+    const eocd = le([[EOCD_SIG, 4], [0, 2], [0, 2], [files.length, 2], [files.length, 2],
+        [central.length, 4], [offset, 4], [0, 2]]);
+    return new Blob([...localParts, central, eocd], { type: 'application/zip' });
+}
+
+/**
+ * Read every file of the OPFS repo (including `.git`) and zip it.
+ *
+ * `readfile` is called with `{ binary: true }` — git objects, samples and wasm
+ * are not text, and reading them as UTF-8 silently corrupts them.
+ *
+ * @param {{ listfiles: Function, readfile: Function }} git the wasm-git client
+ * @param {(done: number, total: number, path: string) => void} [onProgress]
+ */
+export async function zipRepo(git, onProgress = () => {}) {
+    const paths = await git.listfiles('', { includeGit: true, includeDirs: true });
+    if (!paths.length) throw new Error('the repository is empty — nothing to export');
+
+    const files = [];
+    const unreadable = [];
+    for (const [i, path] of paths.entries()) {
+        onProgress(i, paths.length, path);
+        // Directory entries carry no content — they exist so EMPTY ones survive.
+        if (path.endsWith('/')) { files.push({ path, bytes: new Uint8Array(0) }); continue; }
+        try {
+            const contents = await git.readfile(path, 30000, { binary: true });
+            files.push({ path, bytes: toBytes(contents) });
+        } catch (e) {
+            // One unreadable file must not lose the whole export; report which.
+            unreadable.push(`${path}: ${e?.message || e}`);
+        }
+    }
+    onProgress(paths.length, paths.length, '');
+    return { blob: await buildZip(files), fileCount: files.length, unreadable };
+}
+
+function toBytes(contents) {
+    if (contents instanceof Uint8Array) return contents;
+    if (contents instanceof ArrayBuffer) return new Uint8Array(contents);
+    return new TextEncoder().encode(String(contents));
+}
+
+/** Hand the blob to the browser as a download. */
+export function downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.documentElement.appendChild(a);
+    a.click();
+    a.remove();
+    // Revoking immediately can cancel the download in some browsers.
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+}

--- a/wasmaudioworklet/wasmgit/repozip.test.mjs
+++ b/wasmaudioworklet/wasmgit/repozip.test.mjs
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { inflateRawSync } from 'node:zlib';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildZip, zipRepo } from './repozip.js';
+
+// A zip this app writes has to be readable by everything else — the whole
+// point is getting a project OUT of origin-private storage. So these check the
+// bytes against Node's own inflate and, where available, the system `unzip`,
+// rather than only against a reader written alongside the writer.
+
+const bytes = (s) => new TextEncoder().encode(s);
+
+function haveUnzip() {
+    try { execFileSync('unzip', ['-v'], { stdio: 'ignore' }); return true; } catch { return false; }
+}
+
+// Minimal central-directory reader: enough to assert structure and to pull each
+// entry's stored/deflated body back out.
+function readEntries(buf) {
+    const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    let eocd = buf.length - 22;
+    while (eocd >= 0 && view.getUint32(eocd, true) !== 0x06054b50) eocd--;
+    assert.ok(eocd >= 0, 'end-of-central-directory signature not found');
+    const count = view.getUint16(eocd + 10, true);
+    let at = view.getUint32(eocd + 16, true);
+    const entries = [];
+    for (let i = 0; i < count; i++) {
+        assert.equal(view.getUint32(at, true), 0x02014b50, 'central header signature');
+        const method = view.getUint16(at + 10, true);
+        const compSize = view.getUint32(at + 20, true);
+        const rawSize = view.getUint32(at + 24, true);
+        const nameLen = view.getUint16(at + 28, true);
+        const localAt = view.getUint32(at + 42, true);
+        const name = new TextDecoder().decode(buf.subarray(at + 46, at + 46 + nameLen));
+        // Body sits after the local header, which repeats name + extra lengths.
+        const localNameLen = view.getUint16(localAt + 26, true);
+        const localExtraLen = view.getUint16(localAt + 28, true);
+        const bodyAt = localAt + 30 + localNameLen + localExtraLen;
+        const body = buf.subarray(bodyAt, bodyAt + compSize);
+        entries.push({ name, method, rawSize, body });
+        at += 46 + nameLen + view.getUint16(at + 30, true) + view.getUint16(at + 32, true);
+    }
+    return entries;
+}
+
+const decode = (entry) =>
+    entry.method === 0 ? Buffer.from(entry.body) : inflateRawSync(Buffer.from(entry.body));
+
+test('every file round-trips byte for byte', async () => {
+    const files = [
+        { path: 'song.js', bytes: bytes('setBPM(112);\n'.repeat(50)) },
+        { path: 'faust/kick.dsp', bytes: bytes('import("stdfaust.lib");\n') },
+        { path: 'bin.dat', bytes: new Uint8Array([0, 1, 2, 255, 254, 0, 0, 128]) },
+    ];
+    const buf = new Uint8Array(await (await buildZip(files)).arrayBuffer());
+    const entries = readEntries(buf);
+
+    assert.equal(entries.length, files.length);
+    for (const original of files) {
+        const entry = entries.find((e) => e.name === original.path);
+        assert.ok(entry, `${original.path} present`);
+        assert.equal(entry.rawSize, original.bytes.length);
+        assert.deepEqual(new Uint8Array(decode(entry)), original.bytes);
+    }
+});
+
+test('compressible text is deflated, already-compressed data is stored', async () => {
+    const files = [
+        { path: 'song.js', bytes: bytes('a'.repeat(5000)) },
+        { path: '.git/objects/ab/cdef', bytes: new Uint8Array(2000).fill(7) },
+        { path: 'cover.png', bytes: new Uint8Array(2000).fill(9) },
+    ];
+    const entries = readEntries(new Uint8Array(await (await buildZip(files)).arrayBuffer()));
+    // Highly repetitive text must actually compress, or deflate is not running.
+    const song = entries.find((e) => e.name === 'song.js');
+    assert.equal(song.method, 8, 'deflated');
+    assert.ok(song.body.length < 5000 / 10, 'meaningfully smaller');
+    // Git objects and images are already compressed — re-deflating only costs time.
+    assert.equal(entries.find((e) => e.name === '.git/objects/ab/cdef').method, 0, 'git object stored');
+    assert.equal(entries.find((e) => e.name === 'cover.png').method, 0, 'png stored');
+});
+
+test('a real unzip accepts the archive', { skip: !haveUnzip() && 'unzip not installed' }, async () => {
+    const files = [
+        { path: 'song.js', bytes: bytes('loopHere();\n') },
+        { path: 'faust/bass.dsp', bytes: bytes('process = os.osc(55);\n') },
+        { path: '.git/HEAD', bytes: bytes('ref: refs/heads/master\n') },
+    ];
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repozip-'));
+    const zipPath = path.join(dir, 'p.zip');
+    fs.writeFileSync(zipPath, Buffer.from(await (await buildZip(files)).arrayBuffer()));
+
+    // -t is unzip's own integrity check: CRCs, headers, the lot.
+    const testOut = execFileSync('unzip', ['-t', zipPath], { encoding: 'utf8' });
+    assert.match(testOut, /No errors detected/);
+
+    execFileSync('unzip', ['-o', '-q', zipPath, '-d', path.join(dir, 'out')]);
+    for (const f of files) {
+        const got = fs.readFileSync(path.join(dir, 'out', f.path));
+        assert.deepEqual(new Uint8Array(got), f.bytes, `${f.path} extracted intact`);
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('refuses to write an archive that needs Zip64 rather than a broken one', async () => {
+    const many = Array.from({ length: 70000 }, (_, i) => ({ path: `f${i}`, bytes: new Uint8Array(0) }));
+    await assert.rejects(() => buildZip(many), /Zip64/);
+});
+
+test('zipRepo asks for the git directory and reads every file as bytes', async () => {
+    const asked = { includeGit: null, binary: [] };
+    const git = {
+        listfiles: async (prefix, opts) => { asked.includeGit = opts?.includeGit; return ['song.js', '.git/HEAD']; },
+        readfile: async (p, _ms, opts) => { asked.binary.push(opts?.binary); return bytes(`contents of ${p}`); },
+    };
+    const { fileCount, unreadable } = await zipRepo(git);
+    assert.equal(asked.includeGit, true, 'history must be included');
+    assert.deepEqual(asked.binary, [true, true], 'binary reads — UTF-8 would corrupt git objects');
+    assert.equal(fileCount, 2);
+    assert.deepEqual(unreadable, []);
+});
+
+test('one unreadable file does not lose the whole export', async () => {
+    const git = {
+        listfiles: async () => ['good.js', 'bad.bin'],
+        readfile: async (p) => {
+            if (p === 'bad.bin') throw new Error('EIO');
+            return bytes('fine');
+        },
+    };
+    const { fileCount, unreadable } = await zipRepo(git);
+    assert.equal(fileCount, 1);
+    assert.equal(unreadable.length, 1);
+    assert.match(unreadable[0], /bad\.bin/);
+});
+
+test('an empty repo is an error, not an empty zip', async () => {
+    const git = { listfiles: async () => [], readfile: async () => bytes('') };
+    await assert.rejects(() => zipRepo(git), /empty/);
+});
+
+test('empty directories survive — a repo without .git/refs is not a repo', async () => {
+    const files = [
+        { path: '.git/HEAD', bytes: bytes('ref: refs/heads/master\n') },
+        { path: '.git/refs/', bytes: new Uint8Array(0) },   // empty in a fresh repo
+        { path: '.git/refs/heads/', bytes: new Uint8Array(0) },
+    ];
+    const entries = readEntries(new Uint8Array(await (await buildZip(files)).arrayBuffer()));
+    const dir = entries.find((e) => e.name === '.git/refs/');
+    assert.ok(dir, 'directory entry present');
+    assert.equal(dir.rawSize, 0);
+    assert.equal(dir.method, 0, 'stored, never deflated');
+});
+
+test('zipRepo asks for directories so empty ones are not dropped', async () => {
+    let opts = null;
+    const git = {
+        listfiles: async (_p, o) => { opts = o; return ['song.js', 'faust/']; },
+        readfile: async () => bytes('x'),
+    };
+    const { fileCount } = await zipRepo(git);
+    assert.equal(opts?.includeDirs, true);
+    // The directory is an entry too, and must not have been read as a file.
+    assert.equal(fileCount, 2);
+});

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -471,10 +471,15 @@ export async function listSongs() {
     return await getConfig().then(c => c.allsongs);
 }
 
-export async function listfiles(prefix = '') {
+// `includeDirs` appends directory paths with a trailing slash, so a caller that
+// must reproduce the tree faithfully (the zip export) does not silently drop
+// empty directories — `.git/refs` in a fresh repo being the one that matters.
+export async function listfiles(prefix = '', { includeGit = false, includeDirs = false } = {}) {
     const result = await callAndWaitForWorker({
         command: 'listfiles',
         prefix,
+        includeGit,
+        includeDirs,
     });
     return result.files || [];
 }

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -356,6 +356,15 @@ onmessage = async (msg) => {
     try {
       ensureChdir(currentRepoDir);
       const prefix = msg.data.prefix || '';
+      // `.git` is skipped by default — callers want the working tree. The zip
+      // export opts in, because a repo without its history is not a repo you
+      // can push from later.
+      const includeGit = !!msg.data.includeGit;
+      // Directories are normally uninteresting, but an archive that omits the
+      // EMPTY ones is not a faithful copy: a fresh repo's `.git/refs` has no
+      // files in it, and without that directory git does not recognise the
+      // result as a repository at all. Reported with a trailing slash.
+      const includeDirs = !!msg.data.includeDirs;
       // Standard Unix mode bitmask — Emscripten's FS exposes `mode` from
       // FS.stat() but FS.isDir() isn't always available on the helper.
       const S_IFMT = 0o170000;
@@ -365,12 +374,16 @@ onmessage = async (msg) => {
         let entries;
         try { entries = FS.readdir(virtBase); } catch (e) { return; }
         for (const entry of entries) {
-          if (entry === '.' || entry === '..' || entry === '.git') continue;
+          if (entry === '.' || entry === '..') continue;
+          if (entry === '.git' && !includeGit) continue;
           const childVirt = virtBase === '.' ? entry : virtBase + '/' + entry;
           const childRel = relBase ? relBase + '/' + entry : entry;
           let stat;
           try { stat = FS.stat(childVirt); } catch (e) { continue; }
           if ((stat.mode & S_IFMT) === S_IFDIR) {
+            if (includeDirs && (!prefix || childRel.indexOf(prefix) === 0)) {
+              result.push(childRel + '/');
+            }
             walk(childVirt, childRel);
           } else {
             if (!prefix || childRel.indexOf(prefix) === 0) {


### PR DESCRIPTION
A project that exists only in a browser's origin-private storage is one you can lose — there is no file on disk to back up, and clearing site data takes it with no warning.

The export menu gains **"Project repository as ZIP (with git history)"**. Unzip it and you have a working clone: `git log` works, and you can push it somewhere.

## No zip dependency

`CompressionStream('deflate-raw')` is native, and the rest of the format is a few headers — a bundled library would be more code, not less. Git objects and images are **stored** rather than deflated a second time, which only costs time.

## Three things this turns on

- **Reads are binary.** `readfile` already supported `{ binary: true }`; nothing used it. Reading a git object as UTF-8 doesn't fail — it silently corrupts, which is the sort of bug you find when you try to restore.
- **`.git` is included**, via a new `includeGit` option on `listfiles`. The default still skips it: every other caller wants the working tree.
- **Empty directories are included**, via `includeDirs`. A fresh repo's `.git/refs` has no files in it, and without that directory git doesn't recognise the extraction as a repository at all.

That last one is worth calling out: I did not reason my way to it. The e2e extracted the zip, ran `git fsck`, and got *"not a git repository"* — the archive looked perfect and `unzip -t` was happy. It would also have silently dropped any empty directory in a user's project.

## Tests

**9 unit tests** on the archive bytes, checked against Node's own `inflateRawSync` and against the system `unzip -t` — not only against a reader written alongside the writer. Covers round-tripping, deflate-vs-store, the Zip64 refusal, unreadable files, and the empty-directory case.

**1 e2e** drives the real browser path — wasm-git listing `.git`, binary reads, an actual download — then hands the result to git and lets git judge it:

```
git fsck --no-progress --strict     # objects intact
git ls-files --stage                # index intact
git cat-file -p :song.js            # blob matches byte for byte
```

Added to the `unit-tests` CI job as `test-repozip`.

## Notes

- The filename comes from the `?gitrepo=` name, sanitised.
- Exporting without a repo (no `?gitrepo=`) explains itself rather than producing an empty file.
- One unreadable file doesn't lose the export; it finishes and reports what was left out.
- Zip64 isn't supported — >65535 entries throws rather than writing something subtly broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)