### PR TITLE
wasmgit: ask for a token when the push comes back 401

### DIFF
--- a/wasmaudioworklet/docs/git-hosting.md
+++ b/wasmaudioworklet/docs/git-hosting.md
@@ -44,6 +44,20 @@ The URL is written into `.git/config` (which lives in OPFS), so it **persists
 across reloads** — you only need the param once. `origin` still defaults to the
 NEAR url for `<name>` when `remote=` is omitted.
 
+**Swapping the remote of a repo you already have locally** repoints `origin` and
+nothing else: the OPFS directory is keyed on `?gitrepo=`, not on the remote, so
+the existing working tree and history stay put and no clone happens. That's what
+you want in order to push commits you've already made to a newly created repo —
+but it also means a swap will never pull the new remote's content over your own.
+To start from the new remote instead, either use a different `?gitrepo=` name
+(fresh directory, real clone) or "Delete local" first, then reload.
+
+The push itself asks for credentials when it needs them: if the remote answers
+**401**, "Commit & Sync" prompts for a token and retries the push with it. The
+commit has already been made locally at that point, so the retry is only the
+fetch/merge/push half — nothing is committed twice, and cancelling the prompt
+just leaves the commit unpushed.
+
 > **Non-NEAR remotes need CORS + git-over-HTTP.** Only `/near-repo/*` requests
 > go through the NEAR service worker; any other remote is a normal browser
 > `fetch`, so the target server must speak the git smart-HTTP protocol and send

--- a/wasmaudioworklet/e2e/push-401-token-prompt.spec.js
+++ b/wasmaudioworklet/e2e/push-401-token-prompt.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+import { clearOPFS, waitForAppReady } from './near-git-helpers.js';
+
+// Pushing to a `?…&remote=<gitproxy url>` host needs a bring-your-own PAT, and
+// the only place that token was ever asked for was the CLONE at boot. Anyone
+// with an existing local repo — commits already made, remote just repointed at
+// a newly created GitHub repo — never got asked, so "Commit & Sync" pushed
+// anonymously and died on a 401 with nothing but an error modal. The fix:
+// the worker reports the HTTP status as its own field, and the client turns a
+// 401 into a token prompt + one retry of the push.
+//
+// Network-free: every gitproxy request is intercepted and answered 401, so no
+// real remote (and no NEAR sandbox) is involved.
+
+const REPO = 'push401test';
+const GITPROXY_URL = 'http://localhost:8080/gitproxy/github.com/test/push-401-test.git';
+const RETRY_TOKEN = 'RETRYTOKEN123';
+
+// Answer every git request with 401, recording what Authorization went out.
+async function route401(page, auths) {
+    await page.route('**/gitproxy/**', async (route) => {
+        auths.push(route.request().headers()['authorization'] ?? null);
+        await route.fulfill({ status: 401, contentType: 'text/plain', body: 'Unauthorized' });
+    });
+}
+
+test.describe('push rejected with 401 asks for a token and retries', () => {
+    test.afterEach(async ({ page }) => {
+        await clearOPFS(page, `${REPO}.git`);
+    });
+
+    test('the worker reports httpStatus 401 alongside the error', async ({ page }) => {
+        await page.goto('http://localhost:8080');
+        await route401(page, []);
+
+        const reply = await page.evaluate(async ({ repo, remoteUrl }) => {
+            const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
+            const pending = [];
+            let resolveNext = null;
+            worker.onmessage = (m) => {
+                if (resolveNext) { const r = resolveNext; resolveNext = null; r(m.data); }
+                else pending.push(m.data);
+            };
+            const nextRaw = () => pending.length ? Promise.resolve(pending.shift()) : new Promise(r => (resolveNext = r));
+            const next = (ms = 20000) => Promise.race([nextRaw(), new Promise(res => setTimeout(() => res({ __timeout: true }), ms))]);
+
+            try {
+                // A local repo whose origin is the (unauthorized) remote — the
+                // state you're in after repointing `remote=` at a new repo.
+                worker.postMessage({
+                    command: 'initlocal',
+                    url: `${location.origin}/near-repo/${repo}.git`,
+                    repoName: `${repo}.git`,
+                    remoteUrl,
+                });
+                await next(); // dircontents
+                worker.postMessage({ command: 'commitpullpush', commitmessage: 'push me', id: 1 });
+                return await next();
+            } finally {
+                worker.terminate();
+            }
+        }, { repo: REPO, remoteUrl: GITPROXY_URL });
+
+        expect(reply.__timeout).toBeUndefined();
+        expect(reply.error).toBeTruthy();
+        // The regression this guards: the status was ONLY appended to the error
+        // string, so the client had to parse prose to recognise a 401.
+        expect(reply.httpStatus).toBe(401);
+    });
+
+    test('a 401 on Commit & Sync prompts for a token and the retry sends it', async ({ page }) => {
+        test.setTimeout(180000);
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+
+        const auths = [];
+        await route401(page, auths);
+        await page.goto(`http://localhost:8080/?gitrepo=${REPO}&remote=${encodeURIComponent(GITPROXY_URL)}`);
+
+        // Boot asks for a token before cloning; cancel it, which is exactly how
+        // a repo ends up local-with-no-token in the first place.
+        const bootPrompt = page.locator('common-modal #modal-prompt-input');
+        await bootPrompt.waitFor({ timeout: 60000 });
+        await page.locator('common-modal button', { hasText: 'Cancel' }).click();
+
+        // Clone 401s, so the app falls back to a local OPFS repo and boots.
+        await waitForAppReady(page);
+        auths.length = 0;
+
+        await page.evaluate(() => document.querySelector('app-javascriptmusic')
+            .shadowRoot.querySelector('wasmgit-ui').shadowRoot
+            .getElementById('syncRemoteButton').click());
+
+        // The push 401s -> the token prompt, distinguishable from the boot one.
+        const retryPrompt = page.locator('common-modal', { hasText: 'Push was rejected (401)' });
+        await retryPrompt.waitFor({ timeout: 60000 });
+        expect(auths.every((a) => !a)).toBe(true); // the failed push went out anonymously
+
+        await retryPrompt.locator('#modal-prompt-input').fill(RETRY_TOKEN);
+        await retryPrompt.locator('button', { hasText: 'OK' }).click();
+
+        // The retry re-runs fetch/push — this time carrying the token.
+        await expect.poll(() => auths.filter((a) => a === `Bearer ${RETRY_TOKEN}`).length,
+            { timeout: 60000 }).toBeGreaterThan(0);
+    });
+});

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -94,21 +94,41 @@ export async function gitLog() {
 
 const GIT_TOKEN_KEY = 'git-http-token';
 
+function readStoredGitToken() {
+    try { return JSON.parse(sessionStorage.getItem(GIT_TOKEN_KEY) || 'null'); } catch (e) { return null; }
+}
+
+// Ask for a token and hand it to the worker. `label` says WHY we're asking —
+// a first clone, or a push the remote answered with 401. Always prompts, even
+// when one is stored: a stored token that just got rejected is exactly the one
+// that needs replacing. Returns false if the user cancelled/left it empty.
+async function promptForGitToken(label) {
+    const stored = readStoredGitToken();
+    const token = await modalPrompt('GitHub token', label, '');
+    if (!token) { return false; }
+    const entry = {
+        token,
+        username: stored?.username || 'wasmmusic',
+        useremail: stored?.useremail || 'wasmmusic@users.noreply.github.com'
+    };
+    try { sessionStorage.setItem(GIT_TOKEN_KEY, JSON.stringify(entry)); } catch (e) { /* private mode */ }
+    await setGitAuthToken(entry.token, entry);
+    return true;
+}
+
 // Apply a stored (or prompted) BYO git token to the worker BEFORE a clone/push,
 // so a PRIVATE remote repo can authenticate. Only used for `remote=` (gitproxy)
 // repos — NEAR repos use their own credentials.
 async function applyStoredGitToken(promptIfMissing) {
-    let stored = null;
-    try { stored = JSON.parse(sessionStorage.getItem(GIT_TOKEN_KEY) || 'null'); } catch (e) { /* ignore */ }
-    if ((!stored || !stored.token) && promptIfMissing) {
-        const token = await modalPrompt('GitHub token',
-            'Fine-grained PAT (Contents: read/write) to clone/push this repo. Leave empty for a public repo.', '');
-        if (token) {
-            stored = { token, username: 'wasmmusic', useremail: 'wasmmusic@users.noreply.github.com' };
-            try { sessionStorage.setItem(GIT_TOKEN_KEY, JSON.stringify(stored)); } catch (e) { /* ignore */ }
-        }
+    const stored = readStoredGitToken();
+    if (stored && stored.token) {
+        await setGitAuthToken(stored.token, { username: stored.username, useremail: stored.useremail });
+        return true;
     }
-    if (stored && stored.token) { await setGitAuthToken(stored.token, { username: stored.username, useremail: stored.useremail }); return true; }
+    if (promptIfMissing) {
+        return await promptForGitToken(
+            'Fine-grained PAT (Contents: read/write) to clone/push this repo. Leave empty for a public repo.');
+    }
     return false;
 }
 
@@ -193,6 +213,13 @@ export async function initWASMGitClient(gitrepo, remoteUrl) {
         }
     } else {
         console.log('Repository is already local');
+        // No clone ran, so the token hand-off in the branch above didn't either
+        // and the worker would push to a `remote=` host anonymously. Re-apply
+        // whatever this session has; don't prompt — a push that needs a token
+        // asks for one when the remote answers 401 (see commitAndSyncRemote).
+        if (remoteUrl) {
+            await applyStoredGitToken(false);
+        }
     }
     console.log('dircontents', dircontents);
     if (dircontents.indexOf('.git') === -1) {
@@ -359,10 +386,27 @@ export async function commitAndSyncRemote(commitmessage) {
         await sendNearCredentials(auth);
     }
 
-    const dircontents = await callAndWaitForWorker({
+    const push = () => callAndWaitForWorker({
         command: 'commitpullpush',
         commitmessage: commitmessage
     });
+
+    let dircontents;
+    try {
+        dircontents = await push();
+    } catch (e) {
+        // 401 from a `remote=` host means the BYO token is missing, expired or
+        // scoped to the wrong repo — the everyday case being a remote pointed at
+        // a repo the current token doesn't cover, e.g. one just created. Ask for
+        // a token and push again. The commit already landed locally, so the
+        // retry is only the fetch/merge/push half and never double-commits.
+        // NEAR repos are excluded: they authenticate with a key, not a PAT.
+        if (e.httpStatus !== 401 || isNearRepo()) { throw e; }
+        const gotToken = await promptForGitToken(
+            'Push was rejected (401). Fine-grained PAT with Contents: read/write on this repo.');
+        if (!gotToken) { throw e; }
+        dircontents = await push();
+    }
 
     remoteSyncListeners.forEach(remoteSyncListener => remoteSyncListener(dircontents));
     await repoHasChanges(); // update buttons after sync

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -212,6 +212,7 @@ onmessage = async (msg) => {
     }
 
     let err = null;
+    let httpStatus;
     lastHttpRequest = null;
     try {
       callAndCaptureOutput(['fetch', 'origin']);
@@ -222,11 +223,15 @@ onmessage = async (msg) => {
     } catch (e) {
       err = e.message;
       if (lastHttpRequest) {
-        err += ` http status: ${lastHttpRequest.status}`;
+        httpStatus = lastHttpRequest.status;
+        err += ` http status: ${httpStatus}`;
       }
     }
     console.log(currentRepoDir, 'persisted via OPFS');
-    postMessage({ id: msg.data.id, error: err ? err : undefined, dircontents: readdir() });
+    // The status is reported as its own field, not just appended to the message,
+    // so the client can act on a 401 (ask for a token, retry) without parsing
+    // the error string.
+    postMessage({ id: msg.data.id, error: err ? err : undefined, httpStatus, dircontents: readdir() });
   } else if (msg.data.command === 'synclocal') {
     // Candidates in priority order: the canonical `?gitrepo=`-derived name
     // first, then the LEGACY remote-derived name a pre-#183 `?…&remote=` clone


### PR DESCRIPTION
Pushing to a `?…&remote=<url>` host needs a bring-your-own PAT, but the only place one was ever asked for was the **clone at boot**. Repoint `remote=` at a repo the current session has no token for — a repo you just created, say — and "Commit & Sync" pushed anonymously, got a 401, and showed an error modal whose only way forward was `setGitToken()` in the console.

## What changed

- **`wasmgitworker.js`** — `commitpullpush` reports `httpStatus` as its own field. It was previously appended to the error *string* only, so the client would have had to parse prose to recognise a 401.
- **`wasmgitclient.js`** — `promptForGitToken(label)`, split out of `applyStoredGitToken`. It always prompts, including when a token is already stored: a stored token that just got rejected is precisely the one that needs replacing.
- **`wasmgitclient.js`** — `commitAndSyncRemote` catches a 401 from a non-NEAR remote, prompts, and retries the push once. The commit has already landed locally by then, so the retry is only the fetch/merge/push half — nothing is committed twice, and cancelling the prompt just leaves the commit unpushed. NEAR repos are excluded: they authenticate with a key, not a PAT.
- **`wasmgitclient.js`** — the already-local boot path re-applies the session's stored token (no prompt). That path skips the clone, and with it the token hand-off, so the worker pushed anonymously even when a token had been entered earlier in the same session.
- **`docs/git-hosting.md`** — documents the 401 prompt, and spells out what swapping `remote=` on an existing local repo does and does not do (repoints `origin`; never pulls the new remote's content over yours, because the OPFS directory is keyed on `?gitrepo=`).

## Testing

New `e2e/push-401-token-prompt.spec.js` — no network, no NEAR sandbox: every `gitproxy` request is intercepted and answered 401.

- The worker reports `httpStatus: 401` alongside the error.
- The real app is driven through cancel-the-boot-prompt → Commit & Sync → 401 prompt → enter token, asserting the retry request carries `Authorization: Bearer <token>`.

Mutating the 401 branch out of the client makes the UI test fail, so it covers the fix rather than passing vacuously. `anonymous-clone-auth` and `commit-empty-diff-hang` still pass alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)