### PR TITLE
nearai: one malformed tool call no longer bricks the whole session

### DIFF
--- a/tools/studio-agent/bench-drums.mjs
+++ b/tools/studio-agent/bench-drums.mjs
@@ -317,6 +317,13 @@ async function runOnceOpenAI(index) {
       break;
     }
     msg.tool_calls = msg.tool_calls.filter(Boolean);
+    // A tool call whose arguments never arrived leaves '' here, which is not
+    // valid JSON. Left in the history the provider rejects every LATER request
+    // with "Assistant tool call function.arguments must be valid JSON", so one
+    // empty call ends the run. Same normalisation as nearai-core's forHistory.
+    for (const c of msg.tool_calls) {
+      try { JSON.parse(c.function.arguments); } catch { c.function.arguments = '{}'; }
+    }
     if (!msg.tool_calls.length) delete msg.tool_calls;
     messages.push(msg);
 

--- a/wasmaudioworklet/studio-agent/nearai-core.js
+++ b/wasmaudioworklet/studio-agent/nearai-core.js
@@ -63,10 +63,35 @@ export const SERVERLESS_PROMPT_SUFFIX = `
 //
 // This is not a heuristic — reasoning is generated fresh each turn and the
 // providers that emit these fields document that they are not to be sent back.
+// A model can also emit a tool call whose `arguments` is not valid JSON — most
+// often the empty string. The CALL itself copes either way: an empty string is
+// falsy, so the loop below reads it as "no arguments" and runs the tool with {};
+// a malformed non-empty string is caught and answered with an error result.
+// The problem was the message staying in the history verbatim, so
+// every LATER request carried it and the provider rejected the whole
+// conversation with "Assistant tool call function.arguments must be valid JSON".
+// One malformed call bricked the session permanently: no further turn could
+// succeed, whatever the user typed.
+//
+// The call cannot simply be dropped — an assistant tool_call must stay paired
+// with its tool result or the history is malformed a different way. So the
+// arguments are normalised to an empty object, which is both valid and honest
+// about what was actually supplied.
+const isJson = (s) => {
+  if (typeof s !== 'string') return false;
+  try { JSON.parse(s); return true; } catch { return false; }
+};
+
 const forHistory = (msg) => ({
   role: msg.role ?? 'assistant',
   ...(msg.content ? { content: msg.content } : {}),
-  ...(msg.tool_calls?.length ? { tool_calls: msg.tool_calls } : {}),
+  ...(msg.tool_calls?.length
+    ? {
+      tool_calls: msg.tool_calls.map((c) => (isJson(c?.function?.arguments)
+        ? c
+        : { ...c, function: { ...c.function, arguments: '{}' } })),
+    }
+    : {}),
 });
 
 // Run ONE user turn: call the model, execute tool calls against runTool, feed

--- a/wasmaudioworklet/studio-agent/nearai-core.test.mjs
+++ b/wasmaudioworklet/studio-agent/nearai-core.test.mjs
@@ -215,3 +215,60 @@ test('an assistant turn with no content keeps the tool_calls and adds no empty f
   const assistant = bodies[1].messages.find((m) => m.role === 'assistant');
   assert.deepEqual(Object.keys(assistant).sort(), ['role', 'tool_calls']);
 });
+
+// A model can emit a tool call whose arguments are not valid JSON — an empty
+// string is the common one. The call itself was already answered with an error,
+// but the malformed message stayed in the history, so every LATER request was
+// rejected by the provider with "Assistant tool call function.arguments must be
+// valid JSON". One bad call bricked the session: no further turn could succeed.
+// Reproduced from a real 400, where message #71 held set_song with arguments "".
+test('a tool call with unparseable arguments does not poison the history', async () => {
+  const bodies = [];
+  const messages = [{ role: 'user', content: 'hi' }];
+  const results = [];
+  await runAgentTurn({
+    fetchFn: scriptedFetch([
+      completion({
+        role: 'assistant',
+        tool_calls: [{ id: 'c1', type: 'function', function: { name: 'set_song', arguments: '' } }],
+      }),
+      completion({ role: 'assistant', content: 'recovered' }),
+    ], bodies),
+    baseUrl: 'https://x/v1', apiKey: 'k', model: 'm',
+    messages, runTool: async (name, args) => { results.push(args); return 'ok'; },
+  });
+
+  const assistant = bodies[1].messages.find((m) => m.role === 'assistant');
+  assert.equal(assistant.tool_calls[0].function.arguments, '{}', 'normalised to valid JSON');
+  JSON.parse(assistant.tool_calls[0].function.arguments); // must not throw
+  assert.equal(assistant.tool_calls[0].function.name, 'set_song', 'the call itself is preserved');
+  // The pairing must survive: an assistant tool_call needs its tool result.
+  const toolMsg = bodies[1].messages.find((m) => m.role === 'tool');
+  assert.equal(toolMsg.tool_call_id, 'c1');
+  // An empty string is FALSY, so the loop reads it as "no arguments" and runs
+  // the tool with {}. That was never the bug — only the history was.
+  assert.deepEqual(results, [{}]);
+  assert.equal(toolMsg.content, 'ok');
+});
+
+test('genuinely malformed arguments are answered with an error and stored valid', async () => {
+  const bodies = [];
+  const messages = [{ role: 'user', content: 'hi' }];
+  const results = [];
+  await runAgentTurn({
+    fetchFn: scriptedFetch([
+      completion({
+        role: 'assistant',
+        tool_calls: [{ id: 'c9', type: 'function', function: { name: 'set_song', arguments: '{"source": ' } }],
+      }),
+      completion({ role: 'assistant', content: 'recovered' }),
+    ], bodies),
+    baseUrl: 'https://x/v1', apiKey: 'k', model: 'm',
+    messages, runTool: async (name, args) => { results.push(args); return 'ok'; },
+  });
+  const assistant = bodies[1].messages.find((m) => m.role === 'assistant');
+  assert.equal(assistant.tool_calls[0].function.arguments, '{}');
+  const toolMsg = bodies[1].messages.find((m) => m.role === 'tool');
+  assert.match(toolMsg.content, /could not parse tool arguments/);
+  assert.deepEqual(results, [], 'the tool is not run with arguments we could not read');
+});


### PR DESCRIPTION
A deployed session started answering every message with

```
NEAR AI 400: Assistant tool call function.arguments must be valid JSON.
```

and could not recover — not for that turn, not for any later one.

## Cause

The captured request shows it exactly. Message **#71** holds a `set_song` tool call whose `arguments` is the **empty string**:

```
>>> message #71 tool_call set_song has INVALID JSON arguments
    typeof: string | length: 0
    value: ""
```

That message stayed in the history, so every subsequent request carried it and the provider rejected the **entire conversation**. One bad call from the model ended the session permanently, whatever the user typed next.

Worth being precise about what was *not* broken: **the call itself**. An empty string is falsy, so `arguments ? JSON.parse(arguments) : {}` reads it as "no arguments" and runs the tool with `{}`; a malformed *non-empty* string is caught and answered with an error result. Only the stored message was wrong. (I had this wrong at first and the test caught me — the original assertion expected an error result that never happens.)

## Fix

`forHistory` normalises unparseable arguments to `'{}'`. Dropping the call instead would strand its tool result — an assistant `tool_call` must stay paired with one — so the call is kept and its arguments made both valid and honest about what was supplied.

## Verified against production

Replayed the real payload at `webassemblymusic.pages.dev/nearai/v1/chat/completions`, unfixed and fixed:

```
UNFIXED: HTTP 400  Assistant tool call function.arguments must be valid JSON.   ← the reported error
FIXED:   HTTP 200  model: Qwen/Qwen3.6-35B-A3B-FP8 | finish: tool_calls | set_song
```

The session doesn't merely stop erroring — it resumes the work it was doing.

## Not the same bug as #207

Conversation size here was **28,078 chars against the 60k cap** — comfortably under. #207's reasoning fix is working; this is a separate fault that it happened to unmask by letting sessions run longer.

## bench-drums had the same hole

Different route, same result: its streaming loop starts each call's `arguments` at `''` and only appends deltas, so a call that never receives any leaves an empty string in the history. Normalised the same way.

Tests: 75 agent-tools, 137 gitproxy, 14 nearai-core (two new: the empty-string case and a genuinely malformed one), 3/3 nearai e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
