### PR TITLE
wasmgit: bare ?gitrepo= links clone from the legacy host, PAT only on 401

### DIFF
--- a/wasmaudioworklet/docs/git-hosting.md
+++ b/wasmaudioworklet/docs/git-hosting.md
@@ -150,6 +150,13 @@ verifies (or reuse the NEAR login for a signature) — overkill until it's neede
 
 - `?gitrepo=<name>.gitfactory.testnet` is resolved to `<origin>/near-repo/<name>.git`
   ([`wasmgitclient.js`](../wasmgit/wasmgitclient.js)).
+- A name with no NEAR suffix (`?gitrepo=wasmsummit2`) cannot be a contract, so it
+  is cloned from the original wasm-git host (`https://wasm-git.petersalomonsen.com/<name>`)
+  instead — pre-NEAR links keep working. `workspace` and `*.local` names skip that
+  lookup and are purely local; so is any name the legacy host doesn't have.
+- `?gitrepo=<name>&remote=<url>` clones from `<url>` (e.g. GitHub via the CORS
+  proxy). No token is asked for up front: only a 401 on clone, pull or push
+  opens the PAT prompt, so links to public repos just load.
 - A service worker (from `near-git-storage`) intercepts those git HTTP requests
   and translates them into NEAR RPC calls — there is no server. Transaction
   signing happens in the browser; the private key never leaves the client.

--- a/wasmaudioworklet/e2e/clone-token-prompt.spec.js
+++ b/wasmaudioworklet/e2e/clone-token-prompt.spec.js
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import { clearOPFS, waitForAppReady } from './near-git-helpers.js';
+
+// Issue #224: every first visit to a `?…&remote=<gitproxy url>` link opened a
+// "GitHub token" prompt BEFORE cloning, even for a public repo where no token
+// is needed — anyone following a shared link had to work out that "Cancel" was
+// the right answer. Cloning needs no credentials until the remote says so:
+// clone anonymously, and only a 401 (a private repo) asks for a PAT and retries.
+//
+// Network-free: every gitproxy request is intercepted, so no real remote is
+// involved.
+
+const GITPROXY_URL = (repo) => `http://localhost:8080/gitproxy/github.com/test/${repo}.git`;
+const TOKEN = 'CLONETOKEN123';
+
+// Answer every git request with `status`, recording what Authorization went out.
+async function routeStatus(page, status, auths) {
+    await page.route('**/gitproxy/**', async (route) => {
+        auths.push(route.request().headers()['authorization'] ?? null);
+        await route.fulfill({ status, contentType: 'text/plain', body: `status ${status}` });
+    });
+}
+
+test.describe('cloning from a remote= host asks for a token only on 401', () => {
+    test('the worker reports httpStatus alongside a failed clone', async ({ page }) => {
+        const repo = 'clone401worker';
+        await page.goto('http://localhost:8080');
+        await routeStatus(page, 401, []);
+
+        const reply = await page.evaluate(async ({ repo, remoteUrl }) => {
+            const worker = new Worker(new URL('/wasmgit/wasmgitworker.js', location.origin), { type: 'module' });
+            const pending = [];
+            let resolveNext = null;
+            worker.onmessage = (m) => {
+                if (resolveNext) { const r = resolveNext; resolveNext = null; r(m.data); }
+                else pending.push(m.data);
+            };
+            const nextRaw = () => pending.length ? Promise.resolve(pending.shift()) : new Promise(r => (resolveNext = r));
+            const next = (ms = 20000) => Promise.race([nextRaw(), new Promise(res => setTimeout(() => res({ __timeout: true }), ms))]);
+            try {
+                worker.postMessage({ command: 'clone', url: remoteUrl, repoName: `${repo}.git` });
+                return await next();
+            } finally {
+                worker.terminate();
+            }
+        }, { repo, remoteUrl: GITPROXY_URL(repo) });
+
+        expect(reply.__timeout).toBeUndefined();
+        expect(reply.cloneFailed).toBe(true);
+        expect(reply.dircontents).toBeNull();
+        expect(reply.httpStatus).toBe(401);
+    });
+
+    test('a public (or missing) repo never prompts: clone goes out anonymously and the app boots', async ({ page }) => {
+        test.setTimeout(180000);
+        const repo = 'clone404public';
+        const auths = [];
+        await routeStatus(page, 404, auths);
+        await page.goto(`http://localhost:8080/?gitrepo=${repo}&remote=${encodeURIComponent(GITPROXY_URL(repo))}`);
+
+        // Boot must reach the editor without a token modal ever appearing: a
+        // modal blocks init, so the app being ready proves none was opened.
+        await waitForAppReady(page);
+        await expect(page.locator('common-modal #modal-prompt-input')).toHaveCount(0);
+        expect(auths.length).toBeGreaterThan(0);
+        expect(auths.every((a) => !a)).toBe(true); // anonymous
+        await clearOPFS(page, `${repo}.git`);
+    });
+
+    test('a 401 on pull is reported with its status and prompts for a token', async ({ page }) => {
+        test.setTimeout(180000);
+        const repo = 'pull401private';
+        const auths = [];
+        page.on('pageerror', (e) => console.log('[browser-error]', e.message));
+        // Boot: the remote 404s, so the app lands on a local repo whose origin
+        // is the remote — the state after `remote=` was repointed at a repo that
+        // has since been made private.
+        await routeStatus(page, 404, auths);
+        await page.goto(`http://localhost:8080/?gitrepo=${repo}&remote=${encodeURIComponent(GITPROXY_URL(repo))}`);
+        await waitForAppReady(page);
+        await page.unroute('**/gitproxy/**');
+        auths.length = 0;
+        await routeStatus(page, 401, auths);
+
+        const pulled = page.evaluate(async () => {
+            const git = await import('/wasmgit/wasmgitclient.js');
+            try { await git.pull(); return 'ok'; } catch (e) { return 'error:' + e.httpStatus; }
+        });
+
+        const prompt = page.locator('common-modal', { hasText: 'Pull was rejected (401)' });
+        await prompt.waitFor({ timeout: 60000 });
+        expect(auths.every((a) => !a)).toBe(true); // the failed fetch went out anonymously
+        await prompt.locator('#modal-prompt-input').fill(TOKEN);
+        await prompt.locator('button', { hasText: 'OK' }).click();
+
+        // The retry carries the token; it 401s again, and pull() rejects with
+        // the status rather than hanging.
+        expect(await pulled).toBe('error:401');
+        expect(auths.filter((a) => a === `Bearer ${TOKEN}`).length).toBeGreaterThan(0);
+        await clearOPFS(page, `${repo}.git`);
+    });
+
+    test('a 401 on clone prompts for a token and the retry sends it', async ({ page }) => {
+        test.setTimeout(180000);
+        const repo = 'clone401private';
+        const auths = [];
+        await routeStatus(page, 401, auths);
+        await page.goto(`http://localhost:8080/?gitrepo=${repo}&remote=${encodeURIComponent(GITPROXY_URL(repo))}`);
+
+        const prompt = page.locator('common-modal', { hasText: 'Clone was rejected (401)' });
+        await prompt.waitFor({ timeout: 60000 });
+        // The first attempt went out with no credentials at all.
+        expect(auths.length).toBeGreaterThan(0);
+        expect(auths.every((a) => !a)).toBe(true);
+        auths.length = 0;
+
+        await prompt.locator('#modal-prompt-input').fill(TOKEN);
+        await prompt.locator('button', { hasText: 'OK' }).click();
+
+        // The retry carries the token…
+        await expect.poll(() => auths.filter((a) => a === `Bearer ${TOKEN}`).length,
+            { timeout: 60000 }).toBeGreaterThan(0);
+        // …and since it 401s again, the app falls back to a local repo and boots
+        // rather than looping on the prompt.
+        await waitForAppReady(page);
+        await expect(page.locator('common-modal #modal-prompt-input')).toHaveCount(0);
+        await clearOPFS(page, `${repo}.git`);
+    });
+});

--- a/wasmaudioworklet/e2e/legacy-gitrepo-fallback.spec.js
+++ b/wasmaudioworklet/e2e/legacy-gitrepo-fallback.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { clearOPFS, waitForAppReady } from './near-git-helpers.js';
+
+// Issue #224: `?gitrepo=wasmsummit2` (no `remote=`) used to mean a repo on the
+// original wasm-git http server. Since NEAR storage it resolves to a NEAR
+// contract of that name, which can't exist for a suffix-less name, so the link
+// "doesn't load". Such names now clone from the legacy host instead, while the
+// local-only names (`workspace`, `*.local`) and NEAR names never touch it.
+//
+// Network-free: the legacy host is intercepted and answered 404, so the app
+// falls through to its local repo either way; what's asserted is WHERE the
+// clone was attempted.
+
+const LEGACY = 'https://wasm-git.petersalomonsen.com';
+
+async function routeLegacy(page, requests, status = 404) {
+    await page.route(`${LEGACY}/**`, async (route) => {
+        requests.push(new URL(route.request().url()).pathname);
+        await route.fulfill({ status, contentType: 'text/plain', body: `status ${status}` });
+    });
+}
+
+test.describe('a suffix-less ?gitrepo= name is looked up on the legacy wasm-git host', () => {
+    test('legacyRemoteFor picks exactly the pre-NEAR names', async ({ page }) => {
+        await page.goto('http://localhost:8080');
+        const got = await page.evaluate(async () => {
+            const { legacyRemoteFor } = await import('/wasmgit/wasmgitclient.js');
+            return ['wasmsummit2', 'workspace', 'spec-x.local', 'foo.gitfactory.testnet', 'bar.near', 'baz.sandbox', '']
+                .map((n) => [n, legacyRemoteFor(n)]);
+        });
+        expect(Object.fromEntries(got)).toEqual({
+            'wasmsummit2': `${LEGACY}/wasmsummit2`,
+            'workspace': null,
+            'spec-x.local': null,
+            'foo.gitfactory.testnet': null,
+            'bar.near': null,
+            'baz.sandbox': null,
+            '': null,
+        });
+    });
+
+    test('?gitrepo=<legacy name> clones from the legacy host and still boots when it is gone', async ({ page }) => {
+        test.setTimeout(180000);
+        const repo = 'legacy-fallback-test';
+        const requests = [];
+        await routeLegacy(page, requests);
+        await page.goto(`http://localhost:8080/?gitrepo=${repo}`);
+        await waitForAppReady(page);
+        expect(requests.some((p) => p.startsWith(`/${repo}/info/refs`))).toBe(true);
+        await expect(page.locator('common-modal #modal-prompt-input')).toHaveCount(0);
+        await clearOPFS(page, `${repo}.git`);
+    });
+
+    test('local-only names never contact the legacy host', async ({ page }) => {
+        test.setTimeout(180000);
+        const requests = [];
+        await routeLegacy(page, requests);
+        for (const repo of ['workspace', 'spec-legacy-fallback.local']) {
+            await page.goto(`http://localhost:8080/?gitrepo=${repo}`);
+            await waitForAppReady(page);
+            await clearOPFS(page, `${repo}.git`);
+        }
+        expect(requests).toEqual([]);
+    });
+});

--- a/wasmaudioworklet/e2e/push-401-token-prompt.spec.js
+++ b/wasmaudioworklet/e2e/push-401-token-prompt.spec.js
@@ -76,11 +76,12 @@ test.describe('push rejected with 401 asks for a token and retries', () => {
         await route401(page, auths);
         await page.goto(`http://localhost:8080/?gitrepo=${REPO}&remote=${encodeURIComponent(GITPROXY_URL)}`);
 
-        // Boot asks for a token before cloning; cancel it, which is exactly how
-        // a repo ends up local-with-no-token in the first place.
-        const bootPrompt = page.locator('common-modal #modal-prompt-input');
+        // The anonymous clone 401s, so boot asks for a token (see
+        // clone-token-prompt.spec.js); cancel it, which is exactly how a repo
+        // ends up local-with-no-token in the first place.
+        const bootPrompt = page.locator('common-modal', { hasText: 'Clone was rejected (401)' });
         await bootPrompt.waitFor({ timeout: 60000 });
-        await page.locator('common-modal button', { hasText: 'Cancel' }).click();
+        await bootPrompt.locator('button', { hasText: 'Cancel' }).click();
 
         // Clone 401s, so the app falls back to a local OPFS repo and boots.
         await waitForAppReady(page);

--- a/wasmaudioworklet/e2e/repo-zip-export.spec.js
+++ b/wasmaudioworklet/e2e/repo-zip-export.spec.js
@@ -16,7 +16,7 @@ import { waitForAppReady, clearOPFS } from './near-git-helpers.js';
 //
 // No NEAR sandbox needed: an unregistered `?gitrepo=` falls back to local OPFS.
 
-const REPO = 'zip-export-test';
+const REPO = 'zip-export-test.local'; // *.local: never looked up on the legacy host (see legacyRemoteFor)
 
 test.describe('export the repo as a zip', () => {
     // Fail fast: a wasm-git call that never answers should not burn 10 minutes.

--- a/wasmaudioworklet/e2e/studio-agent-abort.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-abort.spec.js
@@ -14,7 +14,7 @@ import { waitForAppReady, waitForStudioAgentTools, clearOPFS } from './near-git-
 //
 // No NEAR sandbox needed: an unregistered `?gitrepo=` falls back to local OPFS.
 
-const REPO = 'abort-e2e-test';
+const REPO = 'abort-e2e-test.local'; // *.local: never looked up on the legacy host (see legacyRemoteFor)
 
 function startMockAgentServer() {
     const wss = new ws.Server({ port: 0 });

--- a/wasmaudioworklet/e2e/studio-agent-kit.spec.js
+++ b/wasmaudioworklet/e2e/studio-agent-kit.spec.js
@@ -17,7 +17,7 @@ import { waitForAppReady, waitForStudioAgentTools, clearOPFS } from './near-git-
 // No NEAR sandbox needed: an unregistered `?gitrepo=` name fails to clone and
 // falls back to a local OPFS repo, which is also the "no AGENT.md" case.
 
-const REPO = 'kit-e2e-test';
+const REPO = 'kit-e2e-test.local'; // *.local: never looked up on the legacy host (see legacyRemoteFor)
 
 // Mock agent server — only needs to capture what the client sends.
 function startMockAgentServer() {

--- a/wasmaudioworklet/wasmgit/wasmgitclient.js
+++ b/wasmaudioworklet/wasmgit/wasmgitclient.js
@@ -116,18 +116,17 @@ async function promptForGitToken(label) {
     return true;
 }
 
-// Apply a stored (or prompted) BYO git token to the worker BEFORE a clone/push,
-// so a PRIVATE remote repo can authenticate. Only used for `remote=` (gitproxy)
-// repos — NEAR repos use their own credentials.
-async function applyStoredGitToken(promptIfMissing) {
+// Apply a stored BYO git token to the worker BEFORE a clone/push, so a PRIVATE
+// remote repo can authenticate. Never prompts: a public repo needs no token to
+// clone, and the ONE place we know one is required is the 401 the remote sends
+// back — so that is where the prompt lives (see the clone at init, and
+// commitAndSyncRemote for push). Only used for `remote=` (gitproxy) repos —
+// NEAR repos use their own credentials.
+async function applyStoredGitToken() {
     const stored = readStoredGitToken();
     if (stored && stored.token) {
         await setGitAuthToken(stored.token, { username: stored.username, useremail: stored.useremail });
         return true;
-    }
-    if (promptIfMissing) {
-        return await promptForGitToken(
-            'Fine-grained PAT (Contents: read/write) to clone/push this repo. Leave empty for a public repo.');
     }
     return false;
 }
@@ -153,6 +152,20 @@ async function sendNearCredentials(auth) {
             useremail: auth.useremail || auth.username,
         });
     });
+}
+
+// Before NEAR storage (PR #119) `?gitrepo=<name>` meant a repo on the original
+// wasm-git http server, and links of that form are still shared — the WebAssembly
+// Summit song in #224 is one. A suffix-less name cannot be a NEAR contract (see
+// isNearRepo), so for those the legacy host is the only remote that could hold
+// it. `workspace` (the first-time visitor's local repo) and `*.local` (the e2e
+// isolation convention) never lived there, so they skip the lookup.
+export const LEGACY_GIT_HOST = 'https://wasm-git.petersalomonsen.com';
+export function legacyRemoteFor(gitrepo) {
+    if (!gitrepo || isNearRepo(gitrepo) || gitrepo === 'workspace' || gitrepo.endsWith('.local')) {
+        return null;
+    }
+    return `${LEGACY_GIT_HOST}/${gitrepo}`;
 }
 
 export async function initWASMGitClient(gitrepo, remoteUrl) {
@@ -193,15 +206,32 @@ export async function initWASMGitClient(gitrepo, remoteUrl) {
 
     if (!dircontents) {
         // Nothing local yet. With a `remote=` (e.g. GitHub via the CORS proxy),
-        // clone from THAT remote — authenticating first so a private repo works.
-        // Otherwise clone the NEAR url. A failed/unreachable clone returns null;
+        // clone from THAT remote, asking for a token only if it turns out to be
+        // private. Otherwise clone the NEAR url (or the legacy host, see below). A failed/unreachable clone returns null;
         // fall back to a persistent local OPFS repo so edits survive reload (#151).
         try {
             if (remoteUrl) {
-                await applyStoredGitToken(true);
+                // Clone anonymously first (a stored token from this session is
+                // still sent). Only a 401 means the repo is private and needs a
+                // PAT — ask for one then, and retry once. Anything else (404,
+                // unreachable) is not a credentials problem; fall through to the
+                // local repo below. A visitor following a link to a PUBLIC repo
+                // must never be greeted with a token prompt (#224).
+                await applyStoredGitToken();
                 dircontents = await clone(remoteUrl);
+                if (!dircontents && lastCloneHttpStatus === 401) {
+                    const gotToken = await promptForGitToken(
+                        'Clone was rejected (401): this looks like a private repo. Fine-grained PAT with Contents: read (write to push).');
+                    if (gotToken) {
+                        dircontents = await clone(remoteUrl);
+                    }
+                }
             } else {
-                dircontents = await clone();
+                // A name the NEAR service worker can't resolve is looked up on
+                // the legacy host instead, so pre-NEAR `?gitrepo=` links keep
+                // working; a miss there still lands in the local repo below.
+                const legacyUrl = legacyRemoteFor(gitrepo);
+                dircontents = legacyUrl ? await clone(legacyUrl) : await clone();
             }
         } catch (e) {
             console.warn('clone failed, falling back to local repo', e);
@@ -218,7 +248,7 @@ export async function initWASMGitClient(gitrepo, remoteUrl) {
         // whatever this session has; don't prompt — a push that needs a token
         // asks for one when the remote answers 401 (see commitAndSyncRemote).
         if (remoteUrl) {
-            await applyStoredGitToken(false);
+            await applyStoredGitToken();
         }
     }
     console.log('dircontents', dircontents);
@@ -261,7 +291,13 @@ export function addRemoteSyncListener(remoteSyncListener) {
 // local directory is keyed on `?gitrepo=` so that synclocal and "Delete local"
 // can find the repo again on the next boot, regardless of what the remote
 // happens to be called. See PR #183.
+// HTTP status of the most recent failed clone (undefined when it succeeded or
+// never got as far as an HTTP reply). Lets init distinguish a private repo
+// (401) from a missing one without changing clone()'s null-on-failure contract.
+let lastCloneHttpStatus;
+
 export async function clone(url = gitrepourl) {
+    lastCloneHttpStatus = undefined;
     worker.postMessage({
         command: 'clone',
         url,
@@ -286,6 +322,9 @@ async function awaitDirContents(timeoutMs = 30000) {
                 // targets the real directory even when it's a legacy one.
                 if (msg.data.repoName) {
                     localRepoName = msg.data.repoName;
+                }
+                if (msg.data.cloneFailed) {
+                    lastCloneHttpStatus = msg.data.httpStatus;
                 }
                 resolve(msg.data.dircontents);
             } else {
@@ -364,9 +403,20 @@ export async function deletelocal() {
 }
 
 export async function pull() {
-    const result = await callAndWaitForWorker({
-        command: 'pull'
-    });
+    const doPull = () => callAndWaitForWorker({ command: 'pull' });
+    let result;
+    try {
+        result = await doPull();
+    } catch (e) {
+        // A private `remote=` host answers the fetch with 401: ask for a PAT
+        // and pull again, exactly as clone (init) and push (commitAndSyncRemote)
+        // do. NEAR repos never need one for reads, so only PAT hosts qualify.
+        if (e.httpStatus !== 401 || isNearRepo()) { throw e; }
+        const gotToken = await promptForGitToken(
+            'Pull was rejected (401): this looks like a private repo. Fine-grained PAT with Contents: read (write to push).');
+        if (!gotToken) { throw e; }
+        result = await doPull();
+    }
     remoteSyncListeners.forEach(remoteSyncListener => remoteSyncListener(result));
     await repoHasChanges();
     return result;

--- a/wasmaudioworklet/wasmgit/wasmgitworker.js
+++ b/wasmaudioworklet/wasmgit/wasmgitworker.js
@@ -279,6 +279,7 @@ onmessage = async (msg) => {
     const repoName = repoDirName(msg.data);
     currentRepoDir = OPFS_MOUNT + '/' + repoName;
 
+    lastHttpRequest = null;
     callMainInDir(['clone', msg.data.url, currentRepoDir]);
 
     // A failed clone (unreachable/unregistered remote) leaves no repo behind —
@@ -293,8 +294,12 @@ onmessage = async (msg) => {
     } catch (e) { /* target dir doesn't exist — clone failed */ }
 
     if (!cloned) {
-      console.log('clone failed, no repository at', currentRepoDir);
-      postMessage({ dircontents: null, cloneFailed: true });
+      // Same as commitpullpush: the HTTP status rides along as its own field
+      // so the client can tell a private repo (401 → ask for a token, retry)
+      // from a remote that simply isn't there (→ local repo).
+      const httpStatus = lastHttpRequest ? lastHttpRequest.status : undefined;
+      console.log('clone failed, no repository at', currentRepoDir, 'http status', httpStatus);
+      postMessage({ dircontents: null, cloneFailed: true, httpStatus });
       return;
     }
 
@@ -350,10 +355,29 @@ onmessage = async (msg) => {
     }
     postMessage({ diff: stdout });
   } else if (msg.data.command === 'pull') {
-    callMainInDir(['fetch', 'origin']);
-    callMainInDir(['merge', 'FETCH_HEAD']);
+    // Same error contract as commitpullpush: a failed fetch (e.g. 401 from a
+    // private `remote=` host) is reported with its HTTP status instead of
+    // throwing inside the worker and leaving the client waiting forever.
+    let err;
+    let httpStatus;
+    lastHttpRequest = null;
+    try {
+      // callAndCaptureOutput (not callMainInDir): lg2 reports git failures on
+      // stderr without throwing, so only the capturing helper turns them into
+      // an error. Skip the merge when the fetch brought nothing, as push does.
+      callAndCaptureOutput(['fetch', 'origin']);
+      if (stdout.indexOf('Received 0/0 objects') === -1) {
+        callAndCaptureOutput(['merge', 'FETCH_HEAD']);
+      }
+    } catch (e) {
+      err = e.message;
+      if (lastHttpRequest) {
+        httpStatus = lastHttpRequest.status;
+        err += ` http status: ${httpStatus}`;
+      }
+    }
     console.log(currentRepoDir, 'persisted via OPFS');
-    postMessage({ id: msg.data.id, dircontents: readdir(), lastHttpStatus: lastHttpRequest.status });
+    postMessage({ id: msg.data.id, error: err ? err : undefined, httpStatus, dircontents: readdir(), lastHttpStatus: lastHttpRequest ? lastHttpRequest.status : undefined });
   } else if (msg.data.command === 'listfiles') {
     // List files matching an optional prefix (e.g. "faust/"). Returns an
     // array of paths (strings) relative to the repo root. Walks the working


### PR DESCRIPTION
Closes #224

## Problem

`https://webassemblymusic.pages.dev/?gitrepo=wasmsummit2` (the WebAssembly Summit song that pywasm3 links to) stopped loading after NEAR storage (#119): a suffix-less name now resolved to a NEAR contract that cannot exist, the clone failed, and the app fell back to an empty local repo. The workaround with an explicit `remote=` worked but was much longer and greeted visitors with a GitHub token prompt.

## Changes

- **Legacy host fallback.** A `?gitrepo=<name>` with no NEAR suffix clones from `https://wasm-git.petersalomonsen.com/<name>`, so every pre-NEAR link works again at its original length. `workspace` and `*.local` names never touch the network; a name the legacy host lacks still falls back to a local repo as before. (`legacyRemoteFor()` in `wasmgitclient.js`.)
- **PAT only when the remote demands it.** Cloning from a `remote=` host no longer prompts up front. Clone, pull and push go out anonymously (or with a token already in the session) and only a 401 opens the prompt, then retries once. Links to public repos just load.
- **Pull reports failures.** The worker's `pull` used the non-throwing helper, so a failed fetch was silently reported as success. It now uses the capturing helper and reports the HTTP status, matching push.
- Docs: `git-hosting.md` describes both rules.
- Tests: new `clone-token-prompt.spec.js` (worker status field, no prompt for public/missing repos, 401 on clone and on pull prompts and retries with the token) and `legacy-gitrepo-fallback.spec.js` (name rule, clone attempted on the legacy host, local-only names never contact it). All network-free via route interception. Three existing specs renamed their repos to `*.local` so CI does not hit the legacy host.

## Verification

- 29 Playwright tests across the token-prompt, legacy-fallback, delete-local, zip-export, studio-agent and commit-empty-diff specs pass locally.
- A one-off real-network run of `?gitrepo=wasmsummit2` in the app loaded `song.js` at the legacy repo's exact size with the matching head commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
