### PR TITLE
sequencer: don't fire the next event early after a recording marker

### DIFF
--- a/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.js
+++ b/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.js
@@ -157,10 +157,15 @@ export function AudioWorkletProcessorSequencerModule() {
         }
 
         // The inner meta loop above can push sequenceIndex past the end
-        // (a broadcast-send / recording marker at the end of the song).
-        // If it did, there's no midi event to fire; the outer loop's
-        // next iteration will re-check the bounds and exit cleanly.
-        if (this.sequenceIndex >= this.sequence.length || !this.sequence[this.sequenceIndex]) {
+        // (a broadcast-send / recording marker at the end of the song), or
+        // onto an event that is still in the future (a recording marker
+        // followed by a gap — e.g. stopRecording(); await waitDuration(4);
+        // loopHere()). Either way there is nothing to fire yet: firing the
+        // future event here would play a note early, or swallow the loop
+        // marker as a bogus midi message so the song never loops.
+        if (this.sequenceIndex >= this.sequence.length ||
+            !this.sequence[this.sequenceIndex] ||
+            this.sequence[this.sequenceIndex].time >= currentTime) {
           break;
         }
 

--- a/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.spec.js
+++ b/wasmaudioworklet/midisequencer/audioworkletprocessorsequencer.spec.js
@@ -1,0 +1,66 @@
+import { AudioWorkletProcessorSequencerModule } from './audioworkletprocessorsequencer.js';
+import { SEQ_MSG_LOOP, SEQ_MSG_STOP_RECORDING } from './sequenceconstants.js';
+
+// Drive the worklet-side sequencer outside an AudioWorklet: it only needs
+// the AudioWorkletGlobalScope object it registers itself on and a sampleRate.
+function createSequencer(sequence) {
+    globalThis.AudioWorkletGlobalScope = {};
+    globalThis.sampleRate = 44100;
+    AudioWorkletProcessorSequencerModule();
+    const seq = AudioWorkletGlobalScope.midisequencer;
+    const fired = [];
+    seq.midireceiver = (a, b, c) => fired.push({ message: [a, b, c], time: Math.round(seq.getCurrentTime()) });
+    seq.setSequenceData(sequence);
+    return { seq, fired };
+}
+
+// Run 128-frame blocks until the sequencer wraps to frame 0, or give up.
+function playUntilLoop(seq, maxMillis) {
+    for (let n = 0; n * 128 / sampleRate * 1000 < maxMillis; n++) {
+        const before = seq.currentFrame;
+        seq.onprocess();
+        if (seq.currentFrame < before) {
+            return true;
+        }
+    }
+    return false;
+}
+
+describe('audioworkletprocessorsequencer', function () {
+    it('should loop when a recording marker is followed by a gap before loopHere', () => {
+        // stopRecording(); await waitDuration(4); loopHere();  (4 beats @ 125 bpm = 1920 ms)
+        const { seq, fired } = createSequencer([
+            { time: 0, message: [0x90, 60, 100] },
+            { time: 500, message: [0x80, 60, 0] },
+            { time: 1000, message: [SEQ_MSG_STOP_RECORDING] },
+            { time: 2920, message: [SEQ_MSG_LOOP] },
+        ]);
+        assert.isTrue(playUntilLoop(seq, 5000), 'song should loop at the loop marker');
+        assert.deepEqual(fired.map(f => f.message), [[0x90, 60, 100], [0x80, 60, 0]],
+            'the loop marker must not be sent to the synth as a midi message');
+        assert.isFalse(seq.recordingActive);
+    });
+
+    it('should not fire a note early when it follows a recording marker after a gap', () => {
+        const { seq, fired } = createSequencer([
+            { time: 1000, message: [SEQ_MSG_STOP_RECORDING] },
+            { time: 1960, message: [0x90, 60, 100] },
+            { time: 2200, message: [0x80, 60, 0] },
+            { time: 2920, message: [SEQ_MSG_LOOP] },
+        ]);
+        assert.isTrue(playUntilLoop(seq, 5000));
+        assert.equal(fired.length, 2);
+        assert.closeTo(fired[0].time, 1960, 5, 'note on should fire at its own time, not at the marker');
+        assert.closeTo(fired[1].time, 2200, 5);
+    });
+
+    it('should still loop when the marker and loopHere share a timestamp', () => {
+        const { seq, fired } = createSequencer([
+            { time: 0, message: [0x90, 60, 100] },
+            { time: 1000, message: [SEQ_MSG_STOP_RECORDING] },
+            { time: 1000, message: [SEQ_MSG_LOOP] },
+        ]);
+        assert.isTrue(playUntilLoop(seq, 3000));
+        assert.equal(fired.length, 1);
+    });
+});

--- a/wasmaudioworklet/webaudiomodules/yoshimi-awp.js
+++ b/wasmaudioworklet/webaudiomodules/yoshimi-awp.js
@@ -81,13 +81,14 @@ class YOSHIMIAWP extends AudioWorkletGlobalScope.WAMProcessor
         this.sequence[this.sequenceIndex] && // sometimes this is undefined for yet unkown reasons
         this.sequence[this.sequenceIndex].time < currentTime) {
 
-      while ( this.sequence[this.sequenceIndex].message[0] < 0) {
+      let loop = false;
+      while (this.sequenceIndex < this.sequence.length &&
+          this.sequence[this.sequenceIndex].message[0] < 0 &&
+          this.sequence[this.sequenceIndex].time <= currentTime) {
         switch (this.sequence[this.sequenceIndex].message[0]) {
           case SEQ_MSG_LOOP:
             // loop
-            this.sequenceIndex = 0;
-            this.currentFrame = 0;
-            currentTime = 0;
+            loop = true;
             break;
           case SEQ_MSG_START_RECORDING:
             this.recordingActive = true;
@@ -98,6 +99,20 @@ class YOSHIMIAWP extends AudioWorkletGlobalScope.WAMProcessor
             this.sequenceIndex++;
             break;
         }
+        if (loop) {
+          break;
+        }
+      }
+      if (loop) {
+        this.sequenceIndex = 0;
+        this.currentFrame = 0;
+        break;
+      }
+      // A recording marker followed by a gap leaves the next event in the
+      // future — don't fire it early (or swallow a loop marker as midi).
+      if (this.sequenceIndex >= this.sequence.length ||
+          this.sequence[this.sequenceIndex].time >= currentTime) {
+        break;
       }
       const message = this.sequence[this.sequenceIndex].message;
       this.WAM._wam_onmidi(this.inst, message[0], message[1], message[2]);


### PR DESCRIPTION
## Bug

In the worklet sequencer, after the inner loop consumed a negative meta marker (stop/start recording, broadcast send), the code fired whatever event came next as a midi message, checking only array bounds and not the event's time.

With a song ending in

```js
stopRecording();
await waitDuration(4);
loopHere();
```

the loop marker is the next event after the stop-recording marker, 4 beats later. It was handed to the synth as a midi message with status byte `-1` and skipped, so the song played past the end into silence and never looped. The same fall-through made a note that follows a recording marker after a gap play at the marker's time instead of its own.

Both observed workarounds fit: with no `waitDuration` the two markers share a timestamp and are consumed together, and `playFromHere()` strips the recording markers entirely.

## Fix

- `midisequencer/audioworkletprocessorsequencer.js`: after the meta loop, also break when the next event's time has not arrived yet.
- `webaudiomodules/yoshimi-awp.js`: same fall-through, plus an inner loop that could spin on a future marker. Now mirrors the main sequencer's structure with the same time check.
- New `midisequencer/audioworkletprocessorsequencer.spec.js` drives the worklet sequencer directly: marker + gap + loop, marker + gap + note, and marker and loop at the same timestamp.

## Test

`npx wtr` on the new spec plus `recording.spec.js` and `songcompiler.spec.js`: 21 passed in Chromium and Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
