### PR TITLE
Load the Yoshimi WAM and MOD player from jsDelivr, not unpkg

### DIFF
--- a/wasmaudioworklet/audioworkletnode.js
+++ b/wasmaudioworklet/audioworkletnode.js
@@ -69,7 +69,7 @@ export function initAudioWorkletNode(componentRoot) {
             }
         } else {
             if (song.modbytes) {
-                bytes = await fetch('https://unpkg.com/wasm-mod-player@0.0.3/wasm-mod-player.wasm')
+                bytes = await fetch('https://cdn.jsdelivr.net/npm/wasm-mod-player@0.0.3/wasm-mod-player.wasm')
                     .then(r => r.arrayBuffer());
 
                 await context.audioWorklet.addModule(new URL('modaudioworkletprocessor.js', import.meta.url));

--- a/wasmaudioworklet/webaudiomodules/preseteditor.js
+++ b/wasmaudioworklet/webaudiomodules/preseteditor.js
@@ -16,7 +16,7 @@ customElements.define('wam-preseteditor',
             const apphtml = await fetch('webaudiomodules/preseteditor.html').then(r => r.text());
             this.shadowRoot.innerHTML = apphtml;
 
-            const soundbanks = await fetch('https://unpkg.com/wasm-yoshimi@0.0.1/banks/root.json').then(r => r.json());
+            const soundbanks = await fetch('https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/banks/root.json').then(r => r.json());
             
             const presetSelectTemplate = this.shadowRoot.getElementById('presetselecttemplate');
             const bankSelectElement = presetSelectTemplate.content.querySelector('#bankselect');

--- a/wasmaudioworklet/webaudiomodules/wammanager.js
+++ b/wasmaudioworklet/webaudiomodules/wammanager.js
@@ -18,8 +18,8 @@ export async function loadWAM() {
         return wamloaded;
     }
     wamloaded = new Promise(async resolve => {
-        await loadScript("https://unpkg.com/wasm-yoshimi@0.0.1/libs/wam-controller.js");
-        await loadScript("https://unpkg.com/wasm-yoshimi@0.0.1/libs/gunzip.js")
+        await loadScript("https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/libs/wam-controller.js");
+        await loadScript("https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/libs/gunzip.js")
         await loadScript("webaudiomodules/yoshimi.js");
         resolve(true);
     });

--- a/wasmaudioworklet/webaudiomodules/yoshimi.js
+++ b/wasmaudioworklet/webaudiomodules/yoshimi.js
@@ -34,7 +34,7 @@ WAM.YOSHIMI = class YOSHIMI extends WAMController
     }
   }
   async loadpreset(channel, filename) {  
-    const url = `https://unpkg.com/wasm-yoshimi@0.0.1/banks/${filename}`;
+    const url = `https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/banks/${filename}`;
     let xml;
     try {
       let data = await fetch(url).then(r => r.arrayBuffer());
@@ -51,11 +51,11 @@ WAM.YOSHIMI = class YOSHIMI extends WAMController
   // -- wasm and scripts need to be loaded first, and in order
   //
   static async importScripts (actx, prefix = "") {
-    YOSHIMI.wasm = await YOSHIMI.load("https://unpkg.com/wasm-yoshimi@0.0.1/worklet/yoshimi.wasm", "bin");    
-    YOSHIMI.js   = await YOSHIMI.load("https://unpkg.com/wasm-yoshimi@0.0.1/worklet/yoshimi.js", "text");    
+    YOSHIMI.wasm = await YOSHIMI.load("https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/worklet/yoshimi.wasm", "bin");    
+    YOSHIMI.js   = await YOSHIMI.load("https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/worklet/yoshimi.js", "text");    
     // YOSHIMI.wasm = await YOSHIMI.load("yoshimi.wasm", "bin");
     // YOSHIMI.js = await YOSHIMI.load("yoshimi.js", "text");
-    await actx.audioWorklet.addModule("https://unpkg.com/wasm-yoshimi@0.0.1/libs/wam-processor.js");
+    await actx.audioWorklet.addModule("https://cdn.jsdelivr.net/npm/wasm-yoshimi@0.0.1/libs/wam-processor.js");
     await actx.audioWorklet.addModule("./webaudiomodules/yoshimi-awp.js");
   }
 


### PR DESCRIPTION
unpkg is currently unable to serve `wasm-yoshimi@0.0.1` and `wasm-mod-player@0.0.3` at all. Requests for any file in those two packages hang until they time out, while unpkg serves other packages fine:

| URL | Result |
|---|---|
| `unpkg.com/wasm-yoshimi@0.0.1/libs/wam-controller.js` | **HTTP 000, hangs 20s+** |
| `unpkg.com/wasm-yoshimi@0.0.1/worklet/yoshimi.wasm` | **hangs** |
| `unpkg.com/wasm-mod-player@0.0.3/wasm-mod-player.wasm` | **hangs** |
| `unpkg.com/react@18.2.0/package.json` | 200 in 0.28s |
| `unpkg.com/jshint@2.9.6/…`, `pako@2.0.3/…`, `wasm-git@0.0.17/…` | 200, all fast |

Both packages are intact in the npm registry (present, not unpublished), and `wasm-git` from the same account serves fine — so this looks like unpkg failing to build its edge cache for two old, rarely-fetched packages rather than anything wrong on our side.

## This is not just CI

`webaudiomodules/yoshimi.js` and `audioworkletnode.js` fetch these at runtime, so **the Yoshimi synth and the MOD player are broken in the deployed app right now**, not only in tests.

## The change

The eight affected URLs move to jsDelivr, which serves every one of them — including the `banks/*.xiz` tree — with `access-control-allow-origin: *` and the correct `application/wasm` / `application/javascript` content types (checked before making the change, since `audioWorklet.addModule` is strict about both).

This also brings these files in line with the rest of the codebase, which already loads AssemblyScript, binaryen, quickjs-wasm, chai, near-api-js, JSZip and reveal.js from jsDelivr. The unpkg URLs were the outliers.

## Verification

`npx wtr webaudiomodules/wammanager.spec.js webaudiomodules/yoshimi.spec.js`, Chromium + Firefox:

```
before (unpkg):    0 passed, 4 failed  — 93.2s, all timeouts
after  (jsDelivr): 4 passed, 0 failed  —  8.1s
```

That matches the 8 failing tests seen on CI exactly (4 tests × 2 browsers: 3 in `wammanager.spec.js`, 1 in `yoshimi.spec.js`).

## Not covered here

Three unpkg references remain, all currently working: `jshint` in `editorcontroller.js`, `pako` in `pianorolldemo/nft.js`, and `wasm-git` in `devserver.js` + `functions/wasm-git/[[path]].js`. They carry the same latent risk but are left alone to keep this diff scoped to the outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)