### PR TITLE
pay: show a pass duration in the unit passes actually have

### DIFF
--- a/wasmaudioworklet/near/x402-client.js
+++ b/wasmaudioworklet/near/x402-client.js
@@ -82,6 +82,23 @@ export function passRemainingSeconds(pass, now = Date.now()) {
   return Math.max(0, Math.floor((claims.exp * 1000 - now) / 1000));
 }
 
+/** A pass duration in words. Passes are minutes long, not hours — the default
+ *  is 30 minutes — so hours were the wrong unit entirely: `Math.floor(1800/3600)`
+ *  told the buyer they had "about 0h left" on a pass they had just been given,
+ *  and the claim message rounded the same figure up to "1 hours". The TTL is
+ *  configurable (X402_PASS_TTL_MS), so this covers the longer cases too rather
+ *  than swapping one hardcoded unit for another. */
+export function formatPassDuration(seconds) {
+  const total = Math.max(0, Math.round(seconds));
+  if (total < 60) return `${total} second${total === 1 ? '' : 's'}`;
+  const minutes = Math.round(total / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  const h = `${hours} hour${hours === 1 ? '' : 's'}`;
+  return rest ? `${h} ${rest} min` : h;
+}
+
 // ---- wallet capability -----------------------------------------------------
 
 /** Does this wallet declare delegate-action signing? Checked before offering

--- a/wasmaudioworklet/near/x402-client.test.mjs
+++ b/wasmaudioworklet/near/x402-client.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildDelegateAction, selectRequirements, walletCanPay, payWithTransaction, passAccountId,
-  encodeHeader, decodeHeader, passRemainingSeconds, passKey,
+  encodeHeader, decodeHeader, passRemainingSeconds, passKey, formatPassDuration,
 } from './x402-client.js';
 import { paymentRequirements, nearTxRequirements, memoFor, x402Config, encodeHeader as srvEncode } from '../functions/_x402.js';
 
@@ -153,4 +153,25 @@ test('one pass per browser, and it says who paid', () => {
   const claims = (sub, exp) => 'h.' + Buffer.from(JSON.stringify({ sub, exp })).toString('base64url') + '.s';
   assert.equal(passAccountId(claims('alice.near', 2 ** 31)), 'alice.near');
   assert.equal(passAccountId('rubbish'), null);
+});
+
+// Passes are MINUTES long — 30 by default — so the pay page's hours arithmetic
+// was the wrong unit throughout: Math.floor(1800/3600) told a buyer they had
+// "about 0h left" on a pass just issued, and the claim message rounded the same
+// figure up to "1 hours". Singular/plural matters here because the numbers are
+// small enough to hit 1 routinely.
+test('formatPassDuration reads naturally at the durations passes actually have', () => {
+  assert.equal(formatPassDuration(1800), '30 minutes');   // the default pass
+  assert.equal(formatPassDuration(60), '1 minute');
+  assert.equal(formatPassDuration(90), '2 minutes');
+  assert.equal(formatPassDuration(3600), '1 hour');
+  assert.equal(formatPassDuration(5400), '1 hour 30 min');
+  assert.equal(formatPassDuration(86400), '24 hours');
+});
+
+test('formatPassDuration handles the edges without saying "0h"', () => {
+  assert.equal(formatPassDuration(0), '0 seconds');
+  assert.equal(formatPassDuration(1), '1 second');
+  assert.equal(formatPassDuration(45), '45 seconds');
+  assert.equal(formatPassDuration(-10), '0 seconds', 'an expired pass never reads as negative');
 });

--- a/wasmaudioworklet/pay.html
+++ b/wasmaudioworklet/pay.html
@@ -56,7 +56,7 @@
 <script type="module">
 import {
   createPaymentFetch, claimSponsorPass, loadPass, passRemainingSeconds, passAccountId,
-  selectRequirements, decodeHeader, PASS_ENDPOINT,
+  formatPassDuration, selectRequirements, decodeHeader, PASS_ENDPOINT,
 } from './near/x402-client.js';
 
 // Claiming runs against the pass endpoint, which mints without spending any
@@ -80,8 +80,8 @@ let connector, wallet, accountId, terms;
 // Already paid? Say so rather than charging twice.
 const existing = loadPass();
 if (passRemainingSeconds(existing) > 0) {
-  const h = Math.floor(passRemainingSeconds(existing) / 3600);
-  say(`You already have a pass — about ${h}h left${passAccountId(existing) ? `, bought by ${passAccountId(existing)}` : ''}.`, 'ok');
+  const left = formatPassDuration(passRemainingSeconds(existing));
+  say(`You already have a pass — about ${left} left${passAccountId(existing) ? `, bought by ${passAccountId(existing)}` : ''}.`, 'ok');
   $('connect').style.display = 'none';
   $('close').style.display = '';
 }
@@ -194,7 +194,7 @@ $('claim').onclick = async () => {
   say('Sign the message in your wallet to prove the account is yours…', 'info');
   try {
     const result = await claimSponsorPass(wallet, sponsorship, { accountId });
-    say(`Thank you for supporting the project. Your pass is active for ${Math.round(result.secondsRemaining / 3600)} hours.`, 'ok');
+    say(`Thank you for supporting the project. Your pass is active for ${formatPassDuration(result.secondsRemaining)}.`, 'ok');
     $('claim').style.display = 'none';
     $('close').style.display = '';
     try { window.opener?.postMessage({ type: 'studio-pass', pass: result.pass }, location.origin); } catch { /* COOP severed it */ }


### PR DESCRIPTION
Passes are **30 minutes**. The pay page measured them in hours, so both of its messages were wrong for every pass we issue:

| shown | computed as |
|---|---|
| *"You already have a pass — about **0h** left."* | `Math.floor(1800 / 3600)` |
| *"Your pass is active for **1 hours**."* | `Math.round(1800 / 3600)` |

The first tells someone their brand-new pass has nothing left on it. The second is both the wrong number and ungrammatical.

## Fix

`formatPassDuration` picks the unit from the duration rather than assuming one — the TTL is configurable via `X402_PASS_TTL_MS`, so swapping a hardcoded "hours" for a hardcoded "minutes" would just move the problem to whoever changes it next:

```
    0 -> "0 seconds"        60 -> "1 minute"      3600 -> "1 hour"
   45 -> "45 seconds"     1800 -> "30 minutes"    5400 -> "1 hour 30 min"
```

It sits beside `passRemainingSeconds` in `near/x402-client.js`, which `pay.html` already imports. Singular/plural is handled — at these durations the count hits 1 routinely, which is how "1 hours" got shipped in the first place.

Tests: 139 gitproxy (2 new, covering the real durations and the edges including a negative remaining time), 7/7 paywall e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
