### PR TITLE
wasmgit: git log on a repo with no commits hung the caller forever

### DIFF
--- a/wasmaudioworklet/e2e/default-workspace.spec.js
+++ b/wasmaudioworklet/e2e/default-workspace.spec.js
@@ -106,3 +106,26 @@ test('without the opt-in, localhost keeps the classic no-repo boot with the MIDI
     expect(await page.evaluate(() => !!document.querySelector('app-javascriptmusic')
         .shadowRoot.querySelector('wasmgit-ui'))).toBe(false);
 });
+
+// A fresh workspace repo has no commits, so it has no HEAD — and `git log`
+// FAILS there rather than printing nothing. The worker's log branch used to run
+// uncaught, so the exception escaped onmessage, `{ log }` was never posted, and
+// gitLog()'s promise (which has no reject path and no timeout) never settled.
+// The studio agent called git_log on a first visit and the whole turn hung
+// forever with no error — the worst shape a failure can take.
+test('git_log on a fresh workspace returns instead of hanging forever', async ({ page }) => {
+    await page.goto('http://localhost:8080/?defaultrepo=1');
+    await waitForAppReady(page);
+    await page.waitForFunction(() => typeof window.studioAgentRunTool === 'function', { timeout: 30000 });
+
+    // Race it: the bug is a promise that never settles, so a plain await would
+    // hang the whole run rather than fail it.
+    const outcome = await page.evaluate(async () => await Promise.race([
+        window.studioAgentRunTool('git_log').then((v) => ({ settled: true, value: String(v) })),
+        new Promise((resolve) => setTimeout(() => resolve({ settled: false }), 20000)),
+    ]));
+
+    expect(outcome.settled).toBe(true);
+    // An empty history is the honest answer, and git_log already words it.
+    expect(outcome.value).toContain('no commits yet');
+});

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -412,8 +412,19 @@ onmessage = async (msg) => {
       postMessage({ filename: msg.data.filename, error: JSON.stringify(e) });
     }
   } else if (msg.data.command === 'log') {
-    callAndCaptureOutput(['log']);
-    postMessage({ log: stdout });
+    // A repo with no commits has no HEAD, and `git log` FAILS there rather than
+    // printing nothing. Uncaught, that exception escapes onmessage, { log } is
+    // never posted, and gitLog() — whose promise has no reject path — hangs its
+    // caller forever. That stalled a whole studio-agent turn: the agent called
+    // git_log on a fresh workspace and the turn never came back. An empty log is
+    // the honest answer for a repo with no commits, which is what git_log's own
+    // `|| '(no commits yet)'` was already written to expect.
+    try {
+      callAndCaptureOutput(['log']);
+      postMessage({ log: stdout });
+    } catch (e) {
+      postMessage({ log: '', error: stderr || (e && e.message) || String(e) });
+    }
   } else {
     const args = msg.data.args || [];
     try {


### PR DESCRIPTION
Found by driving the [reference session](https://github.com/petersalomonsen/javascriptmusic/pull/205) against the live app with NEAR AI: the studio agent called `git_log` on a first visit and **the turn never came back**. Not a model problem, and not a slow one — a promise that never settles.

## The bug

A fresh workspace repo has no commits, so it has no HEAD — and `git log` *fails* there rather than printing nothing. The worker's `log` branch was the only one without a try/catch:

```js
} else if (msg.data.command === 'log') {
  callAndCaptureOutput(['log']);   // throws: reference 'refs/heads/master' not found
  postMessage({ log: stdout });    // never runs
}
```

The exception escapes `onmessage` — surfacing only as a console `Could not find repository HEAD` — so `{ log }` is never posted. On the client, `gitLog()` waits on a promise built with `resolve` and **no reject and no timeout**:

```js
export async function gitLog() {
    return await new Promise((resolve) => { /* only ever resolves on { log } */ });
}
```

So it hangs. The `try/catch` in the `git_log` tool can't help — you cannot catch a promise that never settles.

Isolated with no model involved:

```
calling git_log on a fresh defaultrepo workspace, 60s limit...
NEVER SETTLED after 60s  <-- hangs the agent turn
```

This strands any user on the default local workspace: ask the agent anything, it reaches for `git_log`, and the turn hangs with no error and nothing to retry.

## The fix

Catch, and post an empty log. That's the honest answer for a repo with no commits, and exactly what `git_log`'s own `|| '(no commits yet)'` was already written to expect. After:

```
SETTLED in 0s -> "(no commits yet)"
```

## The test

In `default-workspace.spec.js`, which already boots `?defaultrepo=1`. It **races** the call against a 20s timer rather than awaiting it, because the bug's whole shape is "never returns" — a plain `await` would hang the suite instead of failing it.

Verified both directions: passes with the fix, and with the worker change stashed it fails on `settled: false` after 26s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
