### PR TITLE
studio-agent: the user edits too, and gain is not a knob you can turn

### DIFF
--- a/tools/studio-agent/bench-drums.mjs
+++ b/tools/studio-agent/bench-drums.mjs
@@ -379,7 +379,7 @@ async function runOnceSdk(index) {
     prompt: `${TASK}\n\n(The three instruments already exist: kick on channel 0, snare on channel 1, hihat on channel 2. Only the song needs writing.)`,
     options: {
       model: MODEL,
-      effort: 'medium',
+      effort: process.env.EFFORT || 'medium',
       cwd: REPO_ROOT,
       systemPrompt: SYSTEM_PROMPT,
       mcpServers: { studio: makeTools(state) },

--- a/wasmaudioworklet/studio-agent/prompt.js
+++ b/wasmaudioworklet/studio-agent/prompt.js
@@ -129,6 +129,10 @@ Use \`write_faust(path, source)\` — it writes \`faust/<path>.dsp\` AND transpi
 
 **WHAT A MIDI NOTE ACTUALLY GIVES THE DSP — exactly three things, and nothing else:** \`gate\` (note on/off), \`freq\` (the note's pitch) and \`gain\` (velocity). A note CANNOT press a control you invented: \`button("kick")\` is a channel parameter, not something a note triggers, so it stays 0 forever and the voice is SILENT. The note NUMBER never reaches the DSP except as \`freq\`. Declare no \`gate\` and the instrument compiles, registers and plays NOTHING — no compile error will ever tell you.
 
+**The hslider DEFAULT for \`freq\` and \`gain\` is dead — a note-on overwrites it.** The transpiler emits \`this.<freq> = notefreq(note)\` and \`this.<gain> = velocity / 127\` into \`noteon()\`, so whatever you wrote as the default lasts until the first note and no longer. Editing \`hslider("gain", 0.3, ...)\` to make an instrument quieter does NOTHING. Every OTHER slider is different: it becomes a per-channel field whose default IS its starting value, so setting it in the .dsp is exactly right and needs no CC — CC is only for changing one DURING playback.
+
+**To change an instrument's LEVEL for good, scale it in \`process\`.** \`process = ... * 0.8;\` -> \`* 0.4\` halves it, survives re-recording, and needs no slider and no CC. Mind the ORDER: put the factor AFTER any saturator/waveshaper (\`sat(x) = x/(1+abs(x))\` and friends). Scaling BEFORE one changes how hard the signal clips — that alters the tone, not just the volume.
+
 **ONE .dsp = ONE SOUND.** A voice uses only the FIRST output; \`process = (kick, hat);\` does NOT give two instruments — the hat is silently discarded. So for a DRUM KIT write **one .dsp per drum** (faust/kick.dsp, faust/hihat.dsp), register each on its OWN channel, addInstrument each in order, and give each its own track in the song. (To keep a kit on ONE channel instead, the single voice must branch on \`freq\`, the only thing carrying the note number — e.g. \`kick*(freq<80) + hat*(freq>=80)\`. Do this only if the user asked for one channel.)
 
 **\`c3\`=kick / \`fs3\`=hi-hat is DX7-BUNDLE-SPECIFIC, not a general rule.** That mapping exists because the DX7 drum channel implements it. A Faust instrument has NO GM drum map unless you built one by branching on \`freq\`. Never tell the user "c3 is the kick (GM drum mapping)" for a Faust voice — it is not true, and you cannot hear that it is not.
@@ -189,6 +193,13 @@ You have ONLY these tools. There is no Bash, no shell, no sub-agents. Do not try
 
 ## CRITICAL: never shuttle large files through your context
 Some references (notably examples/dx7/dx7-synth.ts, ~14k lines) are far too large to Read in full or to paste into set_synth. NEVER try to read a big bundle chunk-by-chunk to reproduce it. To put a large file into an editor, call load_synth_from_file / load_song_from_file with its path. Use Read/Grep only to inspect SMALL files or specific ranges so you understand structure (channel layout, note mapping) — not to copy big files.
+
+## The user edits too — you are not the only author
+Between your turns the user opens the same documents and changes them by hand, on purpose. Treat whatever is in a document now as intended, not as damage.
+
+- **Re-read before any WHOLE-document write.** \`write_faust\`, \`set_song\`, \`set_synth\` and \`set_shader\` replace the entire file. Composing one from what you wrote earlier silently discards every hand edit since. Read it first (\`read_faust\`/\`get_song\`/\`get_synth\`/\`get_shader\`) and change only what was asked. There is no \`edit_faust\`, so a .dsp is ALWAYS a full rewrite — that is the one most easily lost.
+- **Never restore committed content unless asked.** \`read_committed\` exists for when the user says something was lost. An editor that differs from HEAD is the normal state of someone working, not a fault to repair, and offering to revert their deliberate edit is worse than saying nothing.
+- **A difference you did not make is information, not a mistake.** If a tuning or a coefficient has changed since you last saw it, someone changed it deliberately. Work with it; ask only if the request genuinely conflicts with it.
 
 ## How to work
 1. Understand the request. It's usually about the SONG (map it to the sequence commands above — if unsure, Read wasmaudioworklet/docs/song-api.md) or about an INSTRUMENT SOUND (author it in Faust).

--- a/wasmaudioworklet/studio-agent/tools-def.js
+++ b/wasmaudioworklet/studio-agent/tools-def.js
@@ -61,7 +61,7 @@ export const TOOL_DEFS = [
 
     // ---- git history of the in-browser OPFS repo ----
     { name: 'git_log', where: 'browser', description: 'Show the commit history of the in-browser OPFS repo (the user commits their work here). Use it to find a commit to restore a file from.', parameters: obj({}) },
-    { name: 'read_committed', where: 'browser', description: 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use to restore something overwritten in the editor: read_committed then set_song/set_synth it back.', parameters: obj({ path: str('repo-relative path'), ref: str('git ref, default HEAD') }, ['path']) },
+    { name: 'read_committed', where: 'browser', description: 'Read the COMMITTED content of a file from the OPFS git repo at a ref (default HEAD). Path is repo-relative (e.g. "song.js", "faust/bass.dsp"). Use ONLY when the user says something was lost: read_committed then set_song/set_synth it back. An editor that differs from HEAD is the normal state of someone working — do not offer to restore a difference the user has not complained about.', parameters: obj({ path: str('repo-relative path'), ref: str('git ref, default HEAD') }, ['path']) },
 
     // ---- build / transport ----
     { name: 'compile', where: 'browser', description: "SAVE + compile the current song+synth in the browser (same as the app's save button). If a track is already playing, the changes are applied and audible immediately. Returns \"compiled OK\" or the exact compiler error. Call after every edit. There is NO play tool — the user starts playback themselves.", parameters: obj({}) },


### PR DESCRIPTION
Three things from a live session, one of them a lost edit.

## A hand-edited echo coefficient was overwritten

The user changed a feedback value in a `.dsp` by hand; the agent was then asked to change a volume, and the manual edit vanished.

`write_faust` replaces the **whole** file, and **there is no `edit_faust`** — every `.dsp` change is a full rewrite. An agent composing that file from what it wrote earlier silently discards everything the user has touched since.

The prompt now requires a re-read before any whole-document write (`write_faust`/`set_song`/`set_synth`/`set_shader`), and names the `.dsp` as the one most easily lost, because it's the only document with no surgical edit tool.

## It offered to restore deliberate edits

Its own tool description told it to:

> `read_committed` — *"Use to restore something overwritten in the editor…"*

That frames a document differing from HEAD as damage, when it's simply what someone mid-edit looks like. Reworded, and the prompt now states plainly:

> A difference you did not make is information, not a mistake.

## Setting a `gain` hslider default does nothing

[faust2as.js:1145](tools/faust2as/faust2as.js#L1145) emits `this.<gain> = velocity / 127` into `noteon()`, and `freq` likewise from the note number — so those two defaults live until the first note and no further. The prompt already said a note supplies `gate`/`freq`/`gain`; it never said their defaults are consequently **dead**, so "make it quieter by lowering the gain default" looks reasonable and silently does nothing.

Every *other* slider is the opposite: it becomes a per-channel field whose default **is** its starting value, so setting it in the `.dsp` is exactly right and needs no CC — CC is only for changing one *during* playback.

And the thing actually wanted:

> To change an instrument's level for good, scale it in `process`.

with a note that the factor belongs **after** any saturator — `sat(x) = x/(1+abs(x))` — because scaling before one changes how hard the signal clips, altering the tone rather than the volume.

## Also

`bench-drums` keeps the `EFFORT` and `THINKING` switches used to measure model settings. Worth noting what they found: `THINKING=off` is worse per task despite being cheaper per call, and the `EFFORT` comparison was **inconclusive** — run-to-run variance (34s–202s within one config) swamped the effect, so no default was changed on the strength of it.

Tests: 79 agent-tools, 139 gitproxy, 7 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
