### PR TITLE
cdn: no more unpkg — wasm-git proxies, jshint and pako on jsDelivr

### DIFF
--- a/wasmaudioworklet/editorcontroller.js
+++ b/wasmaudioworklet/editorcontroller.js
@@ -48,7 +48,7 @@ async function loadCodeMirror() {
     await loadScript('https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/addon/search/jump-to-line.js');
     await loadScript('https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/addon/dialog/dialog.js');
 
-    await loadScript('https://unpkg.com/jshint@2.9.6/dist/jshint.js');
+    await loadScript('https://cdn.jsdelivr.net/npm/jshint@2.9.6/dist/jshint.js');
     await loadScript('https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/addon/lint/lint.js');
     await loadScript('https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/addon/lint/javascript-lint.js');
     await loadCSS('https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/addon/lint/lint.css');

--- a/wasmaudioworklet/midisequencer/ui/pianorolldemo/nft.js
+++ b/wasmaudioworklet/midisequencer/ui/pianorolldemo/nft.js
@@ -1,6 +1,6 @@
 import { deserializePianorollsData, importToPianoroll, serializePianorollsData } from '../pianorollserialization.js';
 import { getMixes, publishMix, buyMix, viewTokenOwner, viewTokenPrice, getMixTokenContent, connectNear } from './nearclient.js';
-import { ungzip, gzip } from 'https://unpkg.com/pako@2.0.3/dist/pako.esm.mjs';
+import { ungzip, gzip } from 'https://cdn.jsdelivr.net/npm/pako@2.0.3/dist/pako.esm.mjs';
 import { toggleSpinner } from '../../../common/ui/progress-spinner.js';
 import { exportWav, addPianoroll, clearAll, selectPianoroll, updateSequence } from './pianorolldemo.js';
 import { COLUMNS_PER_BEAT } from '../pianoroll.js';


### PR DESCRIPTION
## What

Every remaining runtime fetch from unpkg moves to jsDelivr, the convention for the app's other CDN dependencies since unpkg took production down on 2026-08-18:

- `/wasm-git/*` proxy in the dev server (`devserver.js`) and in the production Pages Function (`functions/wasm-git/[[path]].js`) — `wasm-git@0.0.17`
- `jshint@2.9.6` loaded by the editor (`editorcontroller.js`)
- `pako@2.0.3` imported by the pianoroll demo (`nft.js`)

Same packages, same versions, same file layout on jsDelivr; all four files verified 200 with the right content types, and jshint verified loading in the browser through the new URL.

## Why now

A CI run for #227 stalled for 40 minutes: unpkg failed to serve `lg2_opfs.js`, the browser's dynamic import of the wasm-git worker failed (`[browser-error] Failed to fetch dynamically imported module: …/wasm-git/lg2_opfs.js`), and every Playwright test that boots a repo waited out its timeouts. The same code had passed on the previous head, so the stall was the CDN, not the change. Production has the same exposure through the Pages Function.

The wasm-git commit here is the same one that is on #227; that PR drops it when it rebases after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
