### PR TITLE
e2e: make pushBaseline reset the sandbox repo instead of writing over it

### DIFF
--- a/wasmaudioworklet/e2e/near-git-helpers.js
+++ b/wasmaudioworklet/e2e/near-git-helpers.js
@@ -61,7 +61,9 @@ export async function setupServiceWorker(page) {
  * deliberately-broken faust fixture from faust-editor.spec.js surfaced as
  * "missing `process` definition" inside studio-agent-mock.spec.js, which shares
  * none of its code. Reproduced locally — an interrupted run failed 4 tests, and
- * recreating the sandbox container restored all 12.
+ * recreating the sandbox container restored all 12. pushBaseline now wipes the
+ * tree before it pushes, which covers the specs that call it, but a spec that
+ * drives the worker itself still leaves its files behind for the next one.
  *
  * Use the shared sandbox repo ONLY when the test genuinely exercises the NEAR
  * remote: cloning, commit & sync, push, or delete-local behaviour.
@@ -104,7 +106,27 @@ export async function waitForStudioAgentTools(page) {
     await page.waitForFunction(() => typeof window.studioAgentRunTool === 'function', { timeout: 60000 });
 }
 
-/** Push a baseline commit via worker (fast, no UI). */
+/**
+ * Reset the shared sandbox repo to a known baseline and push it (fast, no UI).
+ *
+ * This is a RESET, not just a `song.js` write. The sandbox repo is recreated
+ * once per CI job and every spec that touches it commits into the same tree, so
+ * without a wipe a spec inherits whatever the previous one left: a `synth.ts`
+ * importing `../faust/<something>`, a half-written `faust/*.dsp`, a
+ * `shader.glsl`. That is not hypothetical — `studio-agent-mock.spec.js`'s
+ * shader test, which never calls `set_synth`, has failed with
+ * "missing `process` definition" because it cloned a Faust-backed `synth.ts`
+ * pushed by `faust-save-then-play-bug.spec.js` and `compile` then transpiled a
+ * dsp the test never set up.
+ *
+ * So: every file in the working tree is unlinked, and only `song.js` is written
+ * back. `synth.ts` intentionally does NOT survive — with no stored synth the
+ * app falls back to `synth1/assembly/mixes/emptymidi.mix.ts`, a plain
+ * AssemblyScript mix that compiles, and no `faust/` folder means the Faust
+ * editor has no file selected and `compile` skips the transpile entirely.
+ *
+ * Specs that do not need the NEAR remote should still prefer {@link specRepo}.
+ */
 export async function pushBaseline(page, repoName, content) {
     const creds = await fetchCredentials();
     const publicKey = creds.publicKey.replace('ed25519:', '');
@@ -135,6 +157,17 @@ export async function pushBaseline(page, repoName, content) {
         await next();
         worker.postMessage({ command: 'remote', args: ['add', 'origin', repoUrl], id: id++ });
         await next();
+
+        // Wipe whatever the previous spec left behind. `unlinkfile` only
+        // removes from the working tree; the deletion is staged at commit
+        // time by commitpullpush's `add --update .`, so it lands in the push.
+        worker.postMessage({ command: 'listfiles', id: id++ });
+        const listReply = await next();
+        for (const filename of (listReply.files || [])) {
+            if (filename === 'song.js') continue; // rewritten below anyway
+            worker.postMessage({ command: 'unlinkfile', filename });
+            await next();
+        }
 
         worker.postMessage({ command: 'writefileandstage', filename: 'song.js', contents: content });
         await next();


### PR DESCRIPTION
Fixes the red **Playwright E2E tests** job on master.

## Symptom

A Faust diagnostic in a test that never touches Faust — `studio-agent-mock.spec.js:197`, the shader-tools test:

```
Expected substring: "compiled OK"
Received string:    "Faust transpile failed: faust: error [FRS-EVAL-0001] missing `process` definition"
```

## Cause

The shader test never calls `set_synth`. It doesn't have to — the page snapshot from the failing run shows the synth editor already held:

```js
import { initializeMidiSynth, postprocess } from '../faust/simplesynth';
```

That line belongs to `faust-save-then-play-bug.spec.js`. Every sandbox-backed spec commits into **one** repo (`NEAR_REPO_CONTRACT`), created once per CI job, and `pushBaseline()` cloned that repo and wrote `song.js` on top of it. `synth.ts`, `faust/*.dsp` and `shader.glsl` all survived into the next spec.

`compile()` then calls `saveFaustIfChanged()`, which transpiles as soon as a Faust file is selected — and the `.dsp` it found was a fixture another spec had deliberately left un-transpilable.

Whether it blows up depends on what the previous spec happened to leave behind, which is why **the same tree passed on a PR run and failed on the master push**: the master run retried `near-git.spec.js` twice, and the retries pushed different residue.

## Fix

Make `pushBaseline()` a real reset: list the working tree, unlink everything, write back only `song.js`. `unlinkfile` leaves the deletion unstaged and `commitpullpush`'s `add --update .` stages it, so the wipe lands in the push.

`synth.ts` deliberately does not survive — with no stored synth the app falls back to `synth1/assembly/mixes/emptymidi.mix.ts`, and with no `faust/` folder the Faust editor has nothing selected, so `compile` skips the transpile entirely.

## Verification

Against a local NEAR sandbox, running `faust-editor.spec.js` + `studio-agent-mock.spec.js` in CI order:

| | Result |
|---|---|
| Before | **3 failed + 1 flaky** (1.9m) |
| After | **12/12 passed** (44.7s) |

The reproduction also caught a second instance of the same class: `faust-editor.spec.js`'s *"faust toggle reveals the editor with empty dropdown when no .dsp files exist"* was failing on `.dsp` files left over from an earlier run.

Full suite after the fix: **74 passed, 1 skipped, 0 failed** — on a sandbox already dirtied by three previous runs, which is a stronger guarantee than CI's fresh container.

## Note

[`specRepo()`](https://github.com/petersalomonsen/javascriptmusic/blob/master/wasmaudioworklet/e2e/near-git-helpers.js#L69) remains the better answer for specs that don't need the NEAR remote, and its docblock already warned about exactly this failure. This PR only fixes the specs that legitimately do use the shared repo; a spec that drives the wasm-git worker itself (rather than calling `pushBaseline`) still leaves its files behind for the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)