### PR TITLE
nearai: double the completion budget — successful turns were near the ceiling

### DIFF
--- a/tools/studio-agent/bench-drums.mjs
+++ b/tools/studio-agent/bench-drums.mjs
@@ -18,7 +18,14 @@
 // SDK — same system prompt, same tools, same verdict, so the numbers compare:
 //
 //   BASE_URL=http://localhost:11434/v1 MODEL=gemma4:12b node bench-drums.mjs
-//   BASE_URL=https://cloud-api.near.ai/v1 MODEL=Qwen/Qwen3.5-122B-A10B node bench-drums.mjs
+//   BASE_URL=https://cloud-api.near.ai/v1 MODEL=Qwen/Qwen3.6-35B-A3B-FP8 node bench-drums.mjs
+//   THINKING=off ... node bench-drums.mjs      # disable a reasoning model's CoT
+//
+// THINKING=off answers "is the thinking earning its keep?", which is not
+// obvious: it is far cheaper per call and was clearly worse per TASK — 0/2
+// against 1/2, 22 tool calls against 13, and 311k input tokens against 164k,
+// because a model that reasons less takes more turns to get anywhere. Note
+// reasoning_effort is ignored by Qwen; chat_template_kwargs is the live knob.
 //
 // The key for a remote endpoint comes from API_KEY or ~/.nearai_api_key.
 // Caveat when reading results across backends: this bench exposes the SIX song
@@ -274,6 +281,10 @@ async function runOnceOpenAI(index) {
         body: JSON.stringify({
           model: MODEL, messages, tools, tool_choice: 'auto',
           stream: true, stream_options: { include_usage: true },
+          // THINKING=off disables a reasoning model's chain of thought. Qwen
+          // ignores reasoning_effort; this is the knob it honours.
+          ...(process.env.THINKING === 'off'
+            ? { chat_template_kwargs: { enable_thinking: false } } : {}),
         }),
       });
     } catch (e) {

--- a/wasmaudioworklet/functions/nearai/[[path]].js
+++ b/wasmaudioworklet/functions/nearai/[[path]].js
@@ -62,7 +62,18 @@ const MAX_SYSTEM_CHARS = 80000;
 // at the same input cost. A cap that forces a retry does not bound spending, it
 // doubles it. This has to leave room for the thinking AND the tool call that
 // follows it.
-const MAX_COMPLETION_TOKENS = 8000;
+//
+// 8000 was still too tight. Measured on the drum bench, the runs that SUCCEED
+// average 7,484 output tokens — within 7% of that ceiling, so ordinary work sat
+// one long thought away from truncation. A five-part restructuring ask needed
+// ~9,200 reasoning tokens before it could answer at all.
+//
+// Turning the thinking OFF was tried and is worse, so the budget is the only
+// lever: chat_template_kwargs {enable_thinking:false} scored 0/2 against 1/2,
+// took 22 tool calls against 13, and — because it flails through more turns —
+// spent 311k input tokens against 164k. Cheaper per call, dearer per task.
+// (reasoning_effort is ignored by this model; that knob does nothing.)
+const MAX_COMPLETION_TOKENS = 16000;
 
 export const ALLOWED_ORIGINS = [
   /^https:\/\/([a-z0-9-]+\.)?webassemblymusic\.pages\.dev$/, // prod + preview deploys


### PR DESCRIPTION
#212 raised the cap from 2000 to 8000 after a turn spent the lot on reasoning. **8000 is still too tight**, and the bench says why:

> the runs that **succeed** average **7,484 output tokens**

Ordinary working turns sit within **7%** of truncation, so any turn that thinks a little longer than usual returns nothing at all. The five-part restructuring ask that prompted this needed ~9,200 reasoning tokens before it could answer.

## Turning the thinking off was tried first, and is worse

It looks like the cheaper fix. It isn't:

| | pass | tool calls | **input tokens** |
|---|---|---|---|
| thinking **ON** | 1/2 | 13 | 164k |
| thinking **OFF** | 0/2 | 22 | **311k** |

Cheaper per call, dearer per task — a model that reasons less takes more turns to get anywhere, and pays for the whole conversation again on every one of them.

Also worth recording: **`reasoning_effort` is ignored by this model entirely** (low/minimal produced identical reasoning-token counts). `chat_template_kwargs: {enable_thinking: false}` is the knob that actually works — and per the table, we don't want it.

So the budget is the only lever, and **16000** leaves real headroom above where working turns land.

## What this does *not* fix

A big compound ask still comes back as **prose rather than tool calls**. At 16000 *and* at 24000 the same turn finished cleanly (`finish_reason: stop`) and answered in words without editing anything. The budget was never why that ask failed to land — it's more than this model converts into edits in one step, and the app already says *"try a smaller step"*.

I'd rather state that than let the cap increase imply a fix it doesn't deliver.

## Also

`bench-drums` keeps the `THINKING=off` switch — it's how the comparison above was made, and the next model will need the same question asked of it.

Caveat on the numbers: n=2 per arm. The thinking on/off gap is wide enough to act on; the individual pass rates are not (the same arm scored 2/2 earlier today).

Tests: 139 gitproxy — the cap test already asserts a floor and a ceiling, and 16000 sits inside both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
