### PR TITLE
devcontainer: install Node via the node feature so post-create can run

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -87,6 +87,24 @@ are not `devcontainer.json` options):
 Then check `ssh-add -l` inside the container — if it lists host keys, the
 SSH agent is still being forwarded.
 
+### From the terminal, without VS Code
+
+`volume-up.sh` does the same thing with the `devcontainer` CLI, which
+forwards none of the above in the first place:
+
+```sh
+npm install -g @devcontainers/cli                 # once
+.devcontainer/volume-up.sh [branch] [volume]      # defaults: master, javascriptmusic-agent
+devcontainer exec --workspace-folder ~/.cache/javascriptmusic-devcontainer/javascriptmusic-agent bash
+```
+
+It clones the branch into the named volume (skipped if the volume already
+holds a clone), copies just the clone's `.devcontainer/` to
+`~/.cache/javascriptmusic-devcontainer/<volume>/` on the host so the image
+is built from the cloned branch, rewrites that config's workspace mount to
+the volume, and runs `devcontainer up`. The `exec` line is printed at the
+end; the container's only mount is the volume.
+
 ## Why "sandbox as a process", not a sibling docker container
 
 Earlier iterations of the test setup booted the sandbox image with

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -23,6 +23,14 @@ needed) as well as locally:
 - Drops a `near-git-sandbox` launcher onto PATH that chdirs into
   `/opt/near-sandbox` and runs `git-server` on `localhost:3030`.
 
+`devcontainer.json` layers the `node` feature (Node 24, matching CI's
+`setup-node`) on top. The base image ships no Node whatsoever, so without
+the feature `post-create.sh` dies on `yarn: command not found`. The
+feature's `yarn` is a Corepack shim that downloads yarn classic on first
+use — `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in `containerEnv` suppresses
+the interactive "Do you want to continue?" that would otherwise hang
+`postCreateCommand` (no tty).
+
 `post-create.sh` then just does the Node side:
 
 1. Boots `pulseaudio`.
@@ -53,6 +61,31 @@ node tools/faust2as/generate-test-sources.js
 cd wasmaudioworklet
 yarn playwright test --workers=1
 ```
+
+## Running agents inside (no host filesystem)
+
+Use **Dev Containers: Clone Repository in Container Volume…** rather than
+"Reopen in Container": the workspace then lives in a Docker volume with
+no bind mount of the host checkout. (A bind-mounted container also
+rewrites the host's `node_modules` with Linux binaries on `yarn install`,
+breaking local builds until you `yarn install` again on the host.)
+
+The workspace mount is not the only host connection, though. By default
+the VS Code extension also copies `~/.gitconfig` in, wires the host's git
+credential helper into the container, logs the GitHub CLI in with the
+host's token, and forwards the host SSH agent. If the container is meant
+as a sandbox for agents, turn those off in *host* VS Code settings (they
+are not `devcontainer.json` options):
+
+```json
+"dev.containers.copyGitConfig": false,
+"dev.containers.gitCredentialHelperConfigLocation": "none",
+"dev.containers.githubCLILoginWithToken": false,
+"dev.containers.dockerCredentialHelper": false
+```
+
+Then check `ssh-add -l` inside the container — if it lists host keys, the
+SSH agent is still being forwarded.
 
 ## Why "sandbox as a process", not a sibling docker container
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,17 @@
     // artifacts via `COPY --from=…` so no docker access is needed at
     // runtime. See ./Dockerfile + ./README.md for the design.
     "build": { "dockerfile": "Dockerfile" },
+    // The base image (devcontainers/base:ubuntu) ships no Node at all —
+    // post-create.sh needs node/npm/yarn. Version matches CI's setup-node.
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": { "version": "24" }
+    },
+    // The feature provides `yarn` only as a Corepack shim, and Corepack
+    // asks "Do you want to continue? [Y/n]" before its first download —
+    // which hangs postCreateCommand forever (no tty). Answer it up front.
+    "containerEnv": {
+        "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
+    },
     "postCreateCommand": "./.devcontainer/post-create.sh",
     "customizations": {
         "vscode": {

--- a/.devcontainer/volume-up.sh
+++ b/.devcontainer/volume-up.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Clone the repo into a Docker volume and start the devcontainer on it,
+# from the terminal. The CLI equivalent of VS Code's "Clone Repository in
+# Container Volume…": nothing on the host is bind-mounted, and the
+# devcontainer CLI (unlike the VS Code extension) forwards no gitconfig,
+# credential helper, gh token or SSH agent — a sandbox fit for running
+# agents in.
+#
+#     npm install -g @devcontainers/cli          # once
+#     .devcontainer/volume-up.sh [branch] [volume]
+#
+# Re-running starts the existing container, and leaves the clone alone if
+# the volume already holds one. Shell in with the `devcontainer exec` line
+# printed at the end.
+set -euo pipefail
+
+BRANCH="${1:-master}"
+VOLUME="${2:-javascriptmusic-agent}"
+REPO="${REPO:-https://github.com/petersalomonsen/javascriptmusic.git}"
+# The volume is mounted at /workspaces (as VS Code does it), with the
+# clone inside it — so the workspace folder is a subdirectory, not the
+# mount point.
+WORKSPACE=/workspaces/javascriptmusic
+# Host-side scratch holding only the clone's .devcontainer/ (Dockerfile +
+# config), so the image is built from the branch you cloned rather than
+# whatever checkout is on the host. Stable path: the CLI keys the
+# container off this folder, so it has to be the same on every run.
+CFG="${XDG_CACHE_HOME:-$HOME/.cache}/javascriptmusic-devcontainer/$VOLUME"
+
+docker volume create "$VOLUME" >/dev/null
+if docker run --rm -v "$VOLUME":/w alpine test -e /w/javascriptmusic/.git; then
+    echo "volume $VOLUME already holds a clone, leaving it as is"
+else
+    docker run --rm -v "$VOLUME":/w -w /w alpine/git clone --branch "$BRANCH" "$REPO" javascriptmusic
+    # Hand the tree to the container user: vscode is uid 1000 in the
+    # image, except on a Linux host where the CLI remaps it to your uid.
+    OWNER=1000; [ "$(uname)" = Linux ] && OWNER="$(id -u)"
+    docker run --rm -v "$VOLUME":/w alpine chown -R "$OWNER:$OWNER" /w
+fi
+
+rm -rf "$CFG" && mkdir -p "$CFG"
+docker run --rm -v "$VOLUME":/w alpine tar -C /w/javascriptmusic -cf - .devcontainer | tar -xf - -C "$CFG"
+# Swap the CLI's default bind mount of the host folder for the volume.
+# read-configuration parses the commented JSON for us; its JSON is the
+# last stdout line. Via a temp file: `> devcontainer.json` would truncate
+# the input before read-configuration gets to it.
+devcontainer read-configuration --workspace-folder "$CFG" | tail -1 | node -e '
+    const cfg = JSON.parse(require("fs").readFileSync(0, "utf8")).configuration;
+    delete cfg.configFilePath;
+    cfg.workspaceMount = `source=${process.argv[1]},target=/workspaces,type=volume`;
+    cfg.workspaceFolder = process.argv[2];
+    console.log(JSON.stringify(cfg, null, 2));
+' "$VOLUME" "$WORKSPACE" > "$CFG/.devcontainer/devcontainer.json.tmp"
+mv "$CFG/.devcontainer/devcontainer.json.tmp" "$CFG/.devcontainer/devcontainer.json"
+
+devcontainer up --workspace-folder "$CFG"
+
+cat <<MSG
+
+Shell into it with:
+    devcontainer exec --workspace-folder "$CFG" bash
+MSG


### PR DESCRIPTION
## Problem

`devcontainer up` fails in `post-create.sh`:

```
./.devcontainer/post-create.sh: line 13: yarn: command not found
```

#138 moved the devcontainer onto a custom Dockerfile based on `devcontainers/base:ubuntu-24.04`, which ships no Node at all. The previous `devcontainer.json` had no `image`/`build`, so it silently got the default universal image's node/yarn.

## Fix

- **`features`**: `ghcr.io/devcontainers/features/node:1` at version `24` (matches CI's `setup-node`).
- **`containerEnv`**: `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`. The feature's `yarn` is only a Corepack shim (its `installYarnUsingApt` default is now `false`), and Corepack asks `Do you want to continue? [Y/n]` before its first download — with no tty in `postCreateCommand` that hangs forever.
- **`devcontainer-lock.json`**: committed, pins the feature version.

## Isolated (agent-sandbox) flavour

- **`volume-up.sh`**: terminal-only equivalent of VS Code's "Clone Repository in Container Volume…". Clones a branch into a named Docker volume, copies just the clone's `.devcontainer/` to `~/.cache/javascriptmusic-devcontainer/<volume>/` on the host (so the image is built from the cloned branch), rewrites that config's workspace mount to the volume, and runs `devcontainer up`. Idempotent: re-running reuses the container and an existing clone.
- **README**: documents the above, plus the host-side VS Code settings to disable when the container is a sandbox for agents (`copyGitConfig`, `gitCredentialHelperConfigLocation`, `githubCLILoginWithToken`, `dockerCredentialHelper`) — the CLI path forwards none of those to begin with.

## Verified

Bind-mounted: `devcontainer up --workspace-folder . --remove-existing-container` → `{"outcome":"success"}`; post-create completes. Inside: Node v24.20.0, yarn 1.22.22, Playwright 1.59.1 with chromium-1217, `tools/faust2as` + `tools/claude-bridge` deps installed, pulseaudio running, `near-git-sandbox` on PATH.

Volume: `.devcontainer/volume-up.sh devcontainer-node-feature` → same result; `docker inspect` shows the volume as the container's only mount; inside, `SSH_AUTH_SOCK` is unset, there is no gitconfig and git identity is empty.

Side note for the bind-mounted flavour: the container's `yarn install` replaces the host's `node_modules` platform binaries with Linux ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
