### PR TITLE
Ask for a NEAR key when you push, not when you arrive

### DIFF
--- a/wasmaudioworklet/e2e/default-workspace.spec.js
+++ b/wasmaudioworklet/e2e/default-workspace.spec.js
@@ -17,6 +17,29 @@ test('first visit boots a workspace repo with the MIDI starter; work survives re
     // wasmgit-ui appearing proves the workspace repo mode engaged.
     await waitForAppReady(page);
 
+    // A workspace repo is OPFS-only: there is no contract to sign in to, so the
+    // toolbar must offer no wallet prompt at all. This is the case the old
+    // always-visible `login` button got wrong — it invited a first-time visitor
+    // to authenticate against nothing.
+    const toolbar = await page.evaluate(() => {
+        const ui = document.querySelector('app-javascriptmusic')
+            .shadowRoot.querySelector('wasmgit-ui');
+        return {
+            // Gone from the markup entirely, not merely hidden.
+            hasLoginButton: ui.shadowRoot.getElementById('loginButton') !== null,
+            visible: [...ui.shadowRoot.querySelectorAll('button')]
+                .filter((b) => b.style.display !== 'none')
+                .map((b) => b.textContent.trim()),
+            // Label is state-dependent ("Sync remote" until there are changes),
+            // so assert the control exists rather than what it currently says.
+            hasSyncButton: ui.shadowRoot.getElementById('syncRemoteButton') !== null,
+        };
+    });
+    expect(toolbar.hasLoginButton).toBe(false);
+    expect(toolbar.visible).not.toContain('login');
+    expect(toolbar.visible).not.toContain('logout');
+    expect(toolbar.hasSyncButton).toBe(true);
+
     // MIDI-sequencer starter in both editors (not the legacy pattern format).
     const song = await page.evaluate(() => document.querySelector('app-javascriptmusic')
         .shadowRoot.querySelector('#editor .CodeMirror').CodeMirror.getValue());

--- a/wasmaudioworklet/login.html
+++ b/wasmaudioworklet/login.html
@@ -75,8 +75,21 @@
                     const keyData = { accountId, publicKey, privateKey };
                     localStorage.setItem('near-git-key:' + contractId, JSON.stringify(keyData));
 
-                    statusEl.textContent = 'Key created! Redirecting...';
-                    setTimeout(() => { location.href = returnUrl; }, 500);
+                    // Opened as a popup by the push path: close and let the
+                    // opener resume the sync it was in the middle of. The key
+                    // is already in localStorage, which is how it finds out —
+                    // postMessage is only a hint, since COOP may have severed
+                    // the opener link.
+                    if (params.get('popup')) {
+                        statusEl.textContent = 'Key created! You can close this window.';
+                        try {
+                            window.opener?.postMessage({ type: 'near-git-key', contractId }, location.origin);
+                        } catch (err) { /* opener severed by COOP — polling covers it */ }
+                        setTimeout(() => window.close(), 300);
+                    } else {
+                        statusEl.textContent = 'Key created! Redirecting...';
+                        setTimeout(() => { location.href = returnUrl; }, 500);
+                    }
                 } catch (err) {
                     statusEl.textContent = 'Error adding key: ' + err.message;
                 }

--- a/wasmaudioworklet/wasmgit/nearacl.js
+++ b/wasmaudioworklet/wasmgit/nearacl.js
@@ -1,13 +1,40 @@
-export const nearconfig = {
-    nodeUrl: 'https://archival-rpc.testnet.fastnear.com',
-    networkId: 'testnet',
-};
+// NEAR credentials for git push.
+//
+// Only PUSH needs a key. Clone, pull, the song list and every local operation
+// are view calls or pure OPFS, and the key this creates is scoped to `push` on
+// one repo contract. So there is no sign-in step and no sign-in button: the
+// push path calls `ensureAuth()` at the moment the permission is actually
+// required, exactly as the studio pass is offered when a turn needs one.
+//
+// The network follows the CONTRACT ID (see ../near/network.js) rather than a
+// user-facing switch, so a stored key, an RPC URL and a contract can never
+// disagree about which chain they are on.
+
+import { networkById, networkIdForAccountId } from '../near/network.js';
+
+const KEY_STORAGE_PREFIX = 'near-git-key:';
 
 export let authdata = null;
 
+// Kept as a live export (updated by initNear) so callers always read the
+// network of the repo currently open, not a hardcoded one.
+export let nearconfig = networkById('testnet');
+
 let currentContractId = null;
 
-const KEY_STORAGE_PREFIX = 'near-git-key:';
+/**
+ * Is this repo backed by a NEAR contract at all?
+ *
+ * `workspace` — the local OPFS repo a first-time visitor lands in — is not, and
+ * neither is any other suffix-less name. Those must NEVER be asked to sign in:
+ * there is no contract to sign in to. This is deliberately an explicit suffix
+ * test rather than `networkIdForAccountId`, which falls back to mainnet for
+ * unknown ids and would answer "mainnet" for `workspace`.
+ */
+export function isNearRepo(contractId = currentContractId) {
+    const id = String(contractId || '');
+    return id.endsWith('.near') || id.endsWith('.testnet') || id.endsWith('.sandbox');
+}
 
 function getStoredKey(contractId) {
     const stored = localStorage.getItem(KEY_STORAGE_PREFIX + contractId);
@@ -17,26 +44,97 @@ function getStoredKey(contractId) {
     return null;
 }
 
+function adoptStoredKey(contractId) {
+    const storedKey = getStoredKey(contractId);
+    if (!storedKey) return false;
+    authdata = {
+        username: storedKey.accountId,
+        useremail: storedKey.accountId,
+        publicKey: storedKey.publicKey,
+        privateKey: storedKey.privateKey,
+    };
+    return true;
+}
+
 export async function initNear(contractId) {
     currentContractId = contractId;
+    nearconfig = networkById(networkIdForAccountId(contractId, 'testnet'));
 
-    const storedKey = getStoredKey(contractId);
-    if (storedKey) {
-        authdata = {
-            username: storedKey.accountId,
-            useremail: storedKey.accountId,
-            publicKey: storedKey.publicKey,
-            privateKey: storedKey.privateKey,
-        };
-        console.log('Restored auth for', storedKey.accountId);
+    if (adoptStoredKey(contractId)) {
+        console.log('Restored auth for', authdata.username);
     } else {
         console.log('no loggedin user');
     }
 }
 
+/**
+ * Open the wallet in a POPUP and resolve once a key for this repo shows up.
+ *
+ * A popup rather than the old full-page redirect: the redirect worked (the
+ * commit is already in OPFS before the push, so nothing was lost) but it
+ * reloaded the app mid-action and left the user to work out what happened.
+ * /login.html is COOP-exempt precisely so the wallet's `window.opener`
+ * survives — the same reason /pay.html exists.
+ *
+ * @returns {Promise<boolean>} true once credentials are stored.
+ */
 export function login() {
-    const returnUrl = location.href;
-    location.href = `/login.html?contractId=${encodeURIComponent(currentContractId)}&returnUrl=${encodeURIComponent(returnUrl)}`;
+    return new Promise((resolve) => {
+        if (!currentContractId || !isNearRepo(currentContractId)) {
+            resolve(false);
+            return;
+        }
+        const storageKey = KEY_STORAGE_PREFIX + currentContractId;
+        let settled = false;
+        let poll = null;
+
+        const finish = (ok) => {
+            if (settled) return;
+            settled = true;
+            window.removeEventListener('storage', onStorage);
+            if (poll) clearInterval(poll);
+            if (ok) adoptStoredKey(currentContractId);
+            resolve(ok);
+        };
+        const check = () => { if (getStoredKey(currentContractId)) finish(true); };
+        // `storage` only fires in OTHER documents, and COOP may have severed
+        // the opener link, so polling is the mechanism and the event is a hint.
+        const onStorage = (e) => { if (e.key === storageKey) check(); };
+        window.addEventListener('storage', onStorage);
+
+        const walletNetwork = networkById(
+            networkIdForAccountId(currentContractId, 'testnet')).walletNetworkId;
+        const url = `/login.html?contractId=${encodeURIComponent(currentContractId)}`
+            + `&network=${encodeURIComponent(walletNetwork)}&popup=1`;
+        const win = window.open(url, 'near-git-login', 'width=460,height=680');
+        if (!win) {
+            // Popup blocked, which is likely rather than exotic here: the commit
+            // MESSAGE modal is awaited before this runs, so the click that
+            // started the sync may no longer count as user activation. Fall back
+            // to the old full-page redirect — it is disruptive but it works, and
+            // the commit is already in OPFS so nothing is lost. The timeout is
+            // only a safety net for a navigation that never happens; normally
+            // this document is gone before it fires.
+            location.href = `${url}&returnUrl=${encodeURIComponent(location.href)}`;
+            setTimeout(() => finish(false), 5000);
+            return;
+        }
+        poll = setInterval(() => {
+            check();
+            if (win.closed) finish(Boolean(getStoredKey(currentContractId)));
+        }, 700);
+    });
+}
+
+/**
+ * Credentials for the current repo, asking for them only if this is a NEAR
+ * repo that does not have them yet. Returns null when the repo needs no NEAR
+ * auth at all (local workspace, or a `remote=` host using a PAT instead).
+ */
+export async function ensureAuth() {
+    if (!isNearRepo(currentContractId)) return null;
+    if (authdata) return authdata;
+    return (await login()) ? authdata : null;
 }
 
 export function logout() {

--- a/wasmaudioworklet/wasmgit/nearacl.test.mjs
+++ b/wasmaudioworklet/wasmgit/nearacl.test.mjs
@@ -1,0 +1,50 @@
+// The rule that decides who is asked to sign in.
+//
+// This is the whole point of removing the login button: a visitor who never
+// touches a NEAR repo must never see a wallet. Getting `isNearRepo` wrong in
+// the permissive direction brings the old always-visible prompt back by
+// another route — for a local OPFS repo there is not even a contract to sign
+// in to — so every id shape gets a case here.
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import { isNearRepo, nearconfig } from './nearacl.js';
+
+test('local workspace repos are never NEAR repos', () => {
+    // `workspace` is what a first-time visitor lands in: OPFS only, no chain,
+    // no contract. networkIdForAccountId would answer "mainnet" here via its
+    // fallback, which is exactly why isNearRepo does its own suffix test.
+    assert.equal(isNearRepo('workspace'), false);
+    assert.equal(isNearRepo('my-local-project'), false);
+});
+
+test('chain-backed repos are recognised on every network', () => {
+    assert.equal(isNearRepo('mygitrepo.gitfactory.testnet'), true);
+    assert.equal(isNearRepo('repo.gitfactory.near'), true);
+    // The e2e harness's local sandbox suffix — a real contract, just not a
+    // public network, so it still needs credentials to push.
+    assert.equal(isNearRepo('testrepo.gitfactory.sandbox'), true);
+});
+
+test('missing or empty ids do not prompt', () => {
+    assert.equal(isNearRepo(''), false);
+    assert.equal(isNearRepo(null), false);
+    assert.equal(isNearRepo(undefined), false);
+});
+
+test('a suffix that merely CONTAINS a network name is not a NEAR repo', () => {
+    // Guards the difference between endsWith and includes: these are ordinary
+    // local names that happen to embed a network word.
+    assert.equal(isNearRepo('near'), false);
+    assert.equal(isNearRepo('testnet-experiments'), false);
+    assert.equal(isNearRepo('sandbox-notes'), false);
+});
+
+test('nearconfig defaults to a real network config before any repo is opened', () => {
+    // initNear() replaces this per repo; the default only has to be coherent
+    // rather than correct, but it must not be undefined — the git worker reads
+    // it when deciding which RPC to talk to.
+    assert.ok(nearconfig.nodeUrl, 'nodeUrl is set');
+    assert.ok(nearconfig.networkId, 'networkId is set');
+});

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -1,4 +1,4 @@
-import { initNear, authdata as nearAuthData, login as nearLogin, logout as nearLogout } from './nearacl.js';
+import { initNear, authdata as nearAuthData, ensureAuth as nearEnsureAuth, isNearRepo, logout as nearLogout } from './nearacl.js';
 import { toggleSpinner } from '../common/ui/progress-spinner.js';
 import { modal, modalPrompt } from '../common/ui/modal.js';
 
@@ -112,6 +112,29 @@ async function applyStoredGitToken(promptIfMissing) {
     return false;
 }
 
+/**
+ * Hand NEAR credentials to the git worker, which turns them into the
+ * Authorization header the repo contract's `push` expects. Called at init when
+ * a key is already stored, and again straight after a just-in-time sign-in.
+ */
+async function sendNearCredentials(auth) {
+    await new Promise(resolve => {
+        workerMessageListeners.push((msg) => {
+            if (msg.data.accessTokenConfigured) { resolve(); }
+            else { return true; }
+        });
+        worker.postMessage({
+            accessToken: JSON.stringify({
+                accountId: auth.username,
+                publicKey: auth.publicKey,
+                privateKey: auth.privateKey,
+            }),
+            username: auth.username,
+            useremail: auth.useremail || auth.username,
+        });
+    });
+}
+
 export async function initWASMGitClient(gitrepo, remoteUrl) {
     worker = new Worker(new URL('wasmgitworker.js', import.meta.url));
     worker.onmessage = (msg) => {
@@ -134,23 +157,12 @@ export async function initWASMGitClient(gitrepo, remoteUrl) {
     }
     await registerNearGitServiceWorker();
 
-    // Send NEAR credentials to the git worker so they're included as Authorization headers
+    // Send NEAR credentials to the git worker so they're included as
+    // Authorization headers. Only possible when a key already exists — a repo
+    // whose key is created later (at push time) delivers them via
+    // sendNearCredentials() from there.
     if (nearAuthData) {
-        await new Promise(resolve => {
-            workerMessageListeners.push((msg) => {
-                if (msg.data.accessTokenConfigured) { resolve(); }
-                else { return true; }
-            });
-            worker.postMessage({
-                accessToken: JSON.stringify({
-                    accountId: nearAuthData.username,
-                    publicKey: nearAuthData.publicKey,
-                    privateKey: nearAuthData.privateKey,
-                }),
-                username: nearAuthData.username,
-                useremail: nearAuthData.useremail || nearAuthData.username,
-            });
-        });
+        await sendNearCredentials(nearAuthData);
     }
 
     gitrepourl = `${location.origin}/near-repo/${gitrepo}.git`;
@@ -334,6 +346,19 @@ export async function pull() {
 }
 
 export async function commitAndSyncRemote(commitmessage) {
+    // Push is the ONLY operation that needs a NEAR key — clone, pull and the
+    // song list are view calls — so this is where we ask for one, rather than
+    // greeting every visitor with a sign-in button. A local `workspace` repo
+    // and a `remote=` host (which uses a PAT) both answer false to isNearRepo
+    // and are never prompted.
+    if (isNearRepo() && !nearAuthData) {
+        const auth = await nearEnsureAuth();
+        if (!auth) {
+            throw new Error('Sign-in required to push to this NEAR repository');
+        }
+        await sendNearCredentials(auth);
+    }
+
     const dircontents = await callAndWaitForWorker({
         command: 'commitpullpush',
         commitmessage: commitmessage
@@ -572,17 +597,17 @@ customElements.define('wasmgit-ui',
                     await changeCurrentSong(selectedSongNdx);                    
                 }
             });
+            // Identity is shown only once you HAVE signed in. There is nothing
+            // to click when you have not: the wallet opens from "Commit & Sync",
+            // which is the one action that actually needs a key.
             if (nearAuthData) {
                 this.shadowRoot.getElementById('loggedinuserspan').innerHTML = nearAuthData.username;
                 this.shadowRoot.getElementById('loggedinuserspan').style.display = 'block';
                 this.shadowRoot.getElementById('logoutButton').style.display = 'block';
-                this.shadowRoot.getElementById('loginButton').style.display = 'none';
                 this.shadowRoot.getElementById('logoutButton').onclick = () => nearLogout();
             } else {
-                this.shadowRoot.getElementById('loginButton').style.display = 'block';
                 this.shadowRoot.getElementById('logoutButton').style.display = 'none';
                 this.shadowRoot.getElementById('loggedinuserspan').style.display = 'none';
-                this.shadowRoot.getElementById('loginButton').onclick = () => nearLogin();
             }
             updateCommitAndSyncButtonState(await repoHasChanges());
         }

--- a/wasmaudioworklet/wasmgit/wasmgitui.html
+++ b/wasmaudioworklet/wasmgit/wasmgitui.html
@@ -29,9 +29,11 @@
     }
 </style>
 <div class="toolbar">
+    <!-- No login button: pushing is the only thing that needs a NEAR key, so
+         the wallet is opened from "Commit & Sync" at the moment it is needed.
+         Identity shows up once you HAVE signed in, never as a prompt to. -->
     <span id="loggedinuserspan" style="display: none"></span>
     <button id="logoutButton" style="display: none">logout</button>
-    <button id="loginButton" style="display: none">login</button>
     <button id="syncRemoteButton">Commit & Sync</button>
     <button id="discardChangesButton">Discard changes</button>
     <button id="deleteLocalButton">Delete local</button>


### PR DESCRIPTION
The `login` button greeted every visitor, including the ones it could do
nothing for. Landing with no content source boots a local OPFS `workspace`
repo — no contract, no remote — so the button was offering to sign in to
something that does not exist.

**Push is the only operation that needs a key.** Clone, pull, the song list and
every local edit are view calls or pure OPFS, and the key itself is scoped to
`push` on a single repo contract. So the button is gone, and
`commitAndSyncRemote` asks at the moment the permission is actually required —
the same shape as the studio pass, which is offered when a turn needs one
rather than demanded up front.

Each repo kind now has exactly one auth story:

| repo | needs | asked |
|---|---|---|
| `workspace` (local OPFS) | nothing | never |
| `*.gitfactory.testnet` / `.near` | NEAR key scoped to `push` | at push |
| `remote=…/gitproxy/…` | GitHub PAT | at clone/push (unchanged) |

Identity and logout still appear — but only once you have signed in, never as
an invitation to.

## Popup instead of redirect

The wallet opens in a popup, so the sync resumes on its own instead of
reloading the app mid-action. `/login.html` was already COOP-exempt, so no
header change was needed.

The full-page redirect survives as a fallback, and I expect it to be exercised:
the commit-message modal is `await`ed before the sync runs, so the click that
started it may no longer count as user activation by the time `window.open`
fires. Nothing is lost either way — the commit is in OPFS before the push. If
the fallback turns out to be the common path, opening the wallet *before* the
modal is the real fix.

## Network follows the contract id

`nearacl.js` hardcoded testnet. It now derives from the contract id via
`near/network.js`, which is what `near-git-sw.js` has always done — so a
testnet repo and a future `.near` repo both work with no user-facing switch. A
parallel network selector would let a stored key, an RPC URL and a contract
disagree about which chain they are on; deriving makes that unrepresentable.

**The subtle part, and the reason for a test per id shape:** `isNearRepo` does
its own suffix check rather than reusing `networkIdForAccountId`, which falls
back to mainnet for unknown ids and would confidently answer "mainnet" for
`workspace` — bringing the always-prompt bug back by another route.

## Verification

- 133 unit tests, +5 new covering the prompt/no-prompt rule
- `e2e/near-git.spec.js` against the docker NEAR sandbox: staging, discard, and
  commit + push + re-clone all pass
- `e2e/default-workspace.spec.js`: new assertion that workspace mode renders no
  login button at all — not merely hidden, absent from the markup

**Full suite unverified locally.** My machine was thrashing (load 10.2, ~16 MB
free); suites that take minutes took ~1.3 hours, and a baseline run of HEAD
*without* these changes failed more tests than the branch did. Both runs were
measuring the machine. None of the failures touch git push, and the specs that
do pass in 20 seconds — but that is inference, not proof, which is what CI here
is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
