### PR TITLE
nearai: stop carrying stale copies of a document the model has re-read

### DIFF
--- a/wasmaudioworklet/studio-agent/nearai-core.js
+++ b/wasmaudioworklet/studio-agent/nearai-core.js
@@ -94,6 +94,39 @@ const forHistory = (msg) => ({
     : {}),
 });
 
+// Whole-document reads. Each takes no arguments and returns the entire current
+// document, so a later one STRICTLY supersedes every earlier one — the older
+// copies are not merely redundant, they are wrong, and leaving them in context
+// invites the model to edit against a version that no longer exists.
+//
+// A real session held FOUR full copies of the song: 11,754 chars of a 60k
+// conversation budget, three of them stale. Keeping only the newest is both
+// cheaper and more truthful.
+//
+// Deliberately limited to argument-free whole-document reads: read_faust is
+// per-path and grep_song is per-pattern, so a later call supersedes nothing.
+const SUPERSEDING_READS = new Set(['get_song', 'get_synth', 'get_shader']);
+const SUPERSEDED_NOTE = '(superseded — a later read of this document appears below)';
+
+export function pruneSupersededReads(messages) {
+  const toolName = new Map();
+  for (const m of messages) {
+    for (const c of m?.tool_calls ?? []) if (c?.id) toolName.set(c.id, c.function?.name);
+  }
+  const seen = new Set();
+  // Walk backwards so the FIRST one met is the newest, and keep that.
+  const out = messages.slice();
+  for (let i = out.length - 1; i >= 0; i--) {
+    const m = out[i];
+    if (m?.role !== 'tool') continue;
+    const name = toolName.get(m.tool_call_id);
+    if (!SUPERSEDING_READS.has(name)) continue;
+    if (!seen.has(name)) { seen.add(name); continue; }
+    if (m.content !== SUPERSEDED_NOTE) out[i] = { ...m, content: SUPERSEDED_NOTE };
+  }
+  return out;
+}
+
 // Run ONE user turn: call the model, execute tool calls against runTool, feed
 // results back, repeat until the model answers without tool calls (or the
 // iteration cap is hit). Mutates and returns `messages` (the caller owns and
@@ -126,7 +159,7 @@ export async function runAgentTurn({
       response = await fetchFn(`${baseUrl}/chat/completions`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ ...bodyBase, messages }),
+        body: JSON.stringify({ ...bodyBase, messages: pruneSupersededReads(messages) }),
       });
       const retryable = response.status === 429 || response.status >= 500;
       if (response.ok || !retryable || attempt >= maxRetries) break;

--- a/wasmaudioworklet/studio-agent/nearai-core.test.mjs
+++ b/wasmaudioworklet/studio-agent/nearai-core.test.mjs
@@ -2,7 +2,7 @@
 // loop (NEAR AI serverless provider). fetch is injected, so no network.
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { runAgentTurn, toOpenAiTools, TOOL_DEFS } from './nearai-core.js';
+import { runAgentTurn, toOpenAiTools, TOOL_DEFS, pruneSupersededReads } from './nearai-core.js';
 
 const ok = (payload) => ({ ok: true, json: async () => payload });
 const completion = (message, usage) => ok({ choices: [{ message }], usage });
@@ -317,4 +317,54 @@ test('a turn cut off at the token limit is distinguishable from one that just st
   });
   assert.strictEqual(justStopped.answered, true);
   assert.strictEqual(justStopped.finishReason, 'stop');
+});
+
+// A whole-document read returns the entire current document, so a later one
+// supersedes every earlier one. A real session carried FOUR full copies of the
+// song — 11,754 chars of a 60k budget, three of them stale — and tipped the
+// conversation over the proxy's cap. The old copies are not just waste: they
+// show the model versions of the file that no longer exist.
+const toolCall = (id, name) => ({ role: 'assistant', tool_calls: [{ id, type: 'function', function: { name, arguments: '{}' } }] });
+
+test('only the newest whole-document read is kept', () => {
+  const messages = [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'go' },
+    toolCall('a', 'get_song'), { role: 'tool', tool_call_id: 'a', content: 'SONG VERSION ONE' },
+    toolCall('b', 'get_song'), { role: 'tool', tool_call_id: 'b', content: 'SONG VERSION TWO' },
+    toolCall('c', 'get_song'), { role: 'tool', tool_call_id: 'c', content: 'SONG VERSION THREE' },
+  ];
+  const out = pruneSupersededReads(messages);
+
+  assert.equal(out.length, messages.length, 'a tool result must keep its assistant call');
+  assert.match(out.find((m) => m.tool_call_id === 'a').content, /superseded/);
+  assert.match(out.find((m) => m.tool_call_id === 'b').content, /superseded/);
+  assert.equal(out.find((m) => m.tool_call_id === 'c').content, 'SONG VERSION THREE',
+    'the newest read survives intact');
+  assert.deepEqual(messages.find((m) => m.tool_call_id === 'a').content, 'SONG VERSION ONE',
+    'the caller’s array is not mutated');
+});
+
+test('documents are superseded independently, and only whole-document reads are', () => {
+  const messages = [
+    toolCall('a', 'get_song'), { role: 'tool', tool_call_id: 'a', content: 'old song' },
+    toolCall('b', 'get_synth'), { role: 'tool', tool_call_id: 'b', content: 'the synth' },
+    toolCall('c', 'get_song'), { role: 'tool', tool_call_id: 'c', content: 'new song' },
+    // read_faust is per-PATH and grep_song per-PATTERN: a later call answers a
+    // different question, so it supersedes nothing.
+    toolCall('d', 'read_faust'), { role: 'tool', tool_call_id: 'd', content: 'kick.dsp' },
+    toolCall('e', 'read_faust'), { role: 'tool', tool_call_id: 'e', content: 'hihat.dsp' },
+    toolCall('f', 'grep_song'), { role: 'tool', tool_call_id: 'f', content: 'match one' },
+    toolCall('g', 'grep_song'), { role: 'tool', tool_call_id: 'g', content: 'match two' },
+  ];
+  const out = pruneSupersededReads(messages);
+  const at = (id) => out.find((m) => m.tool_call_id === id).content;
+
+  assert.match(at('a'), /superseded/);
+  assert.equal(at('c'), 'new song');
+  assert.equal(at('b'), 'the synth', 'a different document is untouched');
+  assert.equal(at('d'), 'kick.dsp');
+  assert.equal(at('e'), 'hihat.dsp');
+  assert.equal(at('f'), 'match one');
+  assert.equal(at('g'), 'match two');
 });


### PR DESCRIPTION
Another `conversation too large` — but this one **isn't bloat**. The history is genuinely long: 84 messages, **no `reasoning_content` anywhere** (#207 holding), 60,892 chars against the 60k cap. Over by 1.5%.

## Where the budget goes

| held in history | | |
|---|---|---|
| **`get_song` results** | **4×** | **11,754 chars** |
| `edit_song` call arguments | 19× | 21,547 chars |
| everything else | | 4,840 chars |

Four *full copies of the song document*. A whole-document read returns the entire current document, so a later one supersedes every earlier one — three of those four were stale.

And that's worse than waste: **the model was being shown versions of the file it is editing that no longer exist**, sitting right next to the current one.

## Fix

Superseded results become a short note; the newest is kept intact. On the real failing payload:

```
real failing conversation: 60892 chars  (cap 60000 -> 413)
after pruning stale reads: 52469 chars  OK
reclaimed: 8423 chars
messages unchanged: true
```

Message count is unchanged, so every tool result keeps the assistant call it answers — an orphaned result is malformed a different way.

Limited to **argument-free whole-document reads** (`get_song`/`get_synth`/`get_shader`). `read_faust` is per-path and `grep_song` per-pattern: a later call answers a *different question* and supersedes nothing. There's a test for exactly that.

## This is not compaction

It reclaims a fixed ~14% and removes a correctness hazard. **A session long enough will still reach the cap.** Real compaction — summarising or dropping old turns, and wiring up `/compact` in NEAR AI mode — is still missing, and this shouldn't be mistaken for it.

The 19 `edit_song` argument pairs are now the largest single item at 21.5k. I've left them: they're the model's record of what it changed, and dropping them is a different decision that needs its own care.

Tests: 79 agent-tools (2 new), 139 gitproxy, 8 quickjs-sandbox, 14 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
