### PR TITLE
nearai: give a thinking model room to finish, and say when it ran out

### DIFF
--- a/wasmaudioworklet/functions/nearai/[[path]].js
+++ b/wasmaudioworklet/functions/nearai/[[path]].js
@@ -49,7 +49,20 @@ const MAX_SYSTEM_CHARS = 80000;
 
 // Bounds the expensive half of a request. Output costs several times input on
 // every model we would consider, and was previously unbounded.
-const MAX_COMPLETION_TOKENS = 2000;
+//
+// 2000 was too tight once the model became a THINKING one: reasoning is billed
+// as output and spends the same budget, so a turn could burn the lot before
+// emitting a single token of answer. A real one did exactly that —
+//
+//   "finish_reason": "length",
+//   "usage": { "completion_tokens": 2000, "reasoning_tokens": 2001,
+//              "prompt_tokens": 22976 }
+//
+// — 23k of input paid for, nothing returned, and the user left to send it again
+// at the same input cost. A cap that forces a retry does not bound spending, it
+// doubles it. This has to leave room for the thinking AND the tool call that
+// follows it.
+const MAX_COMPLETION_TOKENS = 8000;
 
 export const ALLOWED_ORIGINS = [
   /^https:\/\/([a-z0-9-]+\.)?webassemblymusic\.pages\.dev$/, // prod + preview deploys

--- a/wasmaudioworklet/nearai-proxy.test.mjs
+++ b/wasmaudioworklet/nearai-proxy.test.mjs
@@ -156,11 +156,19 @@ test('the deployment can pick the model without a code change', async () => {
   assert.equal(modelFor({}), MODEL);
 });
 
-test('completion length is capped — output is the expensive half', async () => {
+// Bounded, but not so tight that a thinking model spends the whole budget on
+// reasoning and returns nothing — a real turn came back with finish_reason
+// "length", completion_tokens 2000 of a 2000 cap and reasoning_tokens 2001,
+// having burned 23k of paid input for no output at all. A cap that forces the
+// user to send it all again is not bounding spend, it is doubling it. So the
+// floor matters as much as the ceiling here.
+test('completion length is capped, with room for thinking AND an answer', async () => {
   const captured = captureFetch();
   await onRequest(chat({ messages: [{ role: 'user', content: 'hi' }] }));
   assert.equal(typeof captured.body.max_tokens, 'number');
-  assert.ok(captured.body.max_tokens > 0 && captured.body.max_tokens <= 4000,
+  assert.ok(captured.body.max_tokens >= 4000,
+    `too tight for a reasoning model to finish a turn: ${captured.body.max_tokens}`);
+  assert.ok(captured.body.max_tokens <= 32000,
     `unbounded or absurd max_tokens: ${captured.body.max_tokens}`);
 });
 

--- a/wasmaudioworklet/studio-agent/client.js
+++ b/wasmaudioworklet/studio-agent/client.js
@@ -753,7 +753,7 @@ async function runNearaiTurn(text) {
   nearaiMessages.push({ role: 'user', content });
   setPhase(`${cfg.model.split('/').pop()} thinking…`);
   try {
-    const { usage, answered } = await runAgentTurn({
+    const { usage, answered, finishReason } = await runAgentTurn({
       // The signal rides on every request of the turn, so Stop lands mid-loop
       // rather than only between tool calls.
       // The pass rides on every request of the turn; a 402 mid-turn (expiry,
@@ -797,8 +797,10 @@ async function runNearaiTurn(text) {
     if (agentText) { conversation.push({ role: 'agent', text: agentText }); saveSession(); }
     finishAgentMessage();
     if (!agentText && answered === false) {
-      addLine('tool', '— the model ended the turn without an answer. Send again, or rephrase —');
-      stopActivity('no answer');
+      addLine('tool', finishReason === 'length'
+        ? '— the model ran out of output budget while thinking, before it could answer. Try a smaller step —'
+        : '— the model ended the turn without an answer. Send again, or rephrase —');
+      stopActivity(finishReason === 'length' ? 'out of output budget' : 'no answer');
     } else {
       stopActivity(`done ✓ (${usage?.total_tokens ?? '?'} tokens)`);
     }

--- a/wasmaudioworklet/studio-agent/nearai-core.js
+++ b/wasmaudioworklet/studio-agent/nearai-core.js
@@ -149,8 +149,15 @@ export async function runAgentTurn({
       // A thinking model can end a turn having emitted only reasoning: no
       // content, no tool calls. Nothing is wrong enough to throw, but the turn
       // produced no answer, and reporting "done" for that reads as the agent
-      // silently giving up. Say which it was.
-      return { messages, usage: data.usage, answered: Boolean(msg.content) };
+      // silently giving up. Say which it was — and pass on finish_reason,
+      // because "length" means it was CUT OFF mid-thought rather than choosing
+      // to stop, which is a different problem with a different fix.
+      return {
+        messages,
+        usage: data.usage,
+        answered: Boolean(msg.content),
+        finishReason: data.choices?.[0]?.finish_reason ?? null,
+      };
     }
     for (const call of msg.tool_calls) {
       // Belt and braces: the tools are registered bare here, but the MCP-style

--- a/wasmaudioworklet/studio-agent/nearai-core.test.mjs
+++ b/wasmaudioworklet/studio-agent/nearai-core.test.mjs
@@ -292,3 +292,29 @@ test('a turn that produces no answer is reported as such, not as done', async ()
   });
   assert.strictEqual(silent.answered, false);
 });
+
+// "no answer" has two causes that need different responses. A model that simply
+// stops has nothing more to say; one cut off at the token limit was mid-thought
+// and would have carried on. A real turn hit the second: finish_reason "length",
+// completion_tokens 2000 against a 2000 cap, reasoning_tokens 2001 — the whole
+// output budget spent thinking, 23k of input paid for, nothing returned.
+test('a turn cut off at the token limit is distinguishable from one that just stopped', async () => {
+  const cutOff = await runAgentTurn({
+    fetchFn: async () => ok({
+      choices: [{ message: { role: 'assistant', reasoning_content: 'thinking…' }, finish_reason: 'length' }],
+      usage: { completion_tokens: 2000, reasoning_tokens: 2001 },
+    }),
+    baseUrl: 'https://x/v1', apiKey: 'k', model: 'm',
+    messages: [{ role: 'user', content: 'hi' }], runTool: async () => 'ok',
+  });
+  assert.strictEqual(cutOff.answered, false);
+  assert.strictEqual(cutOff.finishReason, 'length');
+
+  const justStopped = await runAgentTurn({
+    fetchFn: async () => ok({ choices: [{ message: { role: 'assistant', content: 'here' }, finish_reason: 'stop' }] }),
+    baseUrl: 'https://x/v1', apiKey: 'k', model: 'm',
+    messages: [{ role: 'user', content: 'hi' }], runTool: async () => 'ok',
+  });
+  assert.strictEqual(justStopped.answered, true);
+  assert.strictEqual(justStopped.finishReason, 'stop');
+});


### PR DESCRIPTION
#210 made a turn that produces nothing say so instead of reporting `done ✓`. The very first message it surfaced showed what was actually going on:

```json
"finish_reason": "length",
"usage": { "completion_tokens": 2000, "reasoning_tokens": 2001, "prompt_tokens": 22976 }
```

The proxy caps completions at **2000** tokens. **Reasoning is billed as output and spends the same budget**, so the model burned the entire allowance thinking and was cut off mid-word — before a single token of answer or one tool call. The captured reasoning ends on `` d2(0.3 ``.

## Why the cap was wrong, not just small

Its rationale — *"output is the expensive half"* — predates the model being a thinking one. And on these numbers it doesn't hold even on its own terms: **22,976 prompt tokens were paid for and nothing came back**, so the user sends it again at the same input cost.

A cap that forces a retry doesn't bound spending — it doubles it.

`8000` leaves room for the thinking *and* the tool call that follows it.

## "No answer" has two causes

A model that simply stops has nothing more to say. One cut off at the limit was mid-thought and would have continued. Those need different words, so `finish_reason` now reaches the client:

> — the model ran out of output budget while thinking, before it could answer. Try a smaller step —

rather than suggesting a rephrase that wouldn't have helped.

## Note on how this was missed

**Only proxy mode sets `max_tokens`.** Direct-key sessions never hit it — the same structural blind spot that hid #207 and #208 from my testing. Three bugs now have reached the user first for exactly this reason.

## Test

The cap test asserts a **floor as well as a ceiling**. Too tight is its own failure mode, and that's what this bug was — the old test would have passed happily at 100 tokens.

Suites: 139 gitproxy, 77 agent-tools (1 new in nearai-core), 14 Playwright across the nearai/paywall/kit specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
