### PR TITLE
nearai: stop echoing the model's own reasoning back on every request

### DIFF
--- a/wasmaudioworklet/studio-agent/nearai-core.js
+++ b/wasmaudioworklet/studio-agent/nearai-core.js
@@ -50,6 +50,25 @@ export const SERVERLESS_PROMPT_SUFFIX = `
 - Read/Glob/Grep are NOT available. To read repository reference files (examples, docs) use read_repo_file(path) with a repo-relative path.
 - Keep replies short; each tool call is a full network round-trip.`;
 
+// What goes BACK to the API from an assistant turn: role, content, tool_calls.
+// Nothing else.
+//
+// A thinking model answers with its private reasoning attached —
+// `reasoning_content` under the DeepSeek/Qwen convention, `reasoning` elsewhere.
+// Pushing the raw message kept all of it in the history and re-sent every past
+// thought on every subsequent request. In a real four-ask session that was 59%
+// of the whole conversation: 34,745 of 61,612 chars, which is what pushed a
+// deployed session past the proxy's 60k cap and 413'd it. Dropping it puts the
+// same session at 26,867.
+//
+// This is not a heuristic — reasoning is generated fresh each turn and the
+// providers that emit these fields document that they are not to be sent back.
+const forHistory = (msg) => ({
+  role: msg.role ?? 'assistant',
+  ...(msg.content ? { content: msg.content } : {}),
+  ...(msg.tool_calls?.length ? { tool_calls: msg.tool_calls } : {}),
+});
+
 // Run ONE user turn: call the model, execute tool calls against runTool, feed
 // results back, repeat until the model answers without tool calls (or the
 // iteration cap is hit). Mutates and returns `messages` (the caller owns and
@@ -97,7 +116,7 @@ export async function runAgentTurn({
     const data = await response.json();
     const msg = data.choices?.[0]?.message;
     if (!msg) throw new Error('NEAR AI: empty response (no choices[0].message)');
-    messages.push(msg);
+    messages.push(forHistory(msg));
 
     if (msg.content) onText(msg.content);
 

--- a/wasmaudioworklet/studio-agent/nearai-core.test.mjs
+++ b/wasmaudioworklet/studio-agent/nearai-core.test.mjs
@@ -164,3 +164,54 @@ test('runaway tool loops hit the iteration cap', async () => {
     /did not finish within 3/,
   );
 });
+
+// A thinking model attaches its private reasoning to every answer. Keeping it in
+// the history meant re-sending every past thought on every request: in a real
+// four-ask session that was 34,745 of 61,612 conversation chars — 59% — and it
+// pushed a deployed session past the proxy's 60k cap into a 413. Reasoning is
+// regenerated each turn and the providers emitting these fields document that
+// they are not to be sent back, so history keeps role/content/tool_calls only.
+test('a thinking model’s reasoning is not echoed back on the next request', async () => {
+  const bodies = [];
+  const messages = [{ role: 'user', content: 'hi' }];
+  await runAgentTurn({
+    fetchFn: scriptedFetch([
+      completion({
+        role: 'assistant',
+        content: 'working on it',
+        reasoning_content: 'X'.repeat(5000),
+        reasoning: 'Y'.repeat(5000),
+        tool_calls: [{ id: 'c1', type: 'function', function: { name: 'compile', arguments: '{}' } }],
+      }),
+      completion({ role: 'assistant', content: 'done' }),
+    ], bodies),
+    baseUrl: 'https://x/v1', apiKey: 'k', model: 'm',
+    messages, runTool: async () => 'compiled OK',
+  });
+
+  // The SECOND request carries the first answer back — without the thinking.
+  const sent = JSON.stringify(bodies[1]);
+  assert.ok(!sent.includes('XXXXX'), 'reasoning_content must not be re-sent');
+  assert.ok(!sent.includes('YYYYY'), 'reasoning must not be re-sent');
+
+  const assistant = bodies[1].messages.find((m) => m.role === 'assistant');
+  assert.deepEqual(Object.keys(assistant).sort(), ['content', 'role', 'tool_calls']);
+  assert.equal(assistant.content, 'working on it');
+  assert.equal(assistant.tool_calls[0].function.name, 'compile');
+});
+
+test('an assistant turn with no content keeps the tool_calls and adds no empty fields', async () => {
+  const bodies = [];
+  const messages = [{ role: 'user', content: 'hi' }];
+  await runAgentTurn({
+    fetchFn: scriptedFetch([
+      completion({ role: 'assistant', content: '', reasoning_content: 'thinking…',
+        tool_calls: [{ id: 'c1', type: 'function', function: { name: 'get_song', arguments: '{}' } }] }),
+      completion({ role: 'assistant', content: 'ok' }),
+    ], bodies),
+    baseUrl: 'https://x/v1', apiKey: 'k', model: 'm',
+    messages, runTool: async () => 'setBPM(120);',
+  });
+  const assistant = bodies[1].messages.find((m) => m.role === 'assistant');
+  assert.deepEqual(Object.keys(assistant).sort(), ['role', 'tool_calls']);
+});


### PR DESCRIPTION
A deployed session died on `NEAR AI 413: conversation too large` four asks into the reference session. Measured on **the actual failing request**:

| field | chars | share of conversation |
|---|---|---|
| **`reasoning_content`** | **34,745** | **59%** |
| `content` | 16,382 | 28% |
| `tool_calls` | 7,013 | 12% |

61,612 chars against the proxy's 60,000 cap — over by 2.7%, and 59% of it was the model's own thinking being handed back to it.

## Cause

`runAgentTurn` pushed the raw response message into the history:

```js
const msg = data.choices?.[0]?.message;
messages.push(msg);          // reasoning_content and all
```

A thinking model attaches its private reasoning to every answer — `reasoning_content` under the DeepSeek/Qwen convention, `reasoning` elsewhere — so every past thought went back on every subsequent request, compounding turn on turn.

Worth noting what *wasn't* the problem: the tool **results**, the things that look expensive, were 6,060 chars — a tenth of it. I'd have guessed wrong without measuring.

## Fix

History carries `role`, `content`, `tool_calls`, nothing else. Replaying the real failing payload through it:

```
real failing conversation: 61612 chars (413)
with the fix applied:      26375 chars  OK
```

From 2.7% over the cap to 44% of it.

This isn't a threshold to tune. Reasoning is regenerated each turn, and the providers that emit these fields document that they are not to be passed back.

## Why the earlier verification missed it

The live check on #205 ran in **direct key** mode, which talks to `cloud-api.near.ai` and never touches the Pages Function — so `MAX_MESSAGES_CHARS` was never exercised. Only the deployed proxy path enforces it, and that's the path real users are on.

## Notes

- **`bench-drums` needs no change** — its streaming loop builds history from `content` and `tool_call` deltas, so it never carried the field.
- Two regression tests: reasoning is absent from the next request, and the surviving keys are exactly `role`/`content`/`tool_calls` (plus a no-content case, since a tool-call-only turn must not gain an empty `content`).
- **Still open, and not addressed here:** there is no compaction for genuinely long sessions. This buys a lot of headroom — a four-ask session drops to 44% of budget — but a long enough session will still reach the cap, and `/compact` is not wired up in NEAR AI mode. That's the same wall the very first recorded session hit.

Tests: 73 agent-tools, 137 gitproxy, 12 nearai-core, 3/3 nearai e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
