### PR TITLE
Studio agent kit: ma.tanh is a valid saturator, drop the stale tanhf warning

### DIFF
--- a/wasmaudioworklet/e2e/studio-agent-kit.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-kit.spec.js
@@ -110,9 +110,10 @@ test.describe('studio-agent project kit', () => {
         }
         expect(kit).toContain('import("stdfaust.lib")');
         expect(kit).toContain('initializeMidiSynth');
-        // Hard-won gotchas that cost real compile round-trips when missing.
-        expect(kit, 'must warn against ma.tanh').toContain('ma.tanh');
-        expect(kit, 'must state the sat() replacement').toContain('sat(x) = x / (1.0 + abs(x))');
+        // Saturation options the agent should have without a lookup: ma.tanh
+        // (transpiles to Mathf.tanh) and the cheaper sat() soft clipper.
+        expect(kit, 'must document ma.tanh as a saturator').toContain('ma.tanh');
+        expect(kit, 'must document the sat() soft clipper').toContain('sat(x) = x / (1.0 + abs(x))');
     });
 
     test('every turn carries the kit, not just the first', async ({ page }) => {

--- a/wasmaudioworklet/studio-agent/default-kit.md
+++ b/wasmaudioworklet/studio-agent/default-kit.md
@@ -43,18 +43,17 @@ Expose timing as an `hslider` rather than hard-coding the BPM: sliders become
 channel parameters the song can set, so a tempo change does not mean re-writing
 the DSP.
 
-## Saturation — read this before writing any DSP
+## Saturation
 
-Use this soft clipper:
+Two saturators both work end to end — pick by taste:
 
-```
-sat(x) = x / (1.0 + abs(x));
-```
+- `ma.tanh` — a true tanh soft clipper. The transpiler emits `Mathf.tanh`, which
+  AssemblyScript compiles natively, so `write_faust` → `compile` succeeds.
+- `sat(x) = x / (1.0 + abs(x));` — a cheaper soft clipper (one divide, no
+  transcendental). This is what the kick/bass/lead below use.
 
-**Do NOT use `tanh` or `ma.tanh`.** Bare `tanh` is not a Faust primitive
-(`undefined symbol`), and `ma.tanh` passes Faust but emits `tanhf`, which the
-AssemblyScript backend has no name for — so it fails at `compile` with
-`TS2304: Cannot find name 'tanhf'` *after* `write_faust` reported success.
+Write `ma.tanh`, **not bare `tanh`** — `tanh` on its own is not a Faust
+primitive and fails with `undefined symbol`.
 
 ## Instruments (write these verbatim with `write_faust`)
 


### PR DESCRIPTION
## Summary

The default-kit's "Saturation" section warned agents **not** to use `ma.tanh`, claiming it fails at `compile` with `TS2304: Cannot find name 'tanhf'` after `write_faust` reported success. That was true of an older faust-rs backend, but it is no longer the case: the compiler module the app ships today emits `Mathf.tanh`, which AssemblyScript compiles natively.

This PR corrects the guidance and the e2e test that encoded the stale warning.

## What changed

- **`wasmaudioworklet/studio-agent/default-kit.md`** — rewrote the Saturation section. It now presents two working saturators:
  - `ma.tanh` — a true tanh soft clipper (transpiles to `Mathf.tanh`, compiles natively).
  - `sat(x) = x / (1.0 + abs(x))` — the cheaper soft clipper still used by kick/bass/lead.

  The only real remaining gotcha is kept: bare `tanh` (without the `ma.` prefix) is not a Faust primitive and fails with `undefined symbol`.
- **`wasmaudioworklet/e2e/studio-agent-kit.spec.js`** — the two assertions now check that the kit *documents* `ma.tanh` and the `sat()` clipper, instead of asserting it *warns against* `ma.tanh`. Both checked strings remain present in the doc, so the test stays green. The instrument recipes are untouched.

## Verification

Ran the actual compiler module the app loads (`faust-rs-wasm-ffi 0.5.0`, published as `@psalomo/wasm-music-faust@0.1.1` — the version referenced in `faust-rs-transpile.js`) and the pinned `assemblyscript@0.28.20`:

| Case | Result |
|------|--------|
| `process = ma.tanh` → transpile | `output = <f32>(Mathf.tanh(<f32>(input)))` |
| `Mathf.tanh` → `asc` compile | valid wasm, no `TS2304` |
| `process = tanh` (no `ma.`) | `undefined symbol \`tanh\`` — warning retained, confirmed accurate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tk1exWFTy5JQiYQtaqsRze

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk1exWFTy5JQiYQtaqsRze)_