### PR TITLE
sandbox: carry the song's BPM back to the host, so an inserted take lands right

### DIFF
--- a/wasmaudioworklet/midisequencer/quickjssandbox.js
+++ b/wasmaudioworklet/midisequencer/quickjssandbox.js
@@ -76,6 +76,10 @@ export async function __runSong() {
     }
     result.instrumentNames = instrumentNames;
     result.recordingStartTimeMillis = recordingStartTimeMillis;
+    // setBPM() ran in HERE, so the host's copy of pattern.js still holds the
+    // default. Anything host-side that reads the tempo — inserting a recorded
+    // take is the one that bites — needs it carried back across.
+    result.bpm = bpm;
     result.songParts = Object.fromEntries(Object.entries(songParts)
         .map(([name, part]) => [name, { startTime: part.startTime, endTime: part.endTime }]));
     result.trackerPatterns = trackerPatterns.filter(p => p).map(p => ({

--- a/wasmaudioworklet/midisequencer/songcompiler.js
+++ b/wasmaudioworklet/midisequencer/songcompiler.js
@@ -276,6 +276,12 @@ export async function compileSong(songsource) {
     songmessages = result.events;
     instrumentNames = result.instrumentNames;
     recordingStartTimeMillis = result.recordingStartTimeMillis;
+    // The song's setBPM() ran inside the sandbox, against the GUEST's copy of
+    // pattern.js. Without this the host stays at the 110 default, and
+    // insertMidiRecording — which reads `bpm` from the host module — writes a
+    // take at 110/125 of its real position: every note early, the whole phrase
+    // compressed. It sounded right while playing and wrong once inserted.
+    if (typeof result.bpm === 'number' && result.bpm > 0) setBPM(result.bpm);
     songParts = result.songParts;
     trackerPatterns = result.trackerPatterns;
 

--- a/wasmaudioworklet/quickjs-sandbox-poc.test.mjs
+++ b/wasmaudioworklet/quickjs-sandbox-poc.test.mjs
@@ -119,3 +119,28 @@ test('setVisual rejects names that are not valid GLSL uniforms', async () => {
     await assert.rejects(runSongInSandbox(`setVisual('glow', 'bright'); await createTrack(0).steps(4, [c3]);`),
         /must be a finite number/);
 });
+
+// setBPM() runs INSIDE the guest, against the guest's copy of pattern.js. The
+// host's copy therefore keeps the 110 default unless the tempo is carried back
+// with the rest of the snapshot — and host-side code reads it. insertMidiRecording
+// converts a captured take to beats with `seconds * bpm / 60`, so a 125 BPM song
+// wrote every recorded note at 110/125 = 88% of its real position: the take came
+// in early and compressed, while sounding perfectly correct during playback
+// (audio is scheduled from the compiled event list in milliseconds, which was
+// never wrong). The transport's seek readout reads the same binding.
+test('the song tempo reaches the host, not just the guest', async () => {
+    // Set the host to a value the song does NOT ask for, so this proves the
+    // transfer rather than depending on the module default surviving whatever
+    // other tests in this file compiled first.
+    const { setBPM } = await import('./midisequencer/pattern.js');
+    setBPM(70);
+
+    await compileSong('setBPM(125);\nawait createTrack(0).steps(1, [c4, c4, c4, c4]);\nloopHere();');
+
+    const { bpm: after } = await import('./midisequencer/pattern.js');
+    assert.strictEqual(after, 125);
+
+    // The conversion insertMidiRecording performs, at the tempo it would read.
+    assert.strictEqual(Math.round((10 * after) / 60 * 100) / 100, 20.83,
+        'ten seconds of take lands on the right beat');
+});


### PR DESCRIPTION
A take recorded against a **125 BPM** song sounded correct while playing, then came out **early and compressed** once inserted as code. Every note was written at **110/125 = 88%** of its real beat position.

## Cause

`setBPM()` runs *inside* the QuickJS guest, against the guest's copy of `pattern.js`. The host's copy keeps its `110` default.

`compileSong` already carries `instrumentNames` and `recordingStartTimeMillis` back out of the guest snapshot — `bpm` was missed. And host-side code reads it:

| reader | uses it for |
|---|---|
| `midisequencer/editorfunctions.js` → `RecordConverter` | converting a take: `seconds * bpm / 60` |
| `synth1/audioworklet/midisynthaudioworklet.js` → `attachSeek` | the transport readout |

Demonstrated directly:

```
host bpm BEFORE compile: 110
host bpm AFTER  compile: 110    (song asked for 125)
a take played at 10.0s would be written as beat 18.33 instead of 20.83  -> 88%
```

**Playback was never wrong**, which is exactly what made this confusing to hit — audio is scheduled from the compiled event list in *milliseconds*, so it's unaffected. Only values computed in **beats** on the host were off, and inserting a recording is the one where that reads as musically wrong.

This is a **regression from sandboxing `compileSong`**. Before that, `setBPM` mutated the same module instance the host read, so it had always worked.

## Fix

Two lines: the guest snapshot carries `bpm`, and `compileSong` applies it.

```
host bpm after compile: 125 OK
a take at 10.0s now writes as beat 20.83 (correct is 20.83)
```

## Test

In `quickjs-sandbox-poc.test.mjs`, the home of the host/guest state-transfer tests. It sets the host to a tempo the song does **not** ask for, so it proves the transfer rather than depending on the module default surviving whatever the other tests in that file compiled first — the first version of it passed for the wrong reason and failed on ordering. Verified it fails with the fix reverted.

Suites: 8 quickjs-sandbox, 75 agent-tools, 137 gitproxy, and Web Test Runner 77 passed on both Chromium and Firefox — that last one includes the spec that calls `insertRecording`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
