### PR TITLE
deps: bump transitive fast-uri to 3.1.7 (Dependabot alerts)

### DIFF
--- a/wasmaudioworklet/yarn.lock
+++ b/wasmaudioworklet/yarn.lock
@@ -1413,9 +1413,9 @@ fast-glob@^3.2.9:
     micromatch "^4.0.8"
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastq@^1.6.0:
   version "1.20.1"


### PR DESCRIPTION
Resolves the four open Dependabot alerts (#144, #147, #148, #149), all on the same transitive dev dependency: `fast-uri` 3.1.5, pulled in via `@as-pect/cli → @as-covers → table → ajv`.

The advisories (SSRF via malformed IPv6 normalization and repeated hostname percent-decoding; host confusion via percent-encoded scheme normalization and skipped IDN canonicalization) are all patched in 3.1.6. Re-resolving the `fast-uri@^3.0.1` lock entry picks 3.1.7.

Only `wasmaudioworklet/yarn.lock` changes; `package.json` is untouched. Local `yarn install --frozen-lockfile` succeeds. The AssemblyScript synth check exercises as-pect, which is the only consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
